### PR TITLE
WIP: Migrate secrets manager integration to aws sdkv2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
 	</properties>
 
 	<modules>
+		<module>v3</module>
 		<module>spring-cloud-aws-dependencies</module>
 		<module>spring-cloud-aws-core</module>
 		<module>spring-cloud-aws-context</module>

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -150,6 +150,13 @@
 				<artifactId>spring-cloud-aws-ses</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+
+			<!-- Spring Cloud AWS 3.0 -->
+			<dependency>
+				<groupId>io.awspring.cloud</groupId>
+				<artifactId>spring-cloud-aws-v3-core</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<profiles>

--- a/v3/pom.xml
+++ b/v3/pom.xml
@@ -17,14 +17,17 @@
 	<modules>
 		<module>spring-cloud-aws-v3-core</module>
 		<module>spring-cloud-aws-v3-autoconfigure</module>
+		<module>spring-cloud-aws-v3-secrets-manager-config</module>
+		<module>spring-cloud-starter-aws-v3-secrets-manager-config</module>
+		<module>spring-cloud-aws-v3-dependencies</module>
 	</modules>
 
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>bom</artifactId>
-				<version>2.15.80</version>
+				<groupId>io.awspring.cloud</groupId>
+				<artifactId>spring-cloud-aws-v3-dependencies</artifactId>
+				<version>${project.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/v3/pom.xml
+++ b/v3/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.awspring.cloud</groupId>
+        <artifactId>spring-cloud-aws</artifactId>
+        <version>2.3.0-RC2</version>
+    </parent>
+
+    <artifactId>v3</artifactId>
+    <version>2.3.0-RC2</version>
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>spring-cloud-aws-v3-core</module>
+		<module>spring-cloud-aws-v3-autoconfigure</module>
+	</modules>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>bom</artifactId>
+				<version>2.15.80</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+</project>

--- a/v3/spring-cloud-aws-v3-autoconfigure/pom.xml
+++ b/v3/spring-cloud-aws-v3-autoconfigure/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.awspring.cloud</groupId>
+        <artifactId>v3</artifactId>
+        <version>2.3.0-RC2</version>
+    </parent>
+
+    <groupId>io.awspring.cloud</groupId>
+    <artifactId>spring-cloud-aws-v3-autoconfigure</artifactId>
+    <version>2.3.0-RC2</version>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>io.awspring.cloud</groupId>
+			<artifactId>spring-cloud-aws-v3-core</artifactId>
+			<version>2.3.0-RC2</version>
+		</dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>auth</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/v3/spring-cloud-aws-v3-autoconfigure/pom.xml
+++ b/v3/spring-cloud-aws-v3-autoconfigure/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/CredentialsProviderAutoConfiguration.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/CredentialsProviderAutoConfiguration.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.v3.autoconfigure;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.awspring.cloud.v3.autoconfigure.properties.AwsCredentialsProperties;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.profiles.ProfileFile;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@link EnableAutoConfiguration} for {@link AwsCredentialsProvider}.
+ *
+ * @author Maciej Walkowiak
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(AwsCredentialsProperties.class)
+public class CredentialsProviderAutoConfiguration {
+
+	private final AwsCredentialsProperties properties;
+
+	public CredentialsProviderAutoConfiguration(AwsCredentialsProperties properties) {
+		this.properties = properties;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public AwsCredentialsProvider awsCredentialsProvider() {
+		final List<AwsCredentialsProvider> providers = new ArrayList<>();
+
+		if (StringUtils.hasText(properties.getAccessKey()) && StringUtils.hasText(properties.getSecretKey())) {
+			providers.add(StaticCredentialsProvider
+					.create(AwsBasicCredentials.create(properties.getAccessKey(), properties.getSecretKey())));
+		}
+
+		if (properties.isInstanceProfile()) {
+			providers.add(InstanceProfileCredentialsProvider.create());
+		}
+
+		if (properties.getProfile() != null && properties.getProfile().getName() != null) {
+			providers.add(ProfileCredentialsProvider.builder().profileName(properties.getProfile().getName())
+					.profileFile(properties.getProfile().getPath() != null
+							? ProfileFile.builder().type(ProfileFile.Type.CREDENTIALS)
+									.content(Paths.get(properties.getProfile().getPath())).build()
+							: ProfileFile.defaultProfileFile())
+					.build());
+		}
+
+		if (providers.isEmpty()) {
+			return DefaultCredentialsProvider.create();
+		}
+		else {
+			return AwsCredentialsProviderChain.builder().credentialsProviders(providers).build();
+		}
+	}
+
+}

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/RegionProviderAutoConfiguration.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/RegionProviderAutoConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.v3.autoconfigure;
+
+import io.awspring.cloud.v3.autoconfigure.properties.AwsRegionProperties;
+import io.awspring.cloud.v3.core.region.StaticRegionProvider;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link EnableAutoConfiguration} for {@link AwsRegionProvider}.
+ *
+ * @author Maciej Walkowiak
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(AwsRegionProperties.class)
+public class RegionProviderAutoConfiguration {
+
+	private final AwsRegionProperties properties;
+
+	public RegionProviderAutoConfiguration(AwsRegionProperties properties) {
+		this.properties = properties;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public AwsRegionProvider awsRegionProvider() {
+		if (properties.isStatic()) {
+			return new StaticRegionProvider(properties.getStatic());
+		}
+		else {
+			return DefaultAwsRegionProviderChain.builder().build();
+		}
+	}
+
+}

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsCredentialsProperties.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsCredentialsProperties.java
@@ -90,19 +90,19 @@ public class AwsCredentialsProperties {
 
 		private String path;
 
-		String getName() {
+		public String getName() {
 			return name;
 		}
 
-		void setName(String name) {
+		public void setName(String name) {
 			this.name = name;
 		}
 
-		String getPath() {
+		public String getPath() {
 			return path;
 		}
 
-		void setPath(String path) {
+		public void setPath(String path) {
 			this.path = path;
 		}
 

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsCredentialsProperties.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsCredentialsProperties.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.v3.autoconfigure.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Properties related to AWS credentials.
+ *
+ * @author Tom Gianos
+ * @since 2.0.2
+ */
+@ConfigurationProperties(prefix = AwsCredentialsProperties.PREFIX)
+public class AwsCredentialsProperties {
+
+	/**
+	 * The prefix used for AWS credentials related properties.
+	 */
+	public static final String PREFIX = "spring.cloud.aws.credentials";
+
+	/**
+	 * The access key to be used with a static provider.
+	 */
+	private String accessKey;
+
+	/**
+	 * The secret key to be used with a static provider.
+	 */
+	private String secretKey;
+
+	/**
+	 * Configures an instance profile credentials provider with no further configuration.
+	 */
+	private boolean instanceProfile = false;
+
+	/**
+	 * The AWS profile.
+	 */
+	private Profile profile;
+
+	public String getAccessKey() {
+		return this.accessKey;
+	}
+
+	public void setAccessKey(String accessKey) {
+		this.accessKey = accessKey;
+	}
+
+	public String getSecretKey() {
+		return this.secretKey;
+	}
+
+	public void setSecretKey(String secretKey) {
+		this.secretKey = secretKey;
+	}
+
+	public boolean isInstanceProfile() {
+		return this.instanceProfile;
+	}
+
+	public void setInstanceProfile(boolean instanceProfile) {
+		this.instanceProfile = instanceProfile;
+	}
+
+	public Profile getProfile() {
+		return profile;
+	}
+
+	public void setProfile(Profile profile) {
+		this.profile = profile;
+	}
+
+	public static class Profile {
+
+		private String name;
+
+		private String path;
+
+		String getName() {
+			return name;
+		}
+
+		void setName(String name) {
+			this.name = name;
+		}
+
+		String getPath() {
+			return path;
+		}
+
+		void setPath(String path) {
+			this.path = path;
+		}
+
+	}
+
+}

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsRegionProperties.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsRegionProperties.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.v3.autoconfigure.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * Properties related to AWS region configuration.
+ *
+ * @author Tom Gianos
+ * @author Maciej Walkowiak
+ * @since 2.0.2
+ */
+@ConfigurationProperties(prefix = AwsRegionProperties.PREFIX)
+public class AwsRegionProperties {
+
+	/**
+	 * The prefix used for AWS region related properties.
+	 */
+	public static final String PREFIX = "spring.cloud.aws.region";
+
+	/**
+	 * Configures a static region for the application. Possible regions are (currently)
+	 * us-east-1, us-west-1, us-west-2, eu-west-1, eu-central-1, ap-southeast-1,
+	 * ap-southeast-1, ap-northeast-1, sa-east-1, cn-north-1 and any custom region
+	 * configured with own region meta data.
+	 */
+	private String staticRegion;
+
+	public String getStatic() {
+		return this.staticRegion;
+	}
+
+	public boolean isStatic() {
+		return StringUtils.hasText(this.staticRegion);
+	}
+
+	public void setStatic(String staticRegion) {
+		this.staticRegion = staticRegion;
+	}
+
+}

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/test/java/io/awspring/cloud/v3/autoconfigure/CredentialsProviderAutoConfigurationTests.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/test/java/io/awspring/cloud/v3/autoconfigure/CredentialsProviderAutoConfigurationTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.v3.autoconfigure;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CredentialsProviderAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(CredentialsProviderAutoConfiguration.class));
+
+	// @checkstyle:off
+	@Test
+	void credentialsProvider_noExplicitCredentialsProviderConfigured_configuresDefaultAwsCredentialsProviderChain() {
+		// @checkstyle:on
+		this.contextRunner.run((context) -> {
+			AwsCredentialsProvider awsCredentialsProvider = context.getBean("awsCredentialsProvider",
+					AwsCredentialsProvider.class);
+			assertThat(awsCredentialsProvider).isNotNull().isInstanceOf(DefaultCredentialsProvider.class);
+		});
+
+	}
+
+	// @checkstyle:off
+	@Test
+	void credentialsProvider_accessKeyAndSecretKeyConfigured_configuresStaticCredentialsProviderWithAccessAndSecretKey() {
+		// @checkstyle:on
+		this.contextRunner.withPropertyValues("spring.cloud.aws.credentials.accessKey:foo",
+				"spring.cloud.aws.credentials.secretKey:bar").run((context) -> {
+					AwsCredentialsProvider awsCredentialsProvider = context.getBean("awsCredentialsProvider",
+							AwsCredentialsProvider.class);
+					assertThat(awsCredentialsProvider).isNotNull();
+					assertThat(awsCredentialsProvider.resolveCredentials().accessKeyId()).isEqualTo("foo");
+					assertThat(awsCredentialsProvider.resolveCredentials().secretAccessKey()).isEqualTo("bar");
+
+					@SuppressWarnings("unchecked")
+					List<AwsCredentialsProvider> credentialsProviders = (List<AwsCredentialsProvider>) ReflectionTestUtils
+							.getField(awsCredentialsProvider, "credentialsProviders");
+					assertThat(credentialsProviders).hasSize(1).hasOnlyElementsOfType(StaticCredentialsProvider.class);
+				});
+	}
+
+	@Test
+	void credentialsProvider_instanceProfileConfigured_configuresInstanceProfileCredentialsProvider() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.credentials.instance-profile:true").run((context) -> {
+			AwsCredentialsProvider awsCredentialsProvider = context.getBean("awsCredentialsProvider",
+					AwsCredentialsProvider.class);
+			assertThat(awsCredentialsProvider).isNotNull();
+
+			@SuppressWarnings("unchecked")
+			List<AwsCredentialsProvider> credentialsProviders = (List<AwsCredentialsProvider>) ReflectionTestUtils
+					.getField(awsCredentialsProvider, "credentialsProviders");
+			assertThat(credentialsProviders).hasSize(1).hasOnlyElementsOfType(InstanceProfileCredentialsProvider.class);
+		});
+	}
+
+	@Test
+	void credentialsProvider_profileNameAndPathConfigured_configuresProfileCredentialsProvider() throws IOException {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.credentials.profile.name:customProfile",
+				"spring.cloud.aws.credentials.profile.path:"
+						+ new ClassPathResource(getClass().getSimpleName() + "-profile", getClass()).getFile()
+								.getAbsolutePath())
+				.run((context) -> {
+					AwsCredentialsProvider awsCredentialsProvider = context.getBean("awsCredentialsProvider",
+							AwsCredentialsProvider.class);
+					assertThat(awsCredentialsProvider).isNotNull();
+
+					@SuppressWarnings("unchecked")
+					List<AwsCredentialsProvider> credentialsProviders = (List<AwsCredentialsProvider>) ReflectionTestUtils
+							.getField(awsCredentialsProvider, "credentialsProviders");
+					assertThat(credentialsProviders).hasSize(1).hasOnlyElementsOfType(ProfileCredentialsProvider.class);
+
+					ProfileCredentialsProvider provider = (ProfileCredentialsProvider) credentialsProviders.get(0);
+					assertThat(provider.resolveCredentials().accessKeyId()).isEqualTo("testAccessKey");
+					assertThat(provider.resolveCredentials().secretAccessKey()).isEqualTo("testSecretKey");
+				});
+	}
+
+	@Test
+	void credentialsProvider_customCredentialsConfigured_customCredentialsAreUsed() {
+		// @checkstyle:on
+		this.contextRunner.withUserConfiguration(CustomCredentialsProviderConfiguration.class).run((context) -> {
+			AwsCredentialsProvider awsCredentialsProvider = context.getBean(AwsCredentialsProvider.class);
+			assertThat(awsCredentialsProvider).isNotNull().isInstanceOf(CustomAWSCredentialsProvider.class);
+		});
+
+	}
+
+	@Configuration
+	static class CustomCredentialsProviderConfiguration {
+
+		@Bean(name = "awsCredentialsProvider")
+		public AwsCredentialsProvider customAwsCredentialsProvider() {
+			return new CustomAWSCredentialsProvider();
+		}
+
+	}
+
+	static class CustomAWSCredentialsProvider implements AwsCredentialsProvider {
+
+		@Override
+		public AwsCredentials resolveCredentials() {
+			return null;
+		}
+
+	}
+
+}

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/test/java/io/awspring/cloud/v3/autoconfigure/RegionProviderAutoConfigurationTests.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/test/java/io/awspring/cloud/v3/autoconfigure/RegionProviderAutoConfigurationTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.v3.autoconfigure;
+
+import io.awspring.cloud.v3.core.region.StaticRegionProvider;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RegionProviderAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(RegionProviderAutoConfiguration.class));
+
+	@Test
+	void autoDetectionConfigured_noConfigurationProvided_DefaultAwsRegionProviderChainDelegateConfigured() {
+		this.contextRunner.run((context) -> {
+			assertThat(context.getBean(DefaultAwsRegionProviderChain.class)).isNotNull();
+		});
+	}
+
+	@Test
+	void autoDetectionConfigured_emptyStaticRegionConfigured_DefaultAwsRegionProviderChainDelegateConfigured() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.region.static:").run((context) -> {
+			assertThat(context.getBean(DefaultAwsRegionProviderChain.class)).isNotNull();
+		});
+	}
+
+	@Test
+	void staticRegionConfigured_staticRegionProviderWithConfiguredRegionConfigured() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.region.static:eu-west-1").run((context) -> {
+			StaticRegionProvider regionProvider = context.getBean(StaticRegionProvider.class);
+			assertThat(regionProvider.getRegion()).isEqualTo(Region.EU_WEST_1);
+		});
+	}
+
+	@Test
+	void customRegionConfigured() {
+		this.contextRunner.withUserConfiguration(CustomRegionProviderConfiguration.class).run((context) -> {
+			AwsRegionProvider regionProvider = context.getBean(AwsRegionProvider.class);
+			assertThat(regionProvider).isNotNull().isInstanceOf(CustomRegionProvider.class);
+		});
+
+	}
+
+	@Configuration
+	static class CustomRegionProviderConfiguration {
+
+		@Bean(name = "awsRegionProvider")
+		public AwsRegionProvider customRegionProvider() {
+			return new CustomRegionProvider();
+		}
+
+	}
+
+	static class CustomRegionProvider implements AwsRegionProvider {
+
+		@Override
+		public Region getRegion() {
+			return null;
+		}
+
+	}
+
+}

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/test/resources/io/awspring/cloud/v3/autoconfigure/CredentialsProviderAutoConfigurationTests-profile
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/test/resources/io/awspring/cloud/v3/autoconfigure/CredentialsProviderAutoConfigurationTests-profile
@@ -1,0 +1,9 @@
+[default]
+aws_access_key_id=defaultKey
+aws_secret_access_key=defaultKey
+aws_session_token=defaultToken
+
+[customProfile]
+aws_access_key_id=testAccessKey
+aws_secret_access_key=testSecretKey
+aws_session_token=testSessionToken

