### PR TITLE
Provide ClientHttpRequestInterceptor to make aws-sig-4 signed request with the RestTemplate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
 		<module>spring-cloud-aws-parameter-store-config</module>
 		<module>spring-cloud-aws-secrets-manager-config</module>
 		<module>spring-cloud-aws-ses</module>
+		<module>spring-cloud-aws-web</module>
 		<module>spring-cloud-starter-aws</module>
 		<module>spring-cloud-starter-aws-jdbc</module>
 		<module>spring-cloud-starter-aws-messaging</module>

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -112,6 +112,11 @@
 			</dependency>
 			<dependency>
 				<groupId>io.awspring.cloud</groupId>
+				<artifactId>spring-cloud-starter-aws-web</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.awspring.cloud</groupId>
 				<artifactId>spring-cloud-aws-context</artifactId>
 				<version>${project.version}</version>
 			</dependency>

--- a/spring-cloud-aws-web/pom.xml
+++ b/spring-cloud-aws-web/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-aws</artifactId>
+		<version>3.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>spring-cloud-aws-web</artifactId>
+	<name>Spring Cloud AWS Web</name>
+	<description>Spring Cloud AWS Web</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-cloud-aws-web/src/main/java/org/springframework/cloud/aws/web/RequestSigner.java
+++ b/spring-cloud-aws-web/src/main/java/org/springframework/cloud/aws/web/RequestSigner.java
@@ -1,0 +1,29 @@
+package org.springframework.cloud.aws.web;
+
+import com.amazonaws.auth.AWS4Signer;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import org.springframework.http.HttpRequest;
+
+public class RequestSigner {
+	private final String regionName;
+	private final String serviceName;
+	private final AWSCredentialsProvider awsCredentialsProvider;
+
+	public RequestSigner(AWSCredentialsProvider awsCredentialsProvider, String regionName, String serviceName) {
+		this.regionName = regionName;
+		this.serviceName = serviceName;
+		this.awsCredentialsProvider = awsCredentialsProvider;
+	}
+
+	public void signRequest(HttpRequest request, byte[] body) {
+		AWS4Signer signer = this.createAws4Signer();
+		signer.sign(new SpringSignableRequest(request, body), this.awsCredentialsProvider.getCredentials());
+	}
+
+	protected AWS4Signer createAws4Signer() {
+		AWS4Signer signer = new AWS4Signer(false);
+		signer.setRegionName(this.regionName);
+		signer.setServiceName(this.serviceName);
+		return signer;
+	}
+}

--- a/spring-cloud-aws-web/src/main/java/org/springframework/cloud/aws/web/SigningClientHttpRequestInterceptor.java
+++ b/spring-cloud-aws-web/src/main/java/org/springframework/cloud/aws/web/SigningClientHttpRequestInterceptor.java
@@ -1,0 +1,23 @@
+package org.springframework.cloud.aws.web;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.IOException;
+
+public class SigningClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
+	private final RequestSigner signer;
+
+	public SigningClientHttpRequestInterceptor(AWSCredentialsProvider awsCredentialsProvider, String regionName, String serviceName) {
+		this.signer = new RequestSigner(awsCredentialsProvider, regionName, serviceName);
+	}
+
+	@Override
+	public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+		signer.signRequest(request, body);
+		return execution.execute(request, body);
+	}
+}

--- a/spring-cloud-aws-web/src/main/java/org/springframework/cloud/aws/web/SpringSignableRequest.java
+++ b/spring-cloud-aws-web/src/main/java/org/springframework/cloud/aws/web/SpringSignableRequest.java
@@ -1,0 +1,96 @@
+package org.springframework.cloud.aws.web;
+
+import com.amazonaws.ReadLimitInfo;
+import com.amazonaws.SignableRequest;
+import com.amazonaws.http.HttpMethodName;
+import org.springframework.http.HttpRequest;
+import org.springframework.util.Assert;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+class SpringSignableRequest implements SignableRequest<HttpRequest> {
+	private final Map<String, List<String>> parameters;
+	private final URI endpoint;
+	private final HttpRequest request;
+	private final InputStream content;
+
+	public SpringSignableRequest(HttpRequest request, byte[] body) {
+		Assert.notNull(request, "request must not be null");
+		this.request = request;
+		this.content = new ByteArrayInputStream(body != null ? body : new byte[0]);
+		UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpRequest(this.request);
+		this.parameters = uriBuilder.build().getQueryParams();
+		this.endpoint = uriBuilder.replacePath(null).replaceQuery(null).build().toUri();
+	}
+
+	@Override
+	public void addHeader(String name, String value) {
+		this.request.getHeaders().add(name, value);
+	}
+
+	@Override
+	public void addParameter(String name, String value) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setContent(InputStream inputStream) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Map<String, String> getHeaders() {
+		return request.getHeaders().toSingleValueMap();
+	}
+
+	@Override
+	public String getResourcePath() {
+		return request.getURI().getRawPath();
+	}
+
+	@Override
+	public Map<String, List<String>> getParameters() {
+		return this.parameters;
+	}
+
+	@Override
+	public URI getEndpoint() {
+		return this.endpoint;
+	}
+
+	@Override
+	public HttpMethodName getHttpMethod() {
+		return HttpMethodName.fromValue(Objects.toString(request.getMethod(), null));
+	}
+
+	@Override
+	public int getTimeOffset() {
+		return 0;
+	}
+
+	@Override
+	public InputStream getContent() {
+		return this.content;
+	}
+
+	@Override
+	public InputStream getContentUnwrapped() {
+		return this.content;
+	}
+
+	@Override
+	public ReadLimitInfo getReadLimitInfo() {
+		return null;
+	}
+
+	@Override
+	public HttpRequest getOriginalRequestObject() {
+		return request;
+	}
+}

