### PR TITLE
Add warning in case that the SimpleMessageListenerContainer is used with fifo queue and the AmazonSQSBufferedAsyncClient.

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/listener/AbstractMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/listener/AbstractMessageListenerContainer.java
@@ -279,7 +279,7 @@ abstract class AbstractMessageListenerContainer
 		if (getRegisteredQueues().values().stream().anyMatch(queueAttributes -> queueAttributes.isFifo())
 				&& getAmazonSqs() instanceof AmazonSQSBufferedAsyncClient) {
 			getLogger().warn(
-					"`AmazonSQSBufferedAsyncClient` that Spring Cloud AWS uses by default to communicate with SQS is not compatible with FIFO queues.");
+					"AmazonSQSBufferedAsyncClient that Spring Cloud AWS uses by default to communicate with SQS is not compatible with FIFO queues. Consider registering non-buffered AmazonSQSAsyncClient bean.");
 		}
 	}
 

--- a/spring-cloud-aws-messaging/src/test/java/io/awspring/cloud/messaging/listener/MessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/io/awspring/cloud/messaging/listener/MessageListenerContainerTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient;
 import com.amazonaws.services.sqs.model.GetQueueAttributesRequest;
 import com.amazonaws.services.sqs.model.GetQueueAttributesResult;
 import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
@@ -62,6 +63,34 @@ class MessageListenerContainerTest {
 
 		container.afterPropertiesSet();
 		assertThat(container.isActive()).isTrue();
+	}
+
+	@Test
+	void testAfterPropertiesSetIsLoggingWarnMessageIfFifoUsedWithAmazonSQSBufferedAsyncClient() throws Exception {
+		AbstractMessageListenerContainer container = new StubAbstractMessageListenerContainer();
+		Logger loggerMock = container.getLogger();
+		AmazonSQSAsync sqsMock = mock(AmazonSQSBufferedAsyncClient.class, withSettings().stubOnly());
+
+		QueueMessageHandler messageHandler = new QueueMessageHandler();
+		container.setAmazonSqs(sqsMock);
+		container.setMessageHandler(mock(QueueMessageHandler.class));
+		container.setMessageHandler(messageHandler);
+		StaticApplicationContext applicationContext = new StaticApplicationContext();
+		applicationContext.registerSingleton("messageListener", FifoMessageListener.class);
+
+		messageHandler.setApplicationContext(applicationContext);
+
+		when(sqsMock.getQueueUrl(new GetQueueUrlRequest().withQueueName("testQueue.fifo")))
+				.thenReturn(new GetQueueUrlResult().withQueueUrl("http://testQueue.amazonaws.com"));
+		when(sqsMock.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+				.thenReturn(new GetQueueAttributesResult());
+
+		messageHandler.afterPropertiesSet();
+		container.afterPropertiesSet();
+
+		assertThat(container.isActive()).isTrue();
+		verify(loggerMock).warn(
+				"`AmazonSQSBufferedAsyncClient` that Spring Cloud AWS uses by default to communicate with SQS is not compatible with FIFO queues.");
 	}
 
 	@Test
@@ -460,6 +489,16 @@ class MessageListenerContainerTest {
 
 		@SuppressWarnings({ "UnusedDeclaration", "EmptyMethod" })
 		@SqsListener("testQueue")
+		void listenerMethod(String ignore) {
+
+		}
+
+	}
+
+	private static class FifoMessageListener {
+
+		@SuppressWarnings({ "UnusedDeclaration", "EmptyMethod" })
+		@SqsListener("testQueue.fifo")
 		void listenerMethod(String ignore) {
 
 		}

--- a/spring-cloud-aws-messaging/src/test/java/io/awspring/cloud/messaging/listener/MessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/io/awspring/cloud/messaging/listener/MessageListenerContainerTest.java
@@ -90,7 +90,7 @@ class MessageListenerContainerTest {
 
 		assertThat(container.isActive()).isTrue();
 		verify(loggerMock).warn(
-				"`AmazonSQSBufferedAsyncClient` that Spring Cloud AWS uses by default to communicate with SQS is not compatible with FIFO queues.");
+				"AmazonSQSBufferedAsyncClient that Spring Cloud AWS uses by default to communicate with SQS is not compatible with FIFO queues. Consider registering non-buffered AmazonSQSAsyncClient bean.");
 	}
 
 	@Test


### PR DESCRIPTION

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
This PR ads logs a warning if the SimpleMessageListenerContainer is used with a fifo queue and the AmazonSQSBufferedAsyncClient. The AmazonSQSBufferedAsyncClient is not supporting FIFO queues!



## :bulb: Motivation and Context
See https://github.com/awspring/spring-cloud-aws/issues/81


## :green_heart: How did you test it?
Added a test case

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
