### PR TITLE
Fixes #81 by reading the MessageGroupId out of the attibutes

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/listener/SimpleMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/listener/SimpleMessageListenerContainer.java
@@ -373,7 +373,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 		private List<MessageGroup> groupByMessageGroupId(final ReceiveMessageResult receiveMessageResult) {
 			return receiveMessageResult.getMessages().stream()
-					.collect(Collectors.groupingBy(message -> message.getMessageAttributes()
+					.collect(Collectors.groupingBy(message -> message.getAttributes()
 							.get(MessageSystemAttributeName.MessageGroupId.name())))
 					.values().stream().map(MessageGroup::new).collect(Collectors.toList());
 		}

--- a/spring-cloud-aws-messaging/src/test/java/io/awspring/cloud/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/io/awspring/cloud/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -138,10 +138,7 @@ class SimpleMessageListenerContainerTest {
 	}
 
 	private static Message fifoMessage(final String messageGroupId, final String content) {
-		Map<String, MessageAttributeValue> headers = new HashMap<>();
-		headers.put(MessageSystemAttributeName.MessageGroupId.name(), new MessageAttributeValue()
-				.withDataType(MessageAttributeDataTypes.STRING).withStringValue(messageGroupId));
-		return new Message().withMessageAttributes(headers).withBody(content);
+		return new Message().addAttributesEntry(MessageSystemAttributeName.MessageGroupId.name(), messageGroupId).withBody(content);
 	}
 
 	@BeforeEach
@@ -276,7 +273,7 @@ class SimpleMessageListenerContainerTest {
 		container.setAmazonSqs(sqs);
 
 		CountDownLatch countDownLatch = new CountDownLatch(10);
-		List<String> actualHandledMessages = new ArrayList<>();
+		List<String> actualHandledMessages = Collections.synchronizedList(new ArrayList<>());
 		QueueMessageHandler messageHandler = new QueueMessageHandler() {
 
 			@Override


### PR DESCRIPTION
It is now reading the MessageGroupId out of the attribute. Had to fix the test as well because it was using a ArrayList in a multithreaded environment. Because of that the tests were sometimes failing.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Will read the MessageGroupId out of the attributes because it is not part of the MessageAttributes


## :bulb: Motivation and Context
NullpointerException as described in https://github.com/awspring/spring-cloud-aws/issues/81


## :green_heart: How did you test it?
Modified the existing test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ x] I reviewed submitted code
- [x ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
