### PR TITLE
Fix Customizing the Bootstrap Configuration link

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -201,7 +201,7 @@ errors if the properties are not configured at all.
 The Parameter Store and Secrets Manager Configuration support uses a bootstrap context to configure a default `AWSSimpleSystemsManagement`
 client, which uses a `com.amazonaws.auth.DefaultAWSCredentialsProviderChain` and `com.amazonaws.regions.DefaultAwsRegionProviderChain`.
 If you want to override this, then you need to
-https://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration[define your own Spring Cloud bootstrap configuration class]
+https://projects.spring.io/spring-cloud/spring-cloud.html#_customizing_the_bootstrap_configuration[define your own Spring Cloud bootstrap configuration class]
 with a bean of type `AWSSimpleSystemsManagement` that's configured to use your chosen credentials and/or region provider.
 Because this context is created when your Spring Cloud Bootstrap context is created, you can't simply override the bean
 in a regular `@Configuration` class.

--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -201,7 +201,7 @@ errors if the properties are not configured at all.
 The Parameter Store and Secrets Manager Configuration support uses a bootstrap context to configure a default `AWSSimpleSystemsManagement`
 client, which uses a `com.amazonaws.auth.DefaultAWSCredentialsProviderChain` and `com.amazonaws.regions.DefaultAwsRegionProviderChain`.
 If you want to override this, then you need to
-https://projects.spring.io/spring-cloud/spring-cloud.html#_customizing_the_bootstrap_configuration[define your own Spring Cloud bootstrap configuration class]
+https://docs.spring.io/spring-cloud-commons/docs/current/reference/html/#customizing-the-bootstrap-configuration[define your own Spring Cloud bootstrap configuration class]
 with a bean of type `AWSSimpleSystemsManagement` that's configured to use your chosen credentials and/or region provider.
 Because this context is created when your Spring Cloud Bootstrap context is created, you can't simply override the bean
 in a regular `@Configuration` class.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fixes a problem is in "_Parameter Store and Secrets Manager Configuration credentials and region configuration_" paragraph of the current version of the documentation ([link](https://docs.awspring.io/spring-cloud-aws/docs/current/reference/html/index.html#parameter-store-and-secrets-manager-configuration-credentials-and-region-configuration)). The existing link in
> If you want to override this, then you need to [define your own Spring Cloud bootstrap configuration class](https://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration) with a bean of type `AWSSimpleSystemsManagement` that’s configured to use your chosen credentials and/or region provider.

forwards you to the [404 page](https://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration).


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #143


## :green_heart: How did you test it?
Clicked on the link in the updated `.adoc`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
