### PR TITLE
Make Github Action build output less verbose

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,4 +35,4 @@ jobs:
           java-version: 8
           jdkFile: ${{ steps.sdkman.outputs.file }}
       - name: Build with Maven
-        run: ./mvnw -V verify
+        run: ./mvnw -V -B verify


### PR DESCRIPTION
When downloading snapshot dependencies we got thousands of lines of build output with download progress and the HTML page becomes so big that browser becomes not responsive.