### PR TITLE
Add InstanceDataEnvironmentPostProcessor and UserDataEnvironmentPostProcessor

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -464,7 +464,7 @@ The next example shows a typical Spring `@Configuration` class that enables the 
 
 ==== Enabling instance metadata support in Spring Boot
 The instance metadata is available in a Spring Boot application as a property source if the application
-is running on an EC2 instance and `cloud.aws.instance.data.enabled` property is set to `true`.
+is running on an EC2 instance and `spring.cloud.aws.ec2.instance-data.enabled` property is set to `true`. Also, user data is available if `spring.cloud.aws.ec2.user-data.enabled` property is set to `true`.
 
 ==== Using instance metadata
 Instance metadata can be used in XML, Java placeholders and expressions. The example below demonstrates the usage of

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/context/ContextInstanceDataAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/context/ContextInstanceDataAutoConfiguration.java
@@ -17,6 +17,7 @@
 package io.awspring.cloud.autoconfigure.context;
 
 import io.awspring.cloud.autoconfigure.condition.ConditionalOnAwsCloudEnvironment;
+import io.awspring.cloud.autoconfigure.ec2.UserDataEnvironmentPostProcessor;
 
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,6 +35,7 @@ import static io.awspring.cloud.context.config.support.ContextConfigurationUtils
  * {@link org.springframework.context.annotation.PropertySource}.
  *
  * @author Agim Emruli
+ * @deprecated see {@link UserDataEnvironmentPostProcessor}
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(name = "cloud.aws.instance.data.enabled", havingValue = "true")

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/context/ContextInstanceDataAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/context/ContextInstanceDataAutoConfiguration.java
@@ -17,6 +17,7 @@
 package io.awspring.cloud.autoconfigure.context;
 
 import io.awspring.cloud.autoconfigure.condition.ConditionalOnAwsCloudEnvironment;
+import io.awspring.cloud.autoconfigure.ec2.InstanceDataEnvironmentPostProcessor;
 import io.awspring.cloud.autoconfigure.ec2.UserDataEnvironmentPostProcessor;
 
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -35,7 +36,9 @@ import static io.awspring.cloud.context.config.support.ContextConfigurationUtils
  * {@link org.springframework.context.annotation.PropertySource}.
  *
  * @author Agim Emruli
