### PR TITLE
Auto-configure region with InstanceProfileRegionProvider

### DIFF
--- a/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/RegionProviderAutoConfiguration.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/RegionProviderAutoConfiguration.java
@@ -62,8 +62,10 @@ public class RegionProviderAutoConfiguration {
 
 		if (providers.isEmpty()) {
 			return DefaultAwsRegionProviderChain.builder().build();
-		} else {
+		}
+		else {
 			return new AwsRegionProviderChain(providers.toArray(new AwsRegionProvider[0]));
 		}
 	}
+
 }

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/RegionProviderAutoConfiguration.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/RegionProviderAutoConfiguration.java
@@ -38,7 +38,7 @@ import org.springframework.context.annotation.Configuration;
 /**
  * {@link EnableAutoConfiguration} for {@link AwsRegionProvider}.
  *
- * @author Maciej Walkowiak
+ * @author Siva Katamreddy
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(AwsRegionProperties.class)

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsRegionProperties.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsRegionProperties.java
@@ -66,4 +66,5 @@ public class AwsRegionProperties {
 	public void setInstanceProfile(boolean instanceProfile) {
 		this.instanceProfile = instanceProfile;
 	}
+
 }

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsRegionProperties.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsRegionProperties.java
@@ -42,6 +42,11 @@ public class AwsRegionProperties {
 	 */
 	private String staticRegion;
 
+	/**
+	 * Configures an instance profile region provider with no further configuration.
+	 */
+	private boolean instanceProfile = false;
+
 	public String getStatic() {
 		return this.staticRegion;
 	}
@@ -54,4 +59,11 @@ public class AwsRegionProperties {
 		this.staticRegion = staticRegion;
 	}
 
+	public boolean isInstanceProfile() {
+		return instanceProfile;
+	}
+
+	public void setInstanceProfile(boolean instanceProfile) {
+		this.instanceProfile = instanceProfile;
+	}
 }

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/test/java/io/awspring/cloud/v3/autoconfigure/RegionProviderAutoConfigurationTests.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/test/java/io/awspring/cloud/v3/autoconfigure/RegionProviderAutoConfigurationTests.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RegionProviderAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-		.withConfiguration(AutoConfigurations.of(RegionProviderAutoConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(RegionProviderAutoConfiguration.class));
 
 	@Test
 	void autoDetectionConfigured_noConfigurationProvided_DefaultAwsRegionProviderChainDelegateConfigured() {
@@ -71,13 +71,12 @@ class RegionProviderAutoConfigurationTests {
 	@Test
 	void credentialsProvider_instanceProfileConfigured_configuresInstanceProfileCredentialsProvider() {
 		this.contextRunner.withPropertyValues("spring.cloud.aws.region.instance-profile:true").run((context) -> {
-			AwsRegionProvider awsCredentialsProvider = context.getBean("awsRegionProvider",
-				AwsRegionProvider.class);
+			AwsRegionProvider awsCredentialsProvider = context.getBean("awsRegionProvider", AwsRegionProvider.class);
 			assertThat(awsCredentialsProvider).isNotNull();
 
 			@SuppressWarnings("unchecked")
 			List<AwsRegionProvider> credentialsProviders = (List<AwsRegionProvider>) ReflectionTestUtils
-				.getField(awsCredentialsProvider, "providers");
+					.getField(awsCredentialsProvider, "providers");
 			assertThat(credentialsProviders).hasSize(1).hasOnlyElementsOfType(InstanceProfileRegionProvider.class);
 		});
 	}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
`RegionProviderAutoconfiguration` was changed to issue a `InstanceProfileRegionProvider` configured by `spring.cloud.aws.region.instance-profile`  property, similar to `CredentialsProviderAutoconfiguration`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#71 Fixes

## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
