### PR TITLE
[docs] fix spring-cloud-aws-autoconfigure version

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -274,7 +274,7 @@ maven dependency inside the application. The typical configuration will look lik
   <dependency>
     <groupId>io.awspring.cloud</groupId>
     <artifactId>spring-cloud-aws-autoconfigure</artifactId>
-    <version>{spring-cloud-version}</version>
+    <version>{spring-cloud-aws-version}</version>
   </dependency>
 </dependencies>
 ----


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
In the documentation, the dependency `spring-cloud-aws-autoconfigure` has an incorrect version:
```xml
<version>{spring-cloud-version}</version>
```

Should be the same as the `awspring` project, not Spring Cloud:
```xml
<version>{spring-cloud-aws-version}</version>
```

## :bulb: Motivation and Context
Apologies for the pedanticism, but easily took away half an hour from me. Should help future newcomers.

## :green_heart: How did you test it?
After the change, my application was able to get the credentials from `application.yml` (loaded via `spring-cloud-kubernetes`).

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] I updated reference documentation to reflect the change
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
