### PR TITLE
initial commit

### DIFF
--- a/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerProperties.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerProperties.java
@@ -30,6 +30,7 @@ import org.springframework.validation.Validator;
  *
  * @author Fabio Maia
  * @author Matej Nedic
+ * @author Hari Ohm Prasath
  * @since 2.0.0
  */
 @ConfigurationProperties(prefix = AwsSecretsManagerProperties.CONFIG_PREFIX)
@@ -43,7 +44,7 @@ public class AwsSecretsManagerProperties implements Validator {
 	/**
 	 * Pattern used for prefix validation.
 	 */
-	private static final Pattern PREFIX_PATTERN = Pattern.compile("(/[a-zA-Z0-9.\\-_]+)*");
+	private static final Pattern PREFIX_PATTERN = Pattern.compile("(/)?([a-zA-Z0-9.\\-_]+)*");
 
 	/**
 	 * Pattern used for profileSeparator validation.

--- a/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertiesTest.java
+++ b/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertiesTest.java
@@ -36,15 +36,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class AwsSecretsManagerPropertiesTest {
 
-	@Test
-	void validationSucceeds() {
-		AwsSecretsManagerProperties properties = new AwsSecretsManagerPropertiesBuilder().withPrefix("/sec")
-				.withDefaultContext("app").withProfileSeparator("_").build();
-		Errors errors = new BeanPropertyBindingResult(properties, "properties");
-		properties.validate(properties, errors);
-		assertThat(errors.getAllErrors()).isEmpty();
-	}
-
 	@ParameterizedTest
 	@MethodSource("invalidProperties")
 	public void validationFails(AwsSecretsManagerProperties properties, String field, String errorCode) {
@@ -56,28 +47,24 @@ class AwsSecretsManagerPropertiesTest {
 		assertThat(errors.getFieldError(field).getCode()).isEqualTo(errorCode);
 	}
 
-	@Test
-	void acceptsForwardSlashAsProfileSeparator() {
-		AwsSecretsManagerProperties properties = new AwsSecretsManagerProperties();
-		properties.setProfileSeparator("/");
-
+	@ParameterizedTest
+	@MethodSource("validProperties")
+	void validationSucceeds(AwsSecretsManagerProperties properties) {
 		Errors errors = new BeanPropertyBindingResult(properties, "properties");
-
 		properties.validate(properties, errors);
-
-		assertThat(errors.getFieldError("profileSeparator")).isNull();
+		assertThat(errors.getAllErrors()).isEmpty();
 	}
 
-	@Test
-	void acceptsBackslashAsProfileSeparator() {
-		AwsSecretsManagerProperties properties = new AwsSecretsManagerProperties();
-		properties.setProfileSeparator("\\");
-
-		Errors errors = new BeanPropertyBindingResult(properties, "properties");
-
-		properties.validate(properties, errors);
-
-		assertThat(errors.getFieldError("profileSeparator")).isNull();
+	private static Stream<Arguments> validProperties() {
+		return Stream.of(
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("/sec").withDefaultContext("app")
+						.withProfileSeparator("_").build()),
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("secret").withDefaultContext("app")
+						.withProfileSeparator("_").build()),
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("secret").withDefaultContext("app")
+						.withProfileSeparator("\\").build()),
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("secret").withDefaultContext("app")
+						.withProfileSeparator("/").build()));
 	}
 
 	private static Stream<Arguments> invalidProperties() {

--- a/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertiesTest.java
+++ b/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertiesTest.java
@@ -18,7 +18,6 @@ package io.awspring.cloud.secretsmanager;
 
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;


### PR DESCRIPTION
Co-authored-by: Hari Ohm Prasath 

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
The initial code always expected the "prefix" inside "secretmanager" to start with "/" in the front, which not be in true as AWS doesn't impose such restrictions. So the code change takes care of updating the regex to allow 0 or 1 occurrence of "/" as the first character while specifying the prefix inside "secretmanager"


## :bulb: Motivation and Context
[736](https://github.com/spring-cloud/spring-cloud-aws/issues/736)

## :green_heart: How did you test it?
All unit testcases passed.
Integration test was done using a spring boot application and everything worked as expected

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