- * @deprecated see {@link UserDataEnvironmentPostProcessor}
+ * @author Eddú Meléndez
+ * @deprecated see {@link InstanceDataEnvironmentPostProcessor} and
+ * {@link UserDataEnvironmentPostProcessor}
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(name = "cloud.aws.instance.data.enabled", havingValue = "true")

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ec2/InstanceDataEnvironmentPostProcessor.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ec2/InstanceDataEnvironmentPostProcessor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.autoconfigure.ec2;
+
+import io.awspring.cloud.core.env.ec2.InstanceDataPropertySource;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.util.ClassUtils;
+
+/**
+ * An {@link EnvironmentPostProcessor} that fetch user data from EC2 Instance Data
+ * Endpoint and adds it to the {@link Environment}. The new properties are added with
+ * higher priority than the system properties.
+ *
+ * @author Eddú Meléndez
+ * @since 2.3
+ */
+public class InstanceDataEnvironmentPostProcessor implements EnvironmentPostProcessor {
+
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+		boolean coreIsPresent = ClassUtils.isPresent("io.awspring.cloud.core.env.ec2.InstanceDataPropertySource", null);
+		boolean sdkCoreIsPresent = ClassUtils.isPresent("com.amazonaws.util.EC2MetadataUtils", null);
+		boolean instanceDataEnabled = environment.getProperty("spring.cloud.aws.ec2.instance-data.enabled",
+				Boolean.class, false);
+		if (coreIsPresent && sdkCoreIsPresent && instanceDataEnabled) {
+			InstanceDataPropertySource propertySource = new InstanceDataPropertySource("ec2InstanceData");
+			environment.getPropertySources().addLast(propertySource);
+		}
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ec2/UserDataEnvironmentPostProcessor.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ec2/UserDataEnvironmentPostProcessor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.autoconfigure.ec2;
+
+import io.awspring.cloud.core.env.ec2.UserDataPropertySource;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * An {@link EnvironmentPostProcessor} that fetch user data from EC2 User Data Endpoint
+ * and adds it to the {@link Environment}. The new properties are added with higher
+ * priority than the system properties.
+ *
+ * @author Eddú Meléndez
+ * @since 2.3
+ */
+public class UserDataEnvironmentPostProcessor implements EnvironmentPostProcessor {
+
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+		boolean coreIsPresent = ClassUtils.isPresent("io.awspring.cloud.core.env.ec2.UserDataPropertySource", null);
+		boolean sdkCoreIsPresent = ClassUtils.isPresent("com.amazonaws.util.EC2MetadataUtils", null);
+		boolean userDataEnabled = environment.getProperty("spring.cloud.aws.ec2.user-data.enabled", Boolean.class,
+				false);
+		if (coreIsPresent && sdkCoreIsPresent && userDataEnabled) {
+			UserDataPropertySource propertySource = new UserDataPropertySource("ec2UserData");
+
+			String valueSeparator = environment.getProperty("spring.cloud.aws.ec2.user-data.value-separator");
+
+			if (StringUtils.hasText(valueSeparator)) {
+				propertySource.setUserDataValueSeparator(valueSeparator);
+			}
+
+			String attributeSeparator = environment.getProperty("spring.cloud.aws.ec2.user-data.attribute-separator");
+			if (StringUtils.hasText(attributeSeparator)) {
+				propertySource.setUserDataAttributeSeparator(attributeSeparator);
+			}
+
+			environment.getPropertySources().addLast(propertySource);
+		}
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -70,6 +70,12 @@
     },
     {
       "defaultValue": false,
+      "name": "spring.cloud.aws.ec2.instance-data.enabled",
+      "description": "Enables EC2 Instance Data integration.",
+      "type": "java.lang.Boolean"
+    },
+    {
+      "defaultValue": false,
       "name": "spring.cloud.aws.ec2.user-data.enabled",
       "description": "Enables EC2 User Data integration.",
       "type": "java.lang.Boolean"

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -69,6 +69,22 @@
 	  "type": "java.lang.Boolean"
     },
     {
+      "defaultValue": false,
+      "name": "spring.cloud.aws.ec2.user-data.enabled",
+      "description": "Enables EC2 User Data integration.",
+      "type": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.cloud.aws.ec2.user-data.attribute-separator",
+      "description": "Attribute separator in User Data.",
+      "type": "java.lang.String"
+    },
+    {
+      "name": "spring.cloud.aws.ec2.user-data.value-separator",
+      "description": "Value separator in User Data.",
+      "type": "java.lang.String"
+    },
+    {
       "defaultValue": true,
       "name": "spring.cloud.aws.security.cognito.enabled",
       "description": "Enables Cognito integration.",

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -14,4 +14,5 @@ io.awspring.cloud.autoconfigure.metrics.CloudWatchExportAutoConfiguration,\
 io.awspring.cloud.autoconfigure.security.CognitoAuthenticationAutoConfiguration
 
 org.springframework.boot.env.EnvironmentPostProcessor=\
+io.awspring.cloud.autoconfigure.ec2.InstanceDataEnvironmentPostProcessor,\
 io.awspring.cloud.autoconfigure.ec2.UserDataEnvironmentPostProcessor

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -12,3 +12,6 @@ io.awspring.cloud.autoconfigure.messaging.SnsAutoConfiguration,\
 io.awspring.cloud.autoconfigure.jdbc.AmazonRdsDatabaseAutoConfiguration,\
 io.awspring.cloud.autoconfigure.metrics.CloudWatchExportAutoConfiguration,\
 io.awspring.cloud.autoconfigure.security.CognitoAuthenticationAutoConfiguration
+
+org.springframework.boot.env.EnvironmentPostProcessor=\
+io.awspring.cloud.autoconfigure.ec2.UserDataEnvironmentPostProcessor

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/ec2/InstanceDataEnvironmentPostProcessorTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/ec2/InstanceDataEnvironmentPostProcessorTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.autoconfigure.ec2;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import com.amazonaws.SDKGlobalConfiguration;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.util.SocketUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link InstanceDataEnvironmentPostProcessor}
+ *
+ * @author Eddú Meléndez
+ */
+class InstanceDataEnvironmentPostProcessorTest {
+
+	private static final int HTTP_SERVER_TEST_PORT = SocketUtils.findAvailableTcpPort();
+
+	private static HttpServer httpServer;
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withInitializer(context -> new InstanceDataEnvironmentPostProcessor()
+					.postProcessEnvironment(context.getEnvironment(), new SpringApplication()));
+
+	@BeforeAll
+	static void setupHttpServer() throws Exception {
+		InetSocketAddress address = new InetSocketAddress(HTTP_SERVER_TEST_PORT);
+		httpServer = HttpServer.create(address, -1);
+		httpServer.start();
+		overwriteMetadataEndpointUrl("http://" + address.getHostName() + ":" + address.getPort());
+	}
+
+	@AfterAll
+	static void shutdownHttpServer() throws Exception {
+		if (httpServer != null) {
+			httpServer.stop(10);
+		}
+		resetMetadataEndpointUrlOverwrite();
+	}
+
+	@Test
+	void ec2InstanceDataEnabled() {
+		init("/latest/meta-data/instance-id", "spring-cloud-instance");
+		this.contextRunner.withPropertyValues("spring.cloud.aws.ec2.instance-data.enabled:true").run(context -> {
+			assertThat(context.getEnvironment().getProperty("instance-id")).isEqualTo("spring-cloud-instance");
+		});
+	}
+
+	@Test
+	void ec2UserDataDisabledByDefault() {
+		this.contextRunner.run(context -> {
+			assertThat(context.getEnvironment().containsProperty("instance-id")).isFalse();
+		});
+	}
+
+	@Test
+	void ec2UserDataDisabledByNotHavingCoreModule() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.ec2.instance-data.enabled:true")
+				.withClassLoader(new FilteredClassLoader("io.awspring.cloud.core.env.ec2.InstanceDataPropertySource"))
+				.run(context -> {
+					assertThat(context.getEnvironment().containsProperty("instance-id")).isFalse();
+				});
+	}
+
+	@Test
+	void ec2UserDataDisabledByNotHavingAwsSdk() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.ec2.instance-data.enabled:true")
+				.withClassLoader(new FilteredClassLoader("com.amazonaws.util.EC2MetadataUtils")).run(context -> {
+					assertThat(context.getEnvironment().containsProperty("instance-id")).isFalse();
+				});
+	}
+
+	private static void init(String path, String data) {
+		httpServer.createContext(path, new StringWritingHttpHandler(data.getBytes(StandardCharsets.UTF_8)));
+	}
+
+	private static void overwriteMetadataEndpointUrl(String localMetadataServiceEndpointUrl) {
+		System.setProperty(SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY,
+				localMetadataServiceEndpointUrl);
+	}
+
+	private static void resetMetadataEndpointUrlOverwrite() {
+		System.clearProperty(SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY);
+	}
+
+	private static final class StringWritingHttpHandler implements HttpHandler {
+
+		private final byte[] content;
+
+		private StringWritingHttpHandler(byte[] content) {
+			this.content = content;
+		}
+
+		@Override
+		public void handle(HttpExchange httpExchange) throws IOException {
+			httpExchange.sendResponseHeaders(200, this.content.length);
+			OutputStream responseBody = httpExchange.getResponseBody();
+			responseBody.write(this.content);
+			responseBody.flush();
+			responseBody.close();
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/ec2/UserDataEnvironmentPostProcessorTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/ec2/UserDataEnvironmentPostProcessorTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.autoconfigure.ec2;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import com.amazonaws.SDKGlobalConfiguration;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.util.SocketUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link UserDataEnvironmentPostProcessor}
+ *
+ * @author Eddú Meléndez
+ */
+class UserDataEnvironmentPostProcessorTest {
+
+	private static final int HTTP_SERVER_TEST_PORT = SocketUtils.findAvailableTcpPort();
+
+	private static HttpServer httpServer;
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withInitializer(context -> new UserDataEnvironmentPostProcessor()
+					.postProcessEnvironment(context.getEnvironment(), new SpringApplication()));
+
+	@BeforeAll
+	static void setupHttpServer() throws Exception {
+		InetSocketAddress address = new InetSocketAddress(HTTP_SERVER_TEST_PORT);
+		httpServer = HttpServer.create(address, -1);
+		httpServer.start();
+		overwriteMetadataEndpointUrl("http://" + address.getHostName() + ":" + address.getPort());
+	}
+
+	@AfterAll
+	static void shutdownHttpServer() throws Exception {
+		if (httpServer != null) {
+			httpServer.stop(10);
+		}
+		resetMetadataEndpointUrlOverwrite();
+	}
+
+	@AfterEach
+	void removeContext() {
+		httpServer.removeContext("/latest/user-data/");
+	}
+
+	@Test
+	void ec2UserDataEnabled() {
+		init("/latest/user-data/", "keyA:valueA;keyB:valueB");
+		this.contextRunner.withPropertyValues("spring.cloud.aws.ec2.user-data.enabled:true").run(context -> {
+			assertThat(context.getEnvironment().getProperty("keyA")).isEqualTo("valueA");
+			assertThat(context.getEnvironment().getProperty("keyB")).isEqualTo("valueB");
+		});
+	}
+
+	@Test
+	void ec2UserDataEnabledWithCustomSeparators() {
+		init("/latest/user-data/", "keyA=valueA,keyB=valueB");
+		this.contextRunner.withPropertyValues("spring.cloud.aws.ec2.user-data.enabled:true",
+				"spring.cloud.aws.ec2.user-data.attribute-separator:,",
+				"spring.cloud.aws.ec2.user-data.value-separator:=").run(context -> {
+					assertThat(context.getEnvironment().getProperty("keyA")).isEqualTo("valueA");
+					assertThat(context.getEnvironment().getProperty("keyB")).isEqualTo("valueB");
+				});
+	}
+
+	@Test
+	void ec2UserDataDisabledByDefault() {
+		init("/latest/user-data/", "keyA:valueA;keyB:valueB");
+		this.contextRunner.run(context -> {
+			assertThat(context.getEnvironment().containsProperty("keyA")).isFalse();
+			assertThat(context.getEnvironment().containsProperty("keyB")).isFalse();
+		});
+	}
+
+	@Test
+	void ec2UserDataDisabledByNotHavingCoreModule() {
+		init("/latest/user-data/", "keyA:valueA;keyB:valueB");
+		this.contextRunner.withPropertyValues("spring.cloud.aws.ec2.user-data.enabled:true")
+				.withClassLoader(new FilteredClassLoader("io.awspring.cloud.core.env.ec2.UserDataPropertySource"))
+				.run(context -> {
+					assertThat(context.getEnvironment().containsProperty("keyA")).isFalse();
+					assertThat(context.getEnvironment().containsProperty("keyB")).isFalse();
+				});
+	}
+
+	@Test
+	void ec2UserDataDisabledByNotHavingAwsSdk() {
+		init("/latest/user-data/", "keyA:valueA;keyB:valueB");
+		this.contextRunner.withPropertyValues("spring.cloud.aws.ec2.user-data.enabled:true")
+				.withClassLoader(new FilteredClassLoader("com.amazonaws.util.EC2MetadataUtils")).run(context -> {
+					assertThat(context.getEnvironment().containsProperty("keyA")).isFalse();
+					assertThat(context.getEnvironment().containsProperty("keyB")).isFalse();
+				});
+	}
+
+	private static void init(String path, String data) {
+		httpServer.createContext(path, new StringWritingHttpHandler(data.getBytes(StandardCharsets.UTF_8)));
+	}
+
+	private static void overwriteMetadataEndpointUrl(String localMetadataServiceEndpointUrl) {
+		System.setProperty(SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY,
+				localMetadataServiceEndpointUrl);
+	}
+
+	private static void resetMetadataEndpointUrlOverwrite() {
+		System.clearProperty(SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY);
+	}
+
+	private static final class StringWritingHttpHandler implements HttpHandler {
+
+		private final byte[] content;
+
+		private StringWritingHttpHandler(byte[] content) {
+			this.content = content;
+		}
+
+		@Override
+		public void handle(HttpExchange httpExchange) throws IOException {
+			httpExchange.sendResponseHeaders(200, this.content.length);
+			OutputStream responseBody = httpExchange.getResponseBody();
+			responseBody.write(this.content);
+			responseBody.flush();
+			responseBody.close();
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-context/src/main/java/io/awspring/cloud/context/config/AmazonEc2InstanceDataPropertySourcePostProcessor.java
+++ b/spring-cloud-aws-context/src/main/java/io/awspring/cloud/context/config/AmazonEc2InstanceDataPropertySourcePostProcessor.java
@@ -32,6 +32,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * @author Agim Emruli
+ * @deprecated use `UserDataEnvironmentPostProcessor`
  */
 public class AmazonEc2InstanceDataPropertySourcePostProcessor
 		implements PriorityOrdered, EnvironmentAware, BeanFactoryPostProcessor {

--- a/spring-cloud-aws-context/src/main/java/io/awspring/cloud/context/config/support/ContextConfigurationUtils.java
+++ b/spring-cloud-aws-context/src/main/java/io/awspring/cloud/context/config/support/ContextConfigurationUtils.java
@@ -127,6 +127,7 @@ public final class ContextConfigurationUtils {
 				CredentialsProviderFactoryBean.CREDENTIALS_PROVIDER_BEAN_NAME);
 	}
 
+	@Deprecated
 	public static void registerInstanceDataPropertySource(BeanDefinitionRegistry registry, String valueSeparator,
 			String attributeSeparator) {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(POST_PROCESSOR_CLASS_NAME);

--- a/spring-cloud-aws-core/src/main/java/io/awspring/cloud/core/env/ec2/AmazonEc2InstanceDataPropertySource.java
+++ b/spring-cloud-aws-core/src/main/java/io/awspring/cloud/core/env/ec2/AmazonEc2InstanceDataPropertySource.java
@@ -36,7 +36,8 @@ import org.springframework.util.StringUtils;
 
 /**
  * @author Agim Emruli
- * @deprecated use {@link UserDataPropertySource}
+ * @deprecated use {@link UserDataPropertySource} or/and
+ * {@link InstanceDataPropertySource}
  */
 public class AmazonEc2InstanceDataPropertySource extends EnumerablePropertySource<Object> {
 

--- a/spring-cloud-aws-core/src/main/java/io/awspring/cloud/core/env/ec2/InstanceDataPropertySource.java
+++ b/spring-cloud-aws-core/src/main/java/io/awspring/cloud/core/env/ec2/InstanceDataPropertySource.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.core.env.ec2;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.util.EC2MetadataUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Agim Emruli
+ * @author Eddú Meléndez
+ * @since 2.3
+ */
+public class InstanceDataPropertySource extends EnumerablePropertySource<Object> {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(InstanceDataPropertySource.class);
+
+	private static final String EC2_METADATA_ROOT = "/latest/meta-data";
+
+	private static final String DEFAULT_KNOWN_PROPERTIES_PATH = InstanceDataPropertySource.class.getSimpleName()
+			+ ".properties";
+
+	private static final Properties KNOWN_PROPERTY_NAMES;
+
+	static {
+		// Load all known properties from the classpath. This is not meant
+		// to be changed by external developers.
+		try {
+			ClassPathResource resource = new ClassPathResource(DEFAULT_KNOWN_PROPERTIES_PATH,
+					InstanceDataPropertySource.class);
+			KNOWN_PROPERTY_NAMES = PropertiesLoaderUtils.loadProperties(resource);
+		}
+		catch (IOException ex) {
+			throw new IllegalStateException(
+					"Could not load '" + DEFAULT_KNOWN_PROPERTIES_PATH + "': " + ex.getMessage());
+		}
+	}
+
+	public InstanceDataPropertySource(String name) {
+		super(name, new Object());
+	}
+
+	private static String getRootPropertyName(String propertyName) {
+		String[] propertyTokens = StringUtils.split(propertyName, "/");
+		return propertyTokens != null ? propertyTokens[0] : propertyName;
+	}
+
+	@Override
+	public Object getProperty(String name) {
+		if (!KNOWN_PROPERTY_NAMES.containsKey(getRootPropertyName(name))) {
+			return null;
+		}
+
+		try {
+			return EC2MetadataUtils.getData(EC2_METADATA_ROOT + "/" + name);
+		}
+		catch (AmazonClientException e) {
+			// Suppress exception if we are not able to contact the service,
+			// because that is quite often the case if we run in unit tests outside the
+			// environment.
+			LOGGER.warn("Error getting instance meta-data with name '{}' error message is '{}'", name, e.getMessage());
+			return null;
+		}
+	}
+
+	@Override
+	public String[] getPropertyNames() {
+		return KNOWN_PROPERTY_NAMES.keySet().stream().map(Object::toString).distinct().toArray(String[]::new);
+	}
+
+}

--- a/spring-cloud-aws-core/src/main/resources/io/awspring/cloud/core/env/ec2/InstanceDataPropertySource.properties
+++ b/spring-cloud-aws-core/src/main/resources/io/awspring/cloud/core/env/ec2/InstanceDataPropertySource.properties
@@ -1,0 +1,37 @@
+#
+# Copyright 2013-2021 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+ami-id
+ami-launch-index
+ami-manifest-path
+block-device-mapping
+hostname
+iam
+instance-action
+instance-id
+instance-type
+local-hostname
+local-ipv4
+mac
+metrics
+network
+placement
+profile
+public-hostname
+public-ipv4
+public-keys
+reservation-id
+security-groups
+services

--- a/spring-cloud-aws-core/src/test/java/io/awspring/cloud/core/env/ec2/InstanceDataPropertySourceTest.java
+++ b/spring-cloud-aws-core/src/test/java/io/awspring/cloud/core/env/ec2/InstanceDataPropertySourceTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.core.env.ec2;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+
+import com.amazonaws.SDKGlobalConfiguration;
+import com.amazonaws.util.EC2MetadataUtils;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.util.SocketUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link InstanceDataPropertySource}
+ *
+ * @author Agim Emruli
+ * @author Eddú Meléndez
+ */
+class InstanceDataPropertySourceTest {
+
+	private static final int HTTP_SERVER_TEST_PORT = SocketUtils.findAvailableTcpPort();
+
+	@SuppressWarnings("StaticNonFinalField")
+	private static HttpServer httpServer;
+
+	@BeforeAll
+	static void setupHttpServer() throws Exception {
+		InetSocketAddress address = new InetSocketAddress(HTTP_SERVER_TEST_PORT);
+		httpServer = HttpServer.create(address, -1);
+		httpServer.start();
+		overwriteMetadataEndpointUrl("http://" + address.getHostName() + ":" + address.getPort());
+	}
+
+	@AfterAll
+	static void shutdownHttpServer() throws Exception {
+		if (httpServer != null) {
+			httpServer.stop(10);
+		}
+		resetMetadataEndpointUrlOverwrite();
+	}
+
+	private static void overwriteMetadataEndpointUrl(String localMetadataServiceEndpointUrl) {
+		System.setProperty(SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY,
+				localMetadataServiceEndpointUrl);
+	}
+
+	private static void resetMetadataEndpointUrlOverwrite() {
+		System.clearProperty(SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY);
+	}
+
+	@Test
+	void getProperty_knownAttribute_returnsAttributeValue() throws Exception {
+		// Arrange
+		httpServer.createContext("/latest/meta-data/instance-id",
+				new StringWritingHttpHandler("i1234567".getBytes("UTF-8")));
+
+		// Act
+		InstanceDataPropertySource instanceDataPropertySource = new InstanceDataPropertySource("test");
+
+		// Assert
+		assertThat(instanceDataPropertySource.getProperty("instance-id")).isEqualTo("i1234567");
+
+		httpServer.removeContext("/latest/meta-data/instance-id");
+	}
+
+	@Test
+	void getProperty_knownAttributeWithSubAttribute_returnsAttributeValue() throws Exception {
+		// Arrange
+		httpServer.createContext("/latest/meta-data/services/domain",
+				new StringWritingHttpHandler("amazonaws.com".getBytes("UTF-8")));
+
+		// Act
+		InstanceDataPropertySource instanceDataPropertySource = new InstanceDataPropertySource("test");
+
+		// Assert
+		assertThat(instanceDataPropertySource.getProperty("services/domain")).isEqualTo("amazonaws.com");
+
+		httpServer.removeContext("/latest/meta-data/services/domain");
+	}
+
+	@Test
+	void getProperty_unknownAttribute_returnsNull() throws Exception {
+		// Arrange
+		httpServer.createContext("/latest/meta-data/instance-id",
+				new StringWritingHttpHandler("i1234567".getBytes("UTF-8")));
+
+		// Act
+		InstanceDataPropertySource instanceDataPropertySource = new InstanceDataPropertySource("test");
+
+		// Assert
+		assertThat(instanceDataPropertySource.getProperty("non-existing-attribute")).isNull();
+
+		httpServer.removeContext("/latest/meta-data/instance-id");
+	}
+
+	@AfterEach
+	void clearMetadataCache() throws Exception {
+		Field metadataCacheField = EC2MetadataUtils.class.getDeclaredField("cache");
+		metadataCacheField.setAccessible(true);
+		metadataCacheField.set(null, new HashMap<String, String>());
+	}
+
+	private static final class StringWritingHttpHandler implements HttpHandler {
+
+		private final byte[] content;
+
+		private StringWritingHttpHandler(byte[] content) {
+			this.content = content;
+		}
+
+		@Override
+		public void handle(HttpExchange httpExchange) throws IOException {
+			httpExchange.sendResponseHeaders(200, this.content.length);
+			OutputStream responseBody = httpExchange.getResponseBody();
+			responseBody.write(this.content);
+			responseBody.flush();
+			responseBody.close();
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-core/src/test/java/io/awspring/cloud/core/env/ec2/UserDataPropertySourceTest.java
+++ b/spring-cloud-aws-core/src/test/java/io/awspring/cloud/core/env/ec2/UserDataPropertySourceTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.core.env.ec2;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+
+import com.amazonaws.SDKGlobalConfiguration;
+import com.amazonaws.util.EC2MetadataUtils;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.util.SocketUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link UserDataPropertySource}
+ *
+ * @author Agim Emruli
+ * @author Eddú Meléndez
+ */
+class UserDataPropertySourceTest {
+
+	private static final int HTTP_SERVER_TEST_PORT = SocketUtils.findAvailableTcpPort();
+
+	@SuppressWarnings("StaticNonFinalField")
+	private static HttpServer httpServer;
+
+	@BeforeAll
+	static void setupHttpServer() throws Exception {
+		InetSocketAddress address = new InetSocketAddress(HTTP_SERVER_TEST_PORT);
+		httpServer = HttpServer.create(address, -1);
+		httpServer.start();
+		overwriteMetadataEndpointUrl("http://" + address.getHostName() + ":" + address.getPort());
+	}
+
+	@AfterAll
+	static void shutdownHttpServer() throws Exception {
+		if (httpServer != null) {
+			httpServer.stop(10);
+		}
+		resetMetadataEndpointUrlOverwrite();
+	}
+
+	private static void overwriteMetadataEndpointUrl(String localMetadataServiceEndpointUrl) {
+		System.setProperty(SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY,
+				localMetadataServiceEndpointUrl);
+	}
+
+	private static void resetMetadataEndpointUrlOverwrite() {
+		System.clearProperty(SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY);
+	}
+
+	@Test
+	void getProperty_userDataWithDefaultFormatting_ReturnsUserDataKeys() throws Exception {
+		// Arrange
+		httpServer.createContext("/latest/user-data/",
+				new StringWritingHttpHandler("keyA:valueA;keyB:valueB".getBytes("UTF-8")));
+
+		// Act
+		UserDataPropertySource userDataPropertySource = new UserDataPropertySource("test");
+
+		// Assert
+		assertThat(userDataPropertySource.getProperty("keyA")).isEqualTo("valueA");
+		assertThat(userDataPropertySource.getProperty("keyB")).isEqualTo("valueB");
+
+		httpServer.removeContext("/latest/user-data/");
+	}
+
+	@Test
+	void getProperty_userDataWithCustomFormatting_ReturnsUserDataKeys() throws Exception {
+		// Arrange
+		httpServer.createContext("/latest/user-data/",
+				new StringWritingHttpHandler("keyA=valueD,keyB=valueE".getBytes("UTF-8")));
+
+		// Act
+		UserDataPropertySource userDataPropertySource = new UserDataPropertySource("test");
+
+		userDataPropertySource.setUserDataAttributeSeparator(",");
+		userDataPropertySource.setUserDataValueSeparator("=");
+
+		// Assert
+		assertThat(userDataPropertySource.getProperty("keyA")).isEqualTo("valueD");
+		assertThat(userDataPropertySource.getProperty("keyB")).isEqualTo("valueE");
+
+		httpServer.removeContext("/latest/user-data/");
+	}
+
+	@AfterEach
+	void clearMetadataCache() throws Exception {
+		Field metadataCacheField = EC2MetadataUtils.class.getDeclaredField("cache");
+		metadataCacheField.setAccessible(true);
+		metadataCacheField.set(null, new HashMap<String, String>());
+	}
+
+	private static final class StringWritingHttpHandler implements HttpHandler {
+
+		private final byte[] content;
+
+		private StringWritingHttpHandler(byte[] content) {
+			this.content = content;
+		}
+
+		@Override
+		public void handle(HttpExchange httpExchange) throws IOException {
+			httpExchange.sendResponseHeaders(200, this.content.length);
+			OutputStream responseBody = httpExchange.getResponseBody();
+			responseBody.write(this.content);
+			responseBody.flush();
+			responseBody.close();
+		}
+
+	}
+
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Move current `ContextInstanceDataAutoConfiguration` implementation into `InstanceDataEnvironmentPostProcessor` and `UserDataEnvironmentPostProcessor`. Both environmentPostProcessors can be enabled via configuration properties.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Current implementation load ec2 instance data and user data via auto-configuration. However, using environmentPostProcessor will load properties before auto-configurations.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] I updated reference documentation to reflect the change
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
