### PR TITLE
Execute all received sqs messages

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/listener/SimpleMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/listener/SimpleMessageListenerContainer.java
@@ -338,15 +338,10 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 							? groupByMessageGroupId(receiveMessageResult) : groupByMessage(receiveMessageResult);
 					CountDownLatch messageBatchLatch = new CountDownLatch(messageGroups.size());
 					for (MessageGroup messageGroup : messageGroups) {
-						if (isQueueRunning(this.logicalQueueName)) {
-							MessageGroupExecutor messageGroupExecutor = new MessageGroupExecutor(this.logicalQueueName,
-									messageGroup, this.queueAttributes);
-							getTaskExecutor()
-									.execute(new SignalExecutingRunnable(messageBatchLatch, messageGroupExecutor));
-						}
-						else {
-							messageBatchLatch.countDown();
-						}
+						MessageGroupExecutor messageGroupExecutor = new MessageGroupExecutor(this.logicalQueueName,
+								messageGroup, this.queueAttributes);
+						getTaskExecutor()
+								.execute(new SignalExecutingRunnable(messageBatchLatch, messageGroupExecutor));
 					}
 					try {
 						messageBatchLatch.await();


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
After the SimpleMessageListenerContainer has received SQS messages from a queue it does not check again, that the queue is still running and delivers all messages to their handlers even if the queue has stopped in the meantime.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If a SimpleMessageListenerContainer is stopped, e.g. because the service instance is shut down, it might happen that while stopping, the container still receives some SQS messages from a queue, but doesn't distribute those messages to their handlers.
As a result, the SQS messages are invisible for other service instances that are listening to the same queue until the visibility timeout of the messages is reached. This causes a delay of the message delivery.
With this fix, all messages that are pulled from the queue - and thus set invisible - are delivered to their handlers and can therefore be processed, even if the  SimpleMessageListenerContainer is stopped or the service is shut down.

## :green_heart: How did you test it?
Added a unit test:
- Start a SimpleMessageListenerContainer
- Send a SQS message
- Stop the SimpleMessageListenerContainer
- Verify that the message was received by its handler

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
