### PR TITLE
Fix Javadocs generation and upload

### DIFF
--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -8,7 +8,7 @@ on:
       - 2.2.x
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v2
@@ -23,11 +23,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Build docs
-        run: ./mvnw clean package -Pdocs,spring -DskipTests=true
+        run: ./mvnw clean package javadoc:aggregate -Pdocs,spring -DskipTests=true
       - name: Upload to S3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_KEY }}
         run: |
           aws s3 sync --acl public-read docs/target/generated-docs/ s3://awspring-docs/spring-cloud-aws/docs/
+          aws s3 sync --acl public-read target/site/ s3://awspring-docs/spring-cloud-aws/docs/
           aws cloudfront create-invalidation --distribution-id EA7LER7CI960A --paths "/*"

--- a/pom.xml
+++ b/pom.xml
@@ -176,26 +176,27 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.2.0</version>
+				<configuration>
+					<links>
+						<link>https://docs.oracle.com/javase/8/docs/api/</link>
+						<link>https://docs.oracle.com/javaee/8/api/</link>
+						<link>https://fasterxml.github.io/jackson-core/javadoc/2.8/</link>
+						<link>https://docs.spring.io/spring/docs/5.3.x/javadoc-api/</link>
+					</links>
+					<author>true</author>
+					<header>${project.name}</header>
+					<reportOutputDirectory>${project.build.directory}/site/${project.version}/apidocs</reportOutputDirectory>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<reporting>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<configuration>
-					<links>
-						<link>https://docs.oracle.com/javase/7/docs/api/</link>
-						<link>https://docs.oracle.com/javaee/7/api/</link>
-						<link>https://fasterxml.github.com/jackson-core/javadoc/2.0.0/
-						</link>
-						<link>https://docs.spring.io/spring/docs/4.1.x/javadoc-api/</link>
-					</links>
-					<author>true</author>
-					<header>${project.name}</header>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
Fixes generating and uploading Javadocs to S3.

Ubuntu version change is related to https://github.com/aws/aws-cli/issues/5262#issuecomment-773650127