### PR TITLE
Add SNS FIFO Topic support

### DIFF
--- a/docs/src/main/asciidoc/sns.adoc
+++ b/docs/src/main/asciidoc/sns.adoc
@@ -58,6 +58,44 @@ configure the SNS client to setup the default converter.
 <aws-messaging:notification-messaging-template id="notificationMessagingTemplate" />
 ----
 
+FIFO SNS Topics have additional required and optional request parameters. For example MessageGroupId is a required
+parameter for a FIFO topic. These parameters can be set by specifying them in the headers map.
+Spring Cloud AWS extracts the keys and sets the parameters on the underlying SNS SendMessage request.
+
+To specify message attributes on the SNS SendMessage request, additional headers can be added to the header map.
+
+This example shows how to add the MessageGroupId parameter (required for FIFO topics) and MessageDeduplicationId parameter
+(optional) to the request. The additional header is added as a MessageAttribute. The attribute Type is based on the java
+type of the value by Spring Cloud AWS.
+
+[source,java,indent=0]
+----
+import com.amazonaws.services.sns.AmazonSNS;
+import io.awspring.cloud.messaging.core.NotificationMessagingTemplate;
+import io.awspring.cloud.messaging.core.TopicMessageChannel;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.HashMap;
+
+public class SnsNotificationSender {
+
+	private final NotificationMessagingTemplate notificationMessagingTemplate;
+
+	@Autowired
+	public SnsNotificationSender(AmazonSNS amazonSns) {
+		this.notificationMessagingTemplate = new NotificationMessagingTemplate(amazonSns);
+	}
+
+	public void send(String message, String messageGroupId, String messageDeduplicationId) {
+		HashMap<String, Object> headers = new HashMap<>();
+		headers.put(TopicMessageChannel.MESSAGE_GROUP_ID_HEADER, messageGroupId);
+		headers.put(TopicMessageChannel.MESSAGE_DEDUPLICATION_ID_HEADER, messageDeduplicationId);
+		headers.put("attributeName", "attributeValue");
+		this.notificationMessagingTemplate.convertAndSend("physicalTopicName", message, headers);
+	}
+}
+----
+
 ==== Annotation-driven HTTP notification endpoint
 SNS supports multiple endpoint types (SQS, Email, HTTP, HTTPS), Spring Cloud AWS provides support for HTTP(S) endpoints.
 SNS sends three type of requests to an HTTP topic listener endpoint, for each of them annotations are provided:

--- a/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/core/TopicMessageChannel.java
+++ b/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/core/TopicMessageChannel.java
@@ -48,7 +48,7 @@ public class TopicMessageChannel extends AbstractMessageChannel {
 	public static final String NOTIFICATION_SUBJECT_HEADER = "NOTIFICATION_SUBJECT_HEADER";
 
 	/**
-	 * Message group id for SNS message (applies only to FIFO queue).
+	 * Message group id for SNS message (applies only to FIFO topic).
 	 */
 	public static final String MESSAGE_GROUP_ID_HEADER = "MessageGroupId";
 

--- a/spring-cloud-aws-messaging/src/test/java/io/awspring/cloud/messaging/core/TopicMessageChannelTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/io/awspring/cloud/messaging/core/TopicMessageChannelTest.java
@@ -244,4 +244,46 @@ class TopicMessageChannelTest {
 				.isEqualTo(MessageAttributeDataTypes.STRING_ARRAY);
 	}
 
+	@Test
+	public void sendMessage_withMessageGroupIdHeader_shouldSetMessageGroupIdOnPublishRequestAndNotSetItAsMessageAttribute() {
+		// Arrange
+		AmazonSNS amazonSns = mock(AmazonSNS.class);
+		ArgumentCaptor<PublishRequest> publishRequestArgumentCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+		when(amazonSns.publish(publishRequestArgumentCaptor.capture())).thenReturn(new PublishResult());
+
+		Message<String> message = MessageBuilder.withPayload("Hello")
+				.setHeader(TopicMessageChannel.MESSAGE_GROUP_ID_HEADER, "id-5").build();
+		MessageChannel messageChannel = new TopicMessageChannel(amazonSns, "topicArn");
+
+		// Act
+		boolean sent = messageChannel.send(message);
+
+		// Assert
+		assertThat(sent).isTrue();
+		assertThat(publishRequestArgumentCaptor.getValue().getMessageAttributes()
+				.containsKey(TopicMessageChannel.MESSAGE_GROUP_ID_HEADER)).isFalse();
+		assertThat(publishRequestArgumentCaptor.getValue().getMessageGroupId()).isEqualTo("id-5");
+	}
+
+	@Test
+	public void sendMessage_withMessageDeduplicationIdHeader_shouldSetMessageDeduplicationIdOnPublishRequestAndNotSetItAsMessageAttribute() {
+		// Arrange
+		AmazonSNS amazonSns = mock(AmazonSNS.class);
+		ArgumentCaptor<PublishRequest> publishRequestArgumentCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+		when(amazonSns.publish(publishRequestArgumentCaptor.capture())).thenReturn(new PublishResult());
+
+		Message<String> message = MessageBuilder.withPayload("Hello")
+				.setHeader(TopicMessageChannel.MESSAGE_DEDUPLICATION_ID_HEADER, "id-5").build();
+		MessageChannel messageChannel = new TopicMessageChannel(amazonSns, "topicArn");
+
+		// Act
+		boolean sent = messageChannel.send(message);
+
+		// Assert
+		assertThat(sent).isTrue();
+		assertThat(publishRequestArgumentCaptor.getValue().getMessageAttributes()
+				.containsKey(TopicMessageChannel.MESSAGE_DEDUPLICATION_ID_HEADER)).isFalse();
+		assertThat(publishRequestArgumentCaptor.getValue().getMessageDeduplicationId()).isEqualTo("id-5");
+	}
+
 }


### PR DESCRIPTION
Fixes https://github.com/awspring/spring-cloud-aws/issues/41

## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
This pull requests add support for FIFO SNS publishRequest. https://github.com/awspring/spring-cloud-aws/issues/41
The implementation is based on QueueMessageChannel.


## :bulb: Motivation and Context
SNS added FIFO topics which require a mandatory MessageGroupId when publishing messages. 
Without this change it is not possible to use spring-cloud-aws to publish messages to SNS FIFO topics.

## :green_heart: How did you test it?
Unit tests were added.

## :pencil: Checklist
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