--- a/v3/spring-cloud-aws-v3-core/pom.xml
+++ b/v3/spring-cloud-aws-v3-core/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.awspring.cloud</groupId>
+        <artifactId>v3</artifactId>
+        <version>2.3.0-RC2</version>
+    </parent>
+
+    <artifactId>spring-cloud-aws-v3-core</artifactId>
+    <version>2.3.0-RC2</version>
+
+	<dependencies>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>regions</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/v3/spring-cloud-aws-v3-core/src/main/java/io/awspring/cloud/v3/core/region/StaticRegionProvider.java
+++ b/v3/spring-cloud-aws-v3-core/src/main/java/io/awspring/cloud/v3/core/region/StaticRegionProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.v3.core.region;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+
+/**
+ * Static {@link AwsRegionProvider} implementation that can used to statically configure a
+ * region. The region could be provided through a configuration file at configuration
+ * time.
+ *
+ * @author Agim Emruli
+ * @author Maciej Walkowiak
+ * @since 1.0
+ */
+public class StaticRegionProvider implements AwsRegionProvider {
+
+	private final Region configuredRegion;
+
+	/**
+	 * Constructs and configures the static region for this RegionProvider implementation.
+	 * @param configuredRegion - the region that will be statically returned in
+	 * {@link #getRegion()}
+	 */
+	public StaticRegionProvider(String configuredRegion) {
+		try {
+			this.configuredRegion = Region.of(configuredRegion);
+		}
+		catch (IllegalArgumentException e) {
+			throw new IllegalArgumentException("The region '" + configuredRegion + "' is not a valid region!", e);
+		}
+	}
+
+	/**
+	 * Return the configured Region configured at construction time.
+	 * @return the configured region, for every call the same
+	 */
+	@Override
+	public Region getRegion() {
+		return this.configuredRegion;
+	}
+
+}