--- a/spring-cloud-aws-web/src/test/java/org/springframework/cloud/aws/web/RequestSignerTest.java
+++ b/spring-cloud-aws-web/src/test/java/org/springframework/cloud/aws/web/RequestSignerTest.java
@@ -1,0 +1,67 @@
+package org.springframework.cloud.aws.web;
+
+import com.amazonaws.auth.AWS4Signer;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+
+import java.net.URI;
+import java.sql.Date;
+import java.time.Instant;
+
+/**
+ * the test values are taken from the aws-sig-v4-test-suite
+ */
+class RequestSignerTest {
+	private final AWSCredentialsProvider credentials = new AWSStaticCredentialsProvider(
+		new BasicAWSCredentials("AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"));
+
+	@Test
+	void sign_request_without_body() {
+		RequestSigner signer = new RequestSigner(this.credentials, "us-east-1", "service") {
+			@Override
+			protected AWS4Signer createAws4Signer() {
+				AWS4Signer aws4Signer = super.createAws4Signer();
+				aws4Signer.setOverrideDate(Date.from(Instant.parse("2015-08-30T12:36:00Z")));
+				return aws4Signer;
+			}
+		};
+
+		HttpRequest request = new MockClientHttpRequest(HttpMethod.GET, URI.create("http://example.amazonaws.com/?Param2=value2&Param1=value1"));
+		signer.signRequest(request, null);
+
+		assertThat(request.getHeaders()).containsEntry("x-amz-date", singletonList("20150830T123600Z"))
+			.containsEntry("Host", singletonList("example.amazonaws.com"))
+			.containsEntry("Authorization", singletonList(
+				"AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=b97d918cfa904a5beff61c982a1b6f458b799221646efd99d3219ec94cdf2500")
+			);
+	}
+
+	@Test
+	void sign_request_with_body() {
+		RequestSigner signer = new RequestSigner(this.credentials, "us-east-1", "service") {
+			@Override
+			protected AWS4Signer createAws4Signer() {
+				AWS4Signer aws4Signer = super.createAws4Signer();
+				aws4Signer.setOverrideDate(Date.from(Instant.parse("2015-08-30T12:36:00Z")));
+				return aws4Signer;
+			}
+		};
+
+		HttpRequest request = new MockClientHttpRequest(HttpMethod.POST, URI.create("http://example.amazonaws.com/"));
+		request.getHeaders().add("Content-Type", "application/x-www-form-urlencoded");
+		signer.signRequest(request, "Param1=value1".getBytes());
+
+		assertThat(request.getHeaders()).containsEntry("x-amz-date", singletonList("20150830T123600Z"))
+			.containsEntry("Host", singletonList("example.amazonaws.com"))
+			.containsEntry("Authorization", singletonList(
+				"AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=ff11897932ad3f4e8b18135d722051e5ac45fc38421b1da7b9d196a0fe09473a")
+			);
+	}
+}

--- a/spring-cloud-aws-web/src/test/resources/logback.xml
+++ b/spring-cloud-aws-web/src/test/resources/logback.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<logger name="com.amazonaws.util.EC2MetadataUtils" level="ERROR"/>
+	<logger name="com.amazonaws.internal.InstanceMetadataServiceResourceFetcher" level="ERROR"/>
+
+	<root level="error">
+		<appender-ref ref="STDOUT"/>
+	</root>
+</configuration>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Provide a ClientHttpRequestInterceptor which signs requests using the AWS Signature V4 which is needed for example to call various AWS services (like API Gateway)

## :bulb: Motivation and Context
Currently imho it is tedious and lacking a good documentation on how to make signed request using the RestTemplate to the API Gateway. 
Alternative to the RestTemplate you can use generated SDKs or subclassing the `AmazonWebServiceClient`.

Imho being able to make signed requests using the RestTemplate has the benefit for the spring developers to work with a familiar API.

## :green_heart: How did you test it?
There are two test verifying the signatures of requests from the aws-sig-v4-test-suite.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
As this is more or less just a preview of the feature and also lacking support for the WebClient, I am happy to discuss if this is a desirable feature and if yes what further steps are needed to see this feature integrated.


