### PR TITLE
Implementing AwsProfileRegionProvider Autoconfiguration using profile.

### DIFF
--- a/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsCredentialsProperties.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsCredentialsProperties.java
@@ -84,28 +84,4 @@ public class AwsCredentialsProperties {
 		this.profile = profile;
 	}
 
-	public static class Profile {
-
-		private String name;
-
-		private String path;
-
-		public String getName() {
-			return name;
-		}
-
-		public void setName(String name) {
-			this.name = name;
-		}
-
-		public String getPath() {
-			return path;
-		}
-
-		public void setPath(String path) {
-			this.path = path;
-		}
-
-	}
-
 }

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsRegionProperties.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsRegionProperties.java
@@ -67,28 +67,4 @@ public class AwsRegionProperties {
 		return this.staticRegion;
 	}
 
-	public static class Profile {
-
-		private String name;
-
-		private String path;
-
-		public String getName() {
-			return name;
-		}
-
-		public void setName(String name) {
-			this.name = name;
-		}
-
-		public String getPath() {
-			return path;
-		}
-
-		public void setPath(String path) {
-			this.path = path;
-		}
-
-	}
-
 }

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsRegionProperties.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/AwsRegionProperties.java
@@ -42,9 +42,10 @@ public class AwsRegionProperties {
 	 */
 	private String staticRegion;
 
-	public String getStatic() {
-		return this.staticRegion;
-	}
+	/**
+	 * The AWS profile.
+	 */
+	private Profile profile;
 
 	public boolean isStatic() {
 		return StringUtils.hasText(this.staticRegion);
@@ -52,6 +53,42 @@ public class AwsRegionProperties {
 
 	public void setStatic(String staticRegion) {
 		this.staticRegion = staticRegion;
+	}
+
+	public Profile getProfile() {
+		return profile;
+	}
+
+	public void setProfile(Profile profile) {
+		this.profile = profile;
+	}
+
+	public String getStatic() {
+		return this.staticRegion;
+	}
+
+	public static class Profile {
+
+		private String name;
+
+		private String path;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getPath() {
+			return path;
+		}
+
+		public void setPath(String path) {
+			this.path = path;
+		}
+
 	}
 
 }

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/Profile.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/main/java/io/awspring/cloud/v3/autoconfigure/properties/Profile.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.v3.autoconfigure.properties;
+
+/**
+ * Properties related to AWS Profile.
+ *
+ * @author Tom Gianos
+ * @author Siva Katamreddy
+ */
+public class Profile {
+
+	/**
+	 * Profile name.
+	 */
+	private String name;
+
+	/**
+	 * Profile file path.
+	 */
+	private String path;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getPath() {
+		return path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
+	}
+
+}

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/test/java/io/awspring/cloud/v3/autoconfigure/RegionProviderAutoConfigurationTests.java
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/test/java/io/awspring/cloud/v3/autoconfigure/RegionProviderAutoConfigurationTests.java
@@ -16,9 +16,13 @@
 
 package io.awspring.cloud.v3.autoconfigure;
 
+import java.io.IOException;
+import java.util.List;
+
 import io.awspring.cloud.v3.core.region.StaticRegionProvider;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.AwsProfileRegionProvider;
 import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
@@ -26,6 +30,8 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,9 +57,37 @@ class RegionProviderAutoConfigurationTests {
 	@Test
 	void staticRegionConfigured_staticRegionProviderWithConfiguredRegionConfigured() {
 		this.contextRunner.withPropertyValues("spring.cloud.aws.region.static:eu-west-1").run((context) -> {
-			StaticRegionProvider regionProvider = context.getBean(StaticRegionProvider.class);
+			AwsRegionProvider awsRegionProvider = context.getBean(AwsRegionProvider.class);
+
+			@SuppressWarnings("unchecked")
+			List<AwsRegionProvider> regionProviders = (List<AwsRegionProvider>) ReflectionTestUtils
+					.getField(awsRegionProvider, "providers");
+			assertThat(regionProviders).hasSize(1).hasOnlyElementsOfType(StaticRegionProvider.class);
+
+			StaticRegionProvider regionProvider = (StaticRegionProvider) regionProviders.get(0);
 			assertThat(regionProvider.getRegion()).isEqualTo(Region.EU_WEST_1);
 		});
+	}
+
+	@Test
+	void regionProvider_profileNameAndPathConfigured_profileRegionProviderConfiguredWithCustomProfile()
+			throws IOException {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.region.profile.name:customProfile",
+				"spring.cloud.aws.region.profile.path:"
+						+ new ClassPathResource(getClass().getSimpleName() + "-profile", getClass()).getFile()
+								.getAbsolutePath())
+				.run((context) -> {
+					AwsRegionProvider awsRegionProvider = context.getBean("awsRegionProvider", AwsRegionProvider.class);
+					assertThat(awsRegionProvider).isNotNull();
+
+					@SuppressWarnings("unchecked")
+					List<AwsRegionProvider> regionProviders = (List<AwsRegionProvider>) ReflectionTestUtils
+							.getField(awsRegionProvider, "providers");
+					assertThat(regionProviders).hasSize(1).hasOnlyElementsOfType(AwsProfileRegionProvider.class);
+
+					AwsProfileRegionProvider regionProvider = (AwsProfileRegionProvider) regionProviders.get(0);
+					assertThat(regionProvider.getRegion()).isEqualTo(Region.EU_WEST_1);
+				});
 	}
 
 	@Test

--- a/v3/spring-cloud-aws-v3-autoconfigure/src/test/resources/io/awspring/cloud/v3/autoconfigure/RegionProviderAutoConfigurationTests-profile
+++ b/v3/spring-cloud-aws-v3-autoconfigure/src/test/resources/io/awspring/cloud/v3/autoconfigure/RegionProviderAutoConfigurationTests-profile
@@ -1,0 +1,11 @@
+[default]
+aws_access_key_id=defaultKey
+aws_secret_access_key=defaultKey
+aws_session_token=defaultToken
+region=us-east-1
+
+[profile customProfile]
+aws_access_key_id=testAccessKey
+aws_secret_access_key=testSecretKey
+aws_session_token=testSessionToken
+region=eu-west-1


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
This PR fixes https://github.com/awspring/spring-cloud-aws/issues/70
Autoconfigure `AwsProfileRegionProvider` based on `spring.cloud.aws.region.profile.name` property configuration.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Implemented unit test to verify the registration of `AwsProfileRegionProvider` based on profile properties configuration.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