--- a/v3/spring-cloud-aws-v3-dependencies/pom.xml
+++ b/v3/spring-cloud-aws-v3-dependencies/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-dependencies-parent</artifactId>
+		<version>3.0.0</version>
+		<relativePath/>
+	</parent>
+	<groupId>io.awspring.cloud</groupId>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>spring-cloud-aws-v3-dependencies</artifactId>
+	<version>2.3.0-RC2</version>
+	<properties>
+		<aws-java-sdk.version>2.15.80</aws-java-sdk.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>bom</artifactId>
+				<version>${aws-java-sdk.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>io.awspring.cloud</groupId>
+				<artifactId>spring-cloud-aws-v3-core</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>io.awspring.cloud</groupId>
+				<artifactId>spring-cloud-aws-v3-autoconfigure</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>io.awspring.cloud</groupId>
+				<artifactId>spring-cloud-starter-aws-v3-secrets-manager-config</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>io.awspring.cloud</groupId>
+				<artifactId>spring-cloud-aws-v3-secrets-manager-config</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+		</dependencies>
+	</dependencyManagement>
+
+</project>

--- a/v3/spring-cloud-aws-v3-secrets-manager-config/README.adoc
+++ b/v3/spring-cloud-aws-v3-secrets-manager-config/README.adoc
@@ -1,0 +1,5 @@
+= AWS Secrets Manager
+
+== References
+
+https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html[AWS Secrets Manager Official Docs]

--- a/v3/spring-cloud-aws-v3-secrets-manager-config/pom.xml
+++ b/v3/spring-cloud-aws-v3-secrets-manager-config/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>v3</artifactId>
+		<groupId>io.awspring.cloud</groupId>
+		<version>2.3.0-RC2</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>spring-cloud-aws-v3-secrets-manager-config</artifactId>
+	<name>Spring Cloud AWS V3 Secrets Manager Configuration</name>
+	<description>Spring Cloud AWS V3 Secrets Manager Configuration</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>io.awspring.cloud</groupId>
+			<artifactId>spring-cloud-aws-v3-autoconfigure</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-context</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>secretsmanager</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/v3/spring-cloud-aws-v3-secrets-manager-config/src/main/java/io/awspring/cloud/v3/secretsmanager/AwsSecretsManagerProperties.java
+++ b/v3/spring-cloud-aws-v3-secrets-manager-config/src/main/java/io/awspring/cloud/v3/secretsmanager/AwsSecretsManagerProperties.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.v3.secretsmanager;
+
+import java.net.URI;
+import java.util.regex.Pattern;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+/**
+ * Configuration properties for the AWS Secrets Manager integration. Mostly based on the
+ * Spring Cloud Consul Configuration equivalent.
+ *
+ * @author Fabio Maia
+ * @author Matej Nedic
+ * @author Hari Ohm Prasath
+ * @author Arun Patra
+ * @since 2.0.0
+ */
+@ConfigurationProperties(prefix = AwsSecretsManagerProperties.CONFIG_PREFIX)
+public class AwsSecretsManagerProperties implements Validator {
+
+	/**
+	 * Configuration prefix.
+	 */
+	public static final String CONFIG_PREFIX = "aws.secretsmanager";
+
+	/**
+	 * Pattern used for prefix validation.
+	 */
+	private static final Pattern PREFIX_PATTERN = Pattern.compile("(/)?([a-zA-Z0-9.\\-_]+)*");
+
+	/**
+	 * Pattern used for profileSeparator validation.
+	 */
+	private static final Pattern PROFILE_SEPARATOR_PATTERN = Pattern.compile("[a-zA-Z0-9.\\-_/\\\\]+");
+
+	/**
+	 * Prefix indicating first level for every property. Value must start with a forward
+	 * slash followed by a valid path segment or be empty. Defaults to "/secret".
+	 */
+	private String prefix = "/secret";
+
+	private String defaultContext = "application";
+
+	private String profileSeparator = "_";
+
+	/** Throw exceptions during config lookup if true, otherwise, log warnings. */
+	private boolean failFast = true;
+
+	/**
+	 * If region value is not null or empty it will be used in creation of
+	 * AWSSecretsManager.
+	 */
+	private String region;
+
+	/**
+	 * Overrides the default endpoint.
+	 */
+	private URI endpoint;
+
+	/**
+	 * Alternative to spring.application.name to use in looking up values in AWS Secrets
+	 * Manager.
+	 */
+	private String name;
+
+	/** Is AWS Secrets Manager support enabled. */
+	private boolean enabled = true;
+
+	@Override
+	public boolean supports(Class<?> clazz) {
+		return AwsSecretsManagerProperties.class.isAssignableFrom(clazz);
+	}
+
+	@Override
+	public void validate(Object target, Errors errors) {
+		AwsSecretsManagerProperties properties = (AwsSecretsManagerProperties) target;
+
+		if (!StringUtils.hasLength(properties.getPrefix())) {
+			errors.rejectValue("prefix", "NotEmpty", "prefix should not be empty or null.");
+		}
+
+		if (!StringUtils.hasLength(properties.getDefaultContext())) {
+			errors.rejectValue("defaultContext", "NotEmpty", "defaultContext should not be empty or null.");
+		}
+
+		if (!StringUtils.hasLength(properties.getProfileSeparator())) {
+			errors.rejectValue("profileSeparator", "NotEmpty", "profileSeparator should not be empty or null.");
+		}
+
+		if (!PREFIX_PATTERN.matcher(properties.getPrefix()).matches()) {
+			errors.rejectValue("prefix", "Pattern", "The prefix must have pattern of:  " + PREFIX_PATTERN.toString());
+		}
+		if (!PROFILE_SEPARATOR_PATTERN.matcher(properties.getProfileSeparator()).matches()) {
+			errors.rejectValue("profileSeparator", "Pattern",
+					"The profileSeparator must have pattern of:  " + PROFILE_SEPARATOR_PATTERN.toString());
+		}
+	}
+
+	public String getPrefix() {
+		return prefix;
+	}
+
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public String getDefaultContext() {
+		return defaultContext;
+	}
+
+	public void setDefaultContext(String defaultContext) {
+		this.defaultContext = defaultContext;
+	}
+
+	public String getProfileSeparator() {
+		return profileSeparator;
+	}
+
+	public void setProfileSeparator(String profileSeparator) {
+		this.profileSeparator = profileSeparator;
+	}
+
+	public boolean isFailFast() {
+		return failFast;
+	}
+
+	public void setFailFast(boolean failFast) {
+		this.failFast = failFast;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public String getRegion() {
+		return region;
+	}
+
+	public void setRegion(final String region) {
+		this.region = region;
+	}
+
+	public URI getEndpoint() {
+		return endpoint;
+	}
+
+	public void setEndpoint(URI endpoint) {
+		this.endpoint = endpoint;
+	}
+
+}

--- a/v3/spring-cloud-aws-v3-secrets-manager-config/src/main/java/io/awspring/cloud/v3/secretsmanager/AwsSecretsManagerPropertySource.java
+++ b/v3/spring-cloud-aws-v3-secrets-manager-config/src/main/java/io/awspring/cloud/v3/secretsmanager/AwsSecretsManagerPropertySource.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.v3.secretsmanager;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
+
+import org.springframework.core.env.EnumerablePropertySource;
+
+/**
+ * Retrieves secret value under the given context / path from the AWS Secrets Manager
+ * using the provided Secrets Manager client.
+ *
+ * @author Fabio Maia
+ * @author Maciej Walkowiak
+ * @since 2.0.0
+ */
+public class AwsSecretsManagerPropertySource extends EnumerablePropertySource<SecretsManagerClient> {
+
+	private final ObjectMapper jsonMapper = new ObjectMapper();
+
+	private final String context;
+
+	private final Map<String, Object> properties = new LinkedHashMap<>();
+
+	public AwsSecretsManagerPropertySource(String context, SecretsManagerClient smClient) {
+		super(context, smClient);
+		this.context = context;
+	}
+
+	/**
+	 * Loads properties from the Secrets Manager secret.
+	 * @throws ResourceNotFoundException if specified secret does not exist in the
+	 * database.
+	 */
+	public void init() {
+		readSecretValue(GetSecretValueRequest.builder().secretId(context).build());
+	}
+
+	@Override
+	public String[] getPropertyNames() {
+		Set<String> strings = properties.keySet();
+		return strings.toArray(new String[strings.size()]);
+	}
+
+	@Override
+	public Object getProperty(String name) {
+		return properties.get(name);
+	}
+
+	private void readSecretValue(GetSecretValueRequest secretValueRequest) {
+		try {
+			GetSecretValueResponse secretValueResponse = source.getSecretValue(secretValueRequest);
+			Map<String, Object> secretMap = jsonMapper.readValue(secretValueResponse.secretString(),
+					new TypeReference<Map<String, Object>>() {
+					});
+
+			for (Map.Entry<String, Object> secretEntry : secretMap.entrySet()) {
+				properties.put(secretEntry.getKey(), secretEntry.getValue());
+			}
+		}
+		catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/v3/spring-cloud-aws-v3-secrets-manager-config/src/main/java/io/awspring/cloud/v3/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
+++ b/v3/spring-cloud-aws-v3-secrets-manager-config/src/main/java/io/awspring/cloud/v3/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.v3.secretsmanager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+
+import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * Builds a {@link CompositePropertySource} with various
+ * {@link AwsSecretsManagerPropertySource} instances based on active profiles, application
+ * name and default context permutations. Mostly copied from Spring Cloud Consul's config
+ * support.
+ *
+ * Note: this class is used only by legacy Spring Cloud Bootstrap phase based config
+ * loading.
+ *
+ * @author Fabio Maia
+ * @author Matej Nedic
+ * @author Eddú Meléndez
+ * @since 2.0.0
+ */
+public class AwsSecretsManagerPropertySourceLocator implements PropertySourceLocator {
+
+	private final String propertySourceName;
+
+	private final SecretsManagerClient smClient;
+
+	private final AwsSecretsManagerProperties properties;
+
+	private final Set<String> contexts = new LinkedHashSet<>();
+
+	private Log logger = LogFactory.getLog(getClass());
+
+	public AwsSecretsManagerPropertySourceLocator(String propertySourceName, SecretsManagerClient smClient,
+			AwsSecretsManagerProperties properties) {
+		this.propertySourceName = propertySourceName;
+		this.smClient = smClient;
+		this.properties = properties;
+	}
+
+	public AwsSecretsManagerPropertySourceLocator(SecretsManagerClient smClient,
+			AwsSecretsManagerProperties properties) {
+		this("aws-secrets-manager", smClient, properties);
+	}
+
+	public List<String> getContexts() {
+		return new ArrayList<>(contexts);
+	}
+
+	@Override
+	public PropertySource<?> locate(Environment environment) {
+		if (!(environment instanceof ConfigurableEnvironment)) {
+			return null;
+		}
+
+		ConfigurableEnvironment env = (ConfigurableEnvironment) environment;
+
+		AwsSecretsManagerPropertySources sources = new AwsSecretsManagerPropertySources(properties, logger);
+
+		List<String> profiles = Arrays.asList(env.getActiveProfiles());
+		this.contexts.addAll(sources.getAutomaticContexts(profiles));
+
+		CompositePropertySource composite = new CompositePropertySource(this.propertySourceName);
+
+		for (String propertySourceContext : this.contexts) {
+			PropertySource<SecretsManagerClient> propertySource = sources.createPropertySource(propertySourceContext,
+					!this.properties.isFailFast(), this.smClient);
+			if (propertySource != null) {
+				composite.addPropertySource(propertySource);
+			}
+		}
+
+		return composite;
+	}
+
+}

--- a/v3/spring-cloud-aws-v3-secrets-manager-config/src/main/java/io/awspring/cloud/v3/secretsmanager/AwsSecretsManagerPropertySources.java
+++ b/v3/spring-cloud-aws-v3-secrets-manager-config/src/main/java/io/awspring/cloud/v3/secretsmanager/AwsSecretsManagerPropertySources.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.v3.secretsmanager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+
+import org.springframework.util.StringUtils;
+
+public class AwsSecretsManagerPropertySources {
+
+	private final AwsSecretsManagerProperties properties;
+
+	private final Log log;
+
+	public AwsSecretsManagerPropertySources(AwsSecretsManagerProperties properties, Log log) {
+		this.properties = properties;
+		this.log = log;
+	}
+
+	public List<String> getAutomaticContexts(List<String> profiles) {
+		List<String> contexts = new ArrayList<>();
+		String prefix = this.properties.getPrefix();
+		String defaultContext = getContext(prefix, this.properties.getDefaultContext());
+
+		String appName = this.properties.getName();
+
+		String appContext = prefix + "/" + appName;
+		addProfiles(contexts, appContext, profiles);
+		contexts.add(appContext);
+
+		addProfiles(contexts, defaultContext, profiles);
+		contexts.add(defaultContext);
+		return contexts;
+	}
+
+	protected String getContext(String prefix, String context) {
+		if (StringUtils.hasLength(prefix)) {
+			return prefix + "/" + context;
+		}
+		return context;
+	}
+
+	private void addProfiles(List<String> contexts, String baseContext, List<String> profiles) {
+		for (String profile : profiles) {
+			contexts.add(baseContext + this.properties.getProfileSeparator() + profile);
+		}
+	}
+
+	/**
+	 * Creates property source for given context.
+	 * @param context property source context equivalent to the secret name
+	 * @param optional if creating context should fail with exception if secret cannot be
+	 * loaded
+	 * @param client Secret Manager client
+	 * @return a property source or null if secret could not be loaded and optional is set
+	 * to true
+	 */
+	public AwsSecretsManagerPropertySource createPropertySource(String context, boolean optional,
+			SecretsManagerClient client) {
+		log.info("Loading secrets from AWS Secret Manager secret with name: " + context + ", optional: " + optional);
+		try {
+			AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource(context, client);
+			propertySource.init();
+			return propertySource;
+			// TODO: howto call close when /refresh
+		}
+		catch (Exception e) {
+			if (!optional) {
+				throw new AwsSecretsManagerPropertySourceNotFoundException(e);
+			}
+			else {
+				log.warn("Unable to load AWS secret from " + context + ". " + e.getMessage());
+			}
+		}
+		return null;
+	}
+
+	static class AwsSecretsManagerPropertySourceNotFoundException extends RuntimeException {
+
+		AwsSecretsManagerPropertySourceNotFoundException(Exception source) {
+			super(source);
+		}
+
+	}
+
+}

--- a/v3/spring-cloud-aws-v3-secrets-manager-config/src/test/java/io/awspring/cloud/v3/secretsmanager/AwsSecretsManagerPropertiesTest.java
+++ b/v3/spring-cloud-aws-v3-secrets-manager-config/src/test/java/io/awspring/cloud/v3/secretsmanager/AwsSecretsManagerPropertiesTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.v3.secretsmanager;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link AwsSecretsManagerProperties}.
+ *
+ * @author Matej Nedic
+ * @author Maciej Walkowiak
+ */
+class AwsSecretsManagerPropertiesTest {
+
+	private static Stream<Arguments> validProperties() {
+		return Stream.of(
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("/sec").withDefaultContext("app")
+						.withProfileSeparator("_").build()),
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("secret").withDefaultContext("app")
+						.withProfileSeparator("_").build()),
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("secret").withDefaultContext("app")
+						.withProfileSeparator("\\").build()),
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("secret").withDefaultContext("app")
+						.withProfileSeparator("/").build()));
+	}
+
+	private static Stream<Arguments> invalidProperties() {
+		return Stream.of(
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("").build(), "prefix", "NotEmpty"),
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("!.").build(), "prefix", "Pattern"),
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withDefaultContext("").build(), "defaultContext",
+						"NotEmpty"),
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withProfileSeparator("").build(),
+						"profileSeparator", "NotEmpty"),
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withProfileSeparator("!_").build(),
+						"profileSeparator", "Pattern"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("invalidProperties")
+	public void validationFails(AwsSecretsManagerProperties properties, String field, String errorCode) {
+		Errors errors = new BeanPropertyBindingResult(properties, "properties");
+
+		properties.validate(properties, errors);
+
+		assertThat(errors.getFieldError(field)).isNotNull();
+		assertThat(errors.getFieldError(field).getCode()).isEqualTo(errorCode);
+	}
+
+	@ParameterizedTest
+	@MethodSource("validProperties")
+	void validationSucceeds(AwsSecretsManagerProperties properties) {
+		Errors errors = new BeanPropertyBindingResult(properties, "properties");
+		properties.validate(properties, errors);
+		assertThat(errors.getAllErrors()).isEmpty();
+	}
+
+	private static class AwsSecretsManagerPropertiesBuilder {
+
+		private final AwsSecretsManagerProperties properties = new AwsSecretsManagerProperties();
+
+		AwsSecretsManagerPropertiesBuilder withPrefix(String prefix) {
+			this.properties.setPrefix(prefix);
+			return this;
+		}
+
+		AwsSecretsManagerPropertiesBuilder withDefaultContext(String defaultContext) {
+			this.properties.setDefaultContext(defaultContext);
+			return this;
+		}
+
+		AwsSecretsManagerPropertiesBuilder withProfileSeparator(String profileSeparator) {
+			this.properties.setProfileSeparator(profileSeparator);
+			return this;
+		}
+
+		AwsSecretsManagerProperties build() {
+			return this.properties;
+		}
+
+	}
+
+}

