### PR TITLE
Fix documentation how to import default aws-secretsmanager keys

### DIFF
--- a/docs/src/main/asciidoc/secrets-manager.adoc
+++ b/docs/src/main/asciidoc/secrets-manager.adoc
@@ -92,7 +92,7 @@ However, starting at `spring-cloud-aws` `2.3`, allows import default aws secrets
 |Property
 |Description
 
-|`spring.config.import=aws-secretsmanager`
+|`spring.config.import=aws-secretsmanager:`
 |Importing parameters based on spring.application.name property value for each active profile
 
 |`spring.config.import=aws-secretsmanager:secret-key;other-secret-key`


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Documentation had a missing required colon. See AwsSecretsManagerConfigDataLocationResolver.PREFIX

## :bulb: Motivation and Context
Accurate documentation makes getting started a lot easier with less frustration.

## :green_heart: How did you test it?
Tried the following configurations:

Works:
```yaml
spring:
  config:
    import: "aws-secretsmanager:"
```
Does not:
```yaml
spring:
  config:
    import: "aws-secretsmanager"
```
## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
