### PR TITLE
Improve ref manual documentation for Secrets Manager Config and Param Store Config modules -

### DIFF
--- a/docs/src/main/asciidoc/parameter-store.adoc
+++ b/docs/src/main/asciidoc/parameter-store.adoc
@@ -1,8 +1,8 @@
 === Integrating your Spring Cloud application with the AWS Parameter Store
 
 Spring Cloud provides support for centralized configuration, which can be read and made available as a regular Spring
-`PropertySource` when the application is started. The Parameter Store Configuration allows you to use this mechanism
-with the https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html[AWS Parameter Store].
+`PropertySource` when the application is started. The Parameter Store Configuration module allows you to use this mechanism
+with https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html[AWS Parameter Store].
 
 Simply add a dependency on the `spring-cloud-starter-aws-parameter-store-config` starter module to activate the support.
 The support is similar to the support provided for the Spring Cloud Config Server or Consul's key-value store:
@@ -15,7 +15,7 @@ defaults to the configured `spring.application.name`. You can use both dots and 
 of configuration keys. Names of activated profiles will be appended to the path using a separator that defaults to an
 underscore.
 
-That means that for a service called `my-service` the module by default would find and use these parameters:
+That means that for a service called `my-service` the module by default would find and use the following parameters:
 [cols="3*", options="header"]
 |===
 |Parameter key
@@ -40,8 +40,9 @@ Can be overridden with a service-specific property.
 |Specific to the `my-service` service when a `production` Spring profile is activated.
 |===
 
-Note that this module does not support full configuration files to be used as parameter values like e.g. Spring Cloud Consul does:
-AWS parameter values are limited to 4096 characters, so we support individual Spring properties to be configured only.
+Note that this module does not support full configuration files to be used as parameter values like e.g. Spring Cloud
+Consul. AWS Parameter Store's Standard Parameter values are limited to 4096 characters, so we only support individual
+Spring properties being configured.
 
 You can configure the following settings in a Spring Cloud `bootstrap.properties` or `bootstrap.yml` file
 (note that relaxed property binding is applied, so you don't have to use this exact syntax):
@@ -105,7 +106,19 @@ enable it you need an additional dependency:
 </dependency>
 ----
 
-However, starting at `spring-cloud-aws` `2.3`, allows import default aws parameterstore keys
+==== Spring Boot Configuration Import Support
+From Spring Cloud AWS 2.3.0 onwards, the Parameter Store Configuration module additionally supports using
+https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files-importing[Spring Boot's (2.4.0+) application config import feature]
+ to load Parameter Store values into a Spring application's Environment.
+
+*Note* - This is the recommended approach for importing Parameter Store values from Spring Cloud AWS 2.3.0 onwards.
+Using the module's Spring Cloud bootstrap PropertySource is now considered a legacy approach, and support for it will
+be withdrawn in Spring Cloud AWS 3.0.
+
+Importing Parameter Store values using this mechanism is enabled by using Boot's `spring.config.import` application
+config property with a prefix of `aws-parameterstore:`, and optionally specifying a list of the names of parameters to
+import. The table below provides examples of supported property values and describes their behaviour.
+
 [cols="2*", options="header"]
 |===
 |Property
@@ -118,14 +131,14 @@ However, starting at `spring-cloud-aws` `2.3`, allows import default aws paramet
 |Importing parameters by individual keys
 
 |`spring.config.import=optional:aws-parameterstore:config-key;other-config-key`
-|With `optional` application will start even if there is no parameter found for specified parameter.
+|When `optional` is used the application will start even if the specified parameter is not found.
 |===
 
 Spring Boot 2.4 changed the ways files are loaded which means profile loading has changed for spring-cloud-aws as well.
 Link to Spring Boot reference docs about file specific loading: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-files-profile-specific[Reference Docs]
 Read more on the official: https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4[Spring Blog].
 
-=== IAM Permissions
+==== IAM Permissions
 Following IAM permissions are required by Spring Cloud AWS:
 
 [cols="2"]

--- a/docs/src/main/asciidoc/secrets-manager.adoc
+++ b/docs/src/main/asciidoc/secrets-manager.adoc
@@ -1,21 +1,20 @@
 === Integrating your Spring Cloud application with the AWS Secrets Manager
 
 Spring Cloud provides support for centralized configuration, which can be read and made available as a regular Spring
-`PropertySource` when the application is started. The Secrets Manager Configuration allows you to use this mechanism
-with the https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html[AWS Secrets Manager].
+`PropertySource` when the application is started. The Secrets Manager Configuration module allows you to use this mechanism
+with https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html[AWS Secrets Manager].
 
 Simply add a dependency on the `spring-cloud-starter-aws-secrets-manager-config` starter module to activate the support.
 The support is similar to the support provided for the Spring Cloud Config Server or Consul's key-value store:
-configuration parameters can be defined to be shared across all services or for a specific service and can be
+secrets can be defined to be shared across all services or for a specific service and can be
 profile-specific.
 
-All configuration parameters are retrieved from a common path prefix, which defaults to `/secret`. From there shared
-parameters are retrieved from a path that defaults to `application` and service-specific parameters use a path that
-defaults to the configured `spring.application.name`. You can use both dots and forward slashes to specify the names
-of configuration keys. Names of activated profiles will be appended to the path using a separator that defaults to an
-underscore.
+All secrets are retrieved from a common path prefix, which defaults to `/secret`. From there shared secrets are
+retrieved from a path that defaults to `application` and service-specific secrets use a path that defaults to the
+configured `spring.application.name`. You can use both dots and forward slashes to specify the names of secret keys.
+Names of activated profiles will be appended to the path using a separator that defaults to an underscore.
 
-That means that for a service called `my-service` the module by default would find and use these parameters:
+That means that for a service called `my-service` the module by default would find and use the following secrets:
 [cols="2*", options="header"]
 |===
 |Parameter key
@@ -86,28 +85,39 @@ enable it you need an additional dependency:
 </dependency>
 ----
 
-However, starting at `spring-cloud-aws` `2.3`, allows import default aws secretsmanager keys
+==== Spring Boot Configuration Import Support
+From Spring Cloud AWS 2.3.0 onwards, the Secrets Manager Configuration module additionally supports using
+https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files-importing[Spring Boot's (2.4.0+) application config import feature]
+to load secrets from AWS Secrets Manager into a Spring application's Environment.
+
+*Note* - This is the recommended approach for importing secrets from Spring Cloud AWS 2.3.0 onwards. Using the module's
+Spring Cloud bootstrap PropertySource is now considered a legacy approach, and support for it will be withdrawn in
+Spring Cloud AWS 3.0.
+
+Importing secrets using this mechanism is enabled by using Boot's `spring.config.import` application
+config property with a prefix of `aws-secretsmanager:`, and optionally specifying a list of the names of secrets to
+import. The table below provides examples of supported property values and describes their behaviour.
+
 [cols="2*", options="header"]
 |===
 |Property
 |Description
 
 |`spring.config.import=aws-secretsmanager:`
-|Importing parameters based on spring.application.name property value for each active profile
+|Importing secrets based on spring.application.name property value for each active profile
 
 |`spring.config.import=aws-secretsmanager:secret-key;other-secret-key`
 |Importing secrets by individual keys
 
 |`spring.config.import=optional:aws-secretsmanager:secret-key;other-secret-key`
-|With `optional` application will start even if there is no secret found for specified secret.
+|When `optional` is used the application will start even if the specified secret is not found.
 |===
 
 Spring Boot 2.4 changed the ways files are loaded which means profile loading has changed for spring-cloud-aws as well.
 Link to Spring Boot reference docs about file specific loading: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-files-profile-specific[Reference Docs]
 Read more on the official https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4[Spring Blog]
 
-
-=== IAM Permissions
+==== IAM Permissions
 Following IAM permissions are required by Spring Cloud AWS:
 
 [cols="2"]

--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -125,10 +125,10 @@ logging.level.com.amazonaws.internal.InstanceMetadataServiceResourceFetcher=erro
 ====
 
 ==== SDK credentials configuration
-In order to make calls to Amazon web services, credentials must be configured for the Amazon SDK. Spring Cloud AWS
+In order to make calls to Amazon Web Services, credentials must be configured for the Amazon SDK. Spring Cloud AWS
 provides support for configuring an application context specific set of credentials that are used for _each_ service
-call for requests done by Spring Cloud AWS components, with the exception of the Parameter Store and Secrets Manager Configuration.
-Therefore there must be *exactly one* configuration of the credentials for an entire application context.
+call for requests done by Spring Cloud AWS components, except for the Parameter Store and Secrets Manager Configuration
+modules. Therefore, there must be *exactly one* configuration of the credentials for an entire application context.
 
 [TIP]
 ====

--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -37,7 +37,7 @@ as a Bootstrap Property Source, comparable to the support provided for the Sprin
 
 
 == Basic setup
-Before using the Spring Cloud AWS module developers have to pick the dependencies and configure the Spring Cloud AWS module.
+Before using a Spring Cloud AWS module developers have to pick the dependencies and configure the module.
 The next chapters describe the dependency management and also the basic configuration for the Spring AWS Cloud project.
 
 === Spring Cloud AWS maven dependency management
@@ -61,8 +61,9 @@ instead of `spring-cloud-aws-context`)
 
 === Amazon SDK dependency version management
 
-Amazon SDK is released more frequently than Spring Cloud AWS. If you need to use newer version of AWS SDK than one configured by Spring Cloud AWS
-add AWS SDK BOM to dependency management section making sure it is declared before any other BOM dependency that configures AWS SDK dependencies.
+The Amazon SDK is released more frequently than Spring Cloud AWS. If you need to use a  newer version of the SDK than
+the one configured by Spring Cloud AWS, add the SDK BOM to the dependency management section making sure it is declared
+before any other BOM dependency that configures AWS SDK dependencies.
 
 [source,xml,indent=0]
 ----
@@ -102,17 +103,20 @@ use of the modules. A typical XML configuration to use Spring Cloud AWS is outli
 
 [TIP]
 ====
-On application startup, for its internal purposes Spring Cloud AWS performs a check if application runs in AWS cloud environment
-by using `EC2MetadataUtils` class provided by AWS SDK. Starting from version 1.11.678, AWS SDK logs a warning message with exception when this check is made outside of AWS environment.
-This warning message can be hidden by setting `ERROR` logging level on `com.amazonaws.util.EC2MetadataUtils` class.
+On application startup, Spring Cloud AWS performs a check to determine whether the application is running in an AWS
+cloud environment by using the `EC2MetadataUtils` class provided by AWS SDK. Starting from version 1.11.678, the SDK
+logs a warning message detailing an exception when this check is performed outside of an AWS environment. This warning
+message can be suppressed by setting the logging level for the `com.amazonaws.util.EC2MetadataUtils` class to `ERROR` -
 
 [source,indent=0]
 ----
 logging.level.com.amazonaws.util.EC2MetadataUtils=error
 ----
 
-If `ContextInstanceDataAutoConfiguration` is enabled, but application is not running in EC2 environment, AWS SDK logs a warning message with an exception which adds potentially unnecessary noise to application logs.
-This warning message can be hidden by setting `ERROR` logging level on `com.amazonaws.internal.InstanceMetadataServiceResourceFetcher` class.
+If `ContextInstanceDataAutoConfiguration` is enabled, but the application is not running in EC2 environment, the AWS SDK
+logs a warning message with an exception which adds potentially unnecessary noise to application logs. This warning
+message can be suppressed by setting the logging level for the
+`com.amazonaws.internal.InstanceMetadataServiceResourceFetcher` class to `ERROR` -
 
 [source,indent=0]
 ----
@@ -121,9 +125,9 @@ logging.level.com.amazonaws.internal.InstanceMetadataServiceResourceFetcher=erro
 ====
 
 ==== SDK credentials configuration
-In order to make calls to the Amazon Web Service the credentials must be configured for the the Amazon SDK. Spring Cloud AWS
-provides support to configure an application context specific credentials that are used for _each_ service call for requests done
-by Spring Cloud AWS components, with the exception of the Parameter Store and Secrets Manager Configuration.
+In order to make calls to Amazon web services, credentials must be configured for the Amazon SDK. Spring Cloud AWS
+provides support for configuring an application context specific set of credentials that are used for _each_ service
+call for requests done by Spring Cloud AWS components, with the exception of the Parameter Store and Secrets Manager Configuration.
 Therefore there must be *exactly one* configuration of the credentials for an entire application context.
 
 [TIP]
@@ -131,11 +135,11 @@ Therefore there must be *exactly one* configuration of the credentials for an en
 The `com.amazonaws.auth.DefaultAWSCredentialsProviderChain` is used by all the clients if there is no dedicated credentials
  provider defined. This will essentially use the following authentication information
 
-* use the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-* use the system properties `aws.accessKeyId` and `aws.secretKey`
-* use the user specific profile credentials file
-* use ECS credentials if the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set
-* use the instance profile credentials (see below)
+* the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+* the system properties `aws.accessKeyId` and `aws.secretKey`
+* the user specific profile credentials file
+* the ECS credentials if the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set
+* the instance profile credentials (see below)
 ====
 
 Based on the overall credentials policy there are different options to configure the credentials. The possible ones are described in
@@ -198,13 +202,13 @@ errors if the properties are not configured at all.
 ====
 
 ===== Parameter Store and Secrets Manager Configuration credentials and region configuration
-The Parameter Store and Secrets Manager Configuration support uses a bootstrap context to configure a default `AWSSimpleSystemsManagement`
-client, which uses a `com.amazonaws.auth.DefaultAWSCredentialsProviderChain` and `com.amazonaws.regions.DefaultAwsRegionProviderChain`.
-If you want to override this, then you need to
-https://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration[define your own Spring Cloud bootstrap configuration class]
-with a bean of type `AWSSimpleSystemsManagement` that's configured to use your chosen credentials and/or region provider.
-Because this context is created when your Spring Cloud Bootstrap context is created, you can't simply override the bean
-in a regular `@Configuration` class.
+The Parameter Store and Secrets Manager Configuration support uses a bootstrap context to configure a default Amazon
+SDK client for each of AWS services, which uses a `com.amazonaws.auth.DefaultAWSCredentialsProviderChain` and
+`com.amazonaws.regions.DefaultAwsRegionProviderChain`. If you want to override this, then you need to
+https://docs.spring.io/spring-cloud-commons/docs/3.0.0/reference/html/#customizing-the-bootstrap-configuration[define your own Spring Cloud bootstrap configuration class]
+with a bean of the appropriate type of Amazon SDK client (`AWSSimpleSystemsManagement` or `AWSSecretsManager`),
+that's configured to use your chosen credentials and/or region provider. Because this context is created when your
+Spring Cloud Bootstrap context is created, you can't simply override the bean in a regular `@Configuration` class.
 
 ==== Region configuration
 Amazon Web services are available in different https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html[regions]. Based
@@ -454,11 +458,11 @@ class CustomSqsConfiguration {
 
 == Cloud environment
 Applications often need environment specific configuration information, especially in changing environments like in the
-Amazon cloud environment. Spring Cloud AWS provides a support to retrieve and use environment specific data inside the
+Amazon cloud environment. Spring Cloud AWS provides support for retrieving and using environment specific data inside the
 application context using common Spring mechanisms like property placeholder or the Spring expression language.
 
 === Retrieving instance metadata
-https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[Instance metadata] are available inside an
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[Instance metadata] is available inside an
 EC2 environment. The metadata can be queried using a special HTTP address that provides the instance metadata. Spring Cloud
 AWS enables application to access this metadata directly in expression or property placeholder without the need to call
 an external HTTP service.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description
<!--- Describe your changes in detail -->

Having recently read and used the sections of the reference manual for the Secrets Manager Config and Param Store Config modules I have made a few minor improvements to them. In summary - 

1) Various minor updates in section 2 (‘Basic Setup’) and section 3 (‘Cloud Environment’) to improve readability, correct typos and broken link.

2) Updated the relevant subsections of section ‘3. Cloud Environment’ for each of the Config modules to include an additional explanation of Spring Boot Config Import support, including that this approach is now preferred over the use of Spring Cloud bootstrap PropertySource.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Improve project docs.

## :green_heart: How did you test it?

Proof read rendered version of updated AsciiDoc in IDE - confirmed no typos; checked new and fixed links are valid.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