--- a/v3/spring-cloud-aws-v3-secrets-manager-config/src/test/java/io/awspring/cloud/v3/secretsmanager/AwsSecretsManagerPropertySourceLocatorTest.java
+++ b/v3/spring-cloud-aws-v3-secrets-manager-config/src/test/java/io/awspring/cloud/v3/secretsmanager/AwsSecretsManagerPropertySourceLocatorTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.v3.secretsmanager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+import io.awspring.cloud.v3.secretsmanager.AwsSecretsManagerPropertySources.AwsSecretsManagerPropertySourceNotFoundException;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
+
+/**
+ * Unit test for {@link AwsSecretsManagerPropertySourceLocator}.
+ *
+ * @author Anthony Foulfoin
+ * @author Matej Nedic
+ * @author Maciej Walkowiak.
+ */
+class AwsSecretsManagerPropertySourceLocatorTest {
+
+	private final SecretsManagerClient smClient = mock(SecretsManagerClient.class);
+
+	private MockEnvironment env = new MockEnvironment();
+
+	@Test
+	void locate_nameSpecifiedInConstructor_returnsPropertySourceWithSpecifiedName() {
+
+		GetSecretValueResponse secretValueResult = GetSecretValueResponse.builder()
+				.secretString("{\"key1\": \"value1\", \"key2\": \"value2\"}").build();
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
+
+		AwsSecretsManagerProperties properties = new AwsSecretsManagerProperties();
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator("my-name", smClient,
+				properties);
+
+		PropertySource propertySource = locator.locate(env);
+
+		assertThat(propertySource.getName()).isEqualTo("my-name");
+	}
+
+	@Test
+	void locate_nameNotSpecifiedInConstructor_returnsPropertySourceWithDefaultName() {
+		GetSecretValueResponse secretValueResult = GetSecretValueResponse.builder()
+				.secretString("{\"key1\": \"value1\", \"key2\": \"value2\"}").build();
+
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
+
+		AwsSecretsManagerProperties properties = new AwsSecretsManagerProperties();
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(smClient,
+				properties);
+		PropertySource propertySource = locator.locate(env);
+
+		assertThat(propertySource.getName()).isEqualTo("aws-secrets-manager");
+	}
+
+	@Test
+	void contextExpectedToHave2Elements() {
+		AwsSecretsManagerProperties properties = new AwsSecretsManagerPropertiesBuilder()
+				.withDefaultContext("application").withName("application").build();
+
+		GetSecretValueResponse secretValueResult = GetSecretValueResponse.builder()
+				.secretString("{\"key1\": \"value1\", \"key2\": \"value2\"}").build();
+
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
+
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(smClient,
+				properties);
+		env.setActiveProfiles("test");
+		locator.locate(env);
+
+		assertThat(locator.getContexts()).hasSize(2);
+	}
+
+	@Test
+	void contextExpectedToHave4Elements() {
+		AwsSecretsManagerProperties properties = new AwsSecretsManagerPropertiesBuilder()
+				.withDefaultContext("application").withName("messaging-service").build();
+
+		GetSecretValueResponse secretValueResult = GetSecretValueResponse.builder()
+				.secretString("{\"key1\": \"value1\", \"key2\": \"value2\"}").build();
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
+
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(smClient,
+				properties);
+		env.setActiveProfiles("test");
+		locator.locate(env);
+
+		assertThat(locator.getContexts()).hasSize(4);
+	}
+
+	@Test
+	void contextSpecificOrderExpected() {
+		AwsSecretsManagerProperties properties = new AwsSecretsManagerPropertiesBuilder()
+				.withDefaultContext("application").withName("messaging-service").build();
+
+		GetSecretValueResponse secretValueResult = GetSecretValueResponse.builder()
+				.secretString("{\"key1\": \"value1\", \"key2\": \"value2\"}").build();
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
+
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(smClient,
+				properties);
+		env.setActiveProfiles("test");
+		locator.locate(env);
+
+		List<String> contextToBeTested = new ArrayList<>(locator.getContexts());
+
+		assertThat(contextToBeTested.get(0)).isEqualTo("/secret/messaging-service_test");
+		assertThat(contextToBeTested.get(1)).isEqualTo("/secret/messaging-service");
+		assertThat(contextToBeTested.get(2)).isEqualTo("/secret/application_test");
+		assertThat(contextToBeTested.get(3)).isEqualTo("/secret/application");
+	}
+
+	@Test
+	void whenFailFastIsTrueAndSecretDoesNotExistThrowsException() {
+		AwsSecretsManagerProperties properties = new AwsSecretsManagerProperties();
+		properties.setFailFast(true);
+
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class))).thenThrow(ResourceNotFoundException.class);
+
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(smClient,
+				properties);
+		assertThatThrownBy(() -> locator.locate(env))
+				.isInstanceOf(AwsSecretsManagerPropertySourceNotFoundException.class);
+	}
+
+	@Test
+	void whenFailFastIsFalseAndSecretDoesNotExistReturnsEmptyPropertySource() {
+		AwsSecretsManagerProperties properties = new AwsSecretsManagerProperties();
+		properties.setFailFast(false);
+
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class))).thenThrow(ResourceNotFoundException.class);
+
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(smClient,
+				properties);
+
+		CompositePropertySource result = (CompositePropertySource) locator.locate(env);
+
+		assertThat(result.getPropertySources()).isEmpty();
+	}
+
+	private final static class AwsSecretsManagerPropertiesBuilder {
+
+		private final AwsSecretsManagerProperties properties = new AwsSecretsManagerProperties();
+
+		private AwsSecretsManagerPropertiesBuilder() {
+		}
+
+		public AwsSecretsManagerPropertiesBuilder withDefaultContext(String defaultContext) {
+			this.properties.setDefaultContext(defaultContext);
+			return this;
+		}
+
+		public AwsSecretsManagerPropertiesBuilder withName(String name) {
+			this.properties.setName(name);
+			return this;
+		}
+
+		public AwsSecretsManagerProperties build() {
+			return this.properties;
+		}
+
+	}
+
+}

--- a/v3/spring-cloud-aws-v3-secrets-manager-config/src/test/java/io/awspring/cloud/v3/secretsmanager/AwsSecretsManagerPropertySourceTest.java
+++ b/v3/spring-cloud-aws-v3-secrets-manager-config/src/test/java/io/awspring/cloud/v3/secretsmanager/AwsSecretsManagerPropertySourceTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.v3.secretsmanager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
+
+class AwsSecretsManagerPropertySourceTest {
+
+	private SecretsManagerClient client = mock(SecretsManagerClient.class);
+
+	private AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource("/config/myservice",
+			client);
+
+	@Test
+	void shouldParseSecretValue() {
+		GetSecretValueResponse secretValueResult = GetSecretValueResponse.builder()
+				.secretString("{\"key1\": \"value1\", \"key2\": \"value2\"}").build();
+
+		when(client.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
+
+		propertySource.init();
+
+		assertThat(propertySource.getPropertyNames()).containsExactly("key1", "key2");
+		assertThat(propertySource.getProperty("key1")).isEqualTo("value1");
+		assertThat(propertySource.getProperty("key2")).isEqualTo("value2");
+	}
+
+	@Test
+	void throwsExceptionWhenSecretNotFound() {
+		when(client.getSecretValue(any(GetSecretValueRequest.class)))
+				.thenThrow(ResourceNotFoundException.builder().message("secret not found").build());
+
+		assertThatThrownBy(() -> propertySource.init()).isInstanceOf(ResourceNotFoundException.class);
+	}
+
+}

--- a/v3/spring-cloud-starter-aws-v3-secrets-manager-config/pom.xml
+++ b/v3/spring-cloud-starter-aws-v3-secrets-manager-config/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>v3</artifactId>
+		<groupId>io.awspring.cloud</groupId>
+		<version>2.3.0-RC2</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>spring-cloud-starter-aws-v3-secrets-manager-config</artifactId>
+	<name>Spring Cloud AWS V3 Secrets Manager Configuration Starter</name>
+	<description>Spring Cloud AWS V3 Secrets Manager Configuration Starter</description>
+
+	<dependencies>
+		<!-- note that we don't depend on spring-cloud-aws-autoconfigure: that module brings in
+		     spring-cloud-aws-context and unwanted auto-configuration when you just want to use
+		     the Secrets Manager configuration support.
+		     We simply include our own auto-configuration for Spring Cloud in this starter instead. -->
+		<dependency>
+			<groupId>io.awspring.cloud</groupId>
+			<artifactId>spring-cloud-aws-v3-secrets-manager-config</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.awspring.cloud</groupId>
+			<artifactId>spring-cloud-aws-v3-core</artifactId>
+		</dependency>
+	</dependencies>
+
+</project>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring

 
## :scroll: Description
This PR will migrate Secrets Manger to use AWS SDK V2 - #58. Also it will push changes from #54.


## :bulb: Motivation and Context
This change is required for the Secrets manager integration to use AWS SDK V2
The related issues are #56 and #58.


## :green_heart: How did you test it?
Added tests for migrated classes.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps

Need guidance from @maciejwalkowiak , @MatejNedic to proceed forward with migrating the `spring-cloud-starter-aws-secrets-manager-config` module. 