### PR TITLE
gh-151 parameter store fix

### DIFF
--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
@@ -75,30 +75,30 @@ public class AwsParamStoreConfigDataLocationResolver
 		return resolve(resolverContext, location, profiles);
 	}
 
-	private List<AwsParamStoreConfigDataResource> resolve(
-		ConfigDataLocationResolverContext resolverContext, ConfigDataLocation location, @Nullable Profiles profiles)
-		throws ConfigDataLocationNotFoundException {
+	private List<AwsParamStoreConfigDataResource> resolve(ConfigDataLocationResolverContext resolverContext,
+			ConfigDataLocation location, @Nullable Profiles profiles) throws ConfigDataLocationNotFoundException {
 
 		registerBean(resolverContext, AwsParamStoreProperties.class, loadProperties(resolverContext.getBinder()));
 
 		registerAndPromoteBean(resolverContext, AWSSimpleSystemsManagement.class,
-			this::createSimpleSystemManagementClient);
+				this::createSimpleSystemManagementClient);
 
 		AwsParamStoreProperties properties = loadConfigProperties(resolverContext.getBinder());
 
 		AwsParamStorePropertySources sources = new AwsParamStorePropertySources(properties, log);
 
-		if(location.getValue().equals(PREFIX) && profiles == null) {
-			throw new IllegalArgumentException("Automatic paths from profiles are not supported in profile specific application properties files. Move 'spring.config.import' to root application properties file or set custom context.");
+		if (location.getValue().equals(PREFIX) && profiles == null) {
+			throw new IllegalArgumentException(
+					"Automatic paths from profiles are not supported in profile specific application properties files. Move 'spring.config.import' to root application properties file or set custom context.");
 		}
 
 		List<String> contexts = location.getValue().equals(PREFIX)
-			? sources.getAutomaticContexts(profiles.getAccepted())
-			: getCustomContexts(location.getNonPrefixedValue(PREFIX));
+				? sources.getAutomaticContexts(profiles.getAccepted())
+				: getCustomContexts(location.getNonPrefixedValue(PREFIX));
 
 		List<AwsParamStoreConfigDataResource> locations = new ArrayList<>();
 		contexts.forEach(propertySourceContext -> locations
-			.add(new AwsParamStoreConfigDataResource(propertySourceContext, location.isOptional(), sources)));
+				.add(new AwsParamStoreConfigDataResource(propertySourceContext, location.isOptional(), sources)));
 
 		return locations;
 	}

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
@@ -37,8 +37,8 @@ import org.springframework.boot.context.config.ConfigDataLocationResolverContext
 import org.springframework.boot.context.config.Profiles;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
-import org.springframework.lang.Nullable;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
 /**

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
@@ -37,6 +37,7 @@ import org.springframework.boot.context.config.ConfigDataLocationResolverContext
 import org.springframework.boot.context.config.Profiles;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
 /**
@@ -62,31 +63,42 @@ public class AwsParamStoreConfigDataLocationResolver
 	}
 
 	@Override
-	public List<AwsParamStoreConfigDataResource> resolve(ConfigDataLocationResolverContext context,
+	public List<AwsParamStoreConfigDataResource> resolve(ConfigDataLocationResolverContext resolverContext,
 			ConfigDataLocation location) throws ConfigDataLocationNotFoundException {
-		return Collections.emptyList();
+		return resolve(resolverContext, location, null);
 	}
 
 	@Override
 	public List<AwsParamStoreConfigDataResource> resolveProfileSpecific(
 			ConfigDataLocationResolverContext resolverContext, ConfigDataLocation location, Profiles profiles)
 			throws ConfigDataLocationNotFoundException {
+		return resolve(resolverContext, location, profiles);
+	}
+
+	private List<AwsParamStoreConfigDataResource> resolve(
+		ConfigDataLocationResolverContext resolverContext, ConfigDataLocation location, @Nullable Profiles profiles)
+		throws ConfigDataLocationNotFoundException {
+
 		registerBean(resolverContext, AwsParamStoreProperties.class, loadProperties(resolverContext.getBinder()));
 
 		registerAndPromoteBean(resolverContext, AWSSimpleSystemsManagement.class,
-				this::createSimpleSystemManagementClient);
+			this::createSimpleSystemManagementClient);
 
 		AwsParamStoreProperties properties = loadConfigProperties(resolverContext.getBinder());
 
 		AwsParamStorePropertySources sources = new AwsParamStorePropertySources(properties, log);
 
+		if(location.getValue().equals(PREFIX) && profiles == null) {
+			throw new IllegalArgumentException("Automatic paths from profiles are not supported in profile specific application properties files. Move 'spring.config.import' to root application properties file or set custom context.");
+		}
+
 		List<String> contexts = location.getValue().equals(PREFIX)
-				? sources.getAutomaticContexts(profiles.getAccepted())
-				: getCustomContexts(location.getNonPrefixedValue(PREFIX));
+			? sources.getAutomaticContexts(profiles.getAccepted())
+			: getCustomContexts(location.getNonPrefixedValue(PREFIX));
 
 		List<AwsParamStoreConfigDataResource> locations = new ArrayList<>();
 		contexts.forEach(propertySourceContext -> locations
-				.add(new AwsParamStoreConfigDataResource(propertySourceContext, location.isOptional(), sources)));
+			.add(new AwsParamStoreConfigDataResource(propertySourceContext, location.isOptional(), sources)));
 
 		return locations;
 	}

--- a/spring-cloud-starter-aws-parameter-store-config/src/test/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolverTest.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/test/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolverTest.java
@@ -67,7 +67,8 @@ class AwsParamStoreConfigDataLocationResolverTest {
 		try {
 			testResolveNotProfileSpecific(location);
 			fail("Exception expected due to usage of automatic path syntax in resolve without profiles");
-		} catch (IllegalArgumentException e) {
+		}
+		catch (IllegalArgumentException e) {
 			assertThat(e.getMessage()).contains("Automatic paths from profiles are not supported");
 		}
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
With the spring boot 2.4.7 update the way the ConfigDataLocationResolver works has changed. When doing the import in application-{profile}.properties the resolve method is called instead the resolveProfileSpecific one

## :bulb: Motivation and Context
Fixes #151 


## :green_heart: How did you test it?
Via unit and used it in own project

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
