### PR TITLE
Stop processing messages from FIFO queue when exception is thrown

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/listener/SimpleMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/listener/SimpleMessageListenerContainer.java
@@ -428,6 +428,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				}
 				catch (MessagingException messagingException) {
 					applyDeletionPolicyOnError(receiptHandle);
+					break;
 				}
 			}
 		}

--- a/spring-cloud-aws-messaging/src/test/java/io/awspring/cloud/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/io/awspring/cloud/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -794,7 +794,7 @@ class SimpleMessageListenerContainerTest {
 	}
 
 	@Test
-	void receiveMessagesFromFifoQueue_stoppsProcessingMessageGroup_whenExceptionIsThrown() throws Exception {
+	void receiveMessagesFromFifoQueue_stopsProcessingMessageGroup_whenExceptionIsThrown() throws Exception {
 		// Arrange
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description
<!--- Describe your changes in detail -->
I think there is a bug in `SimpleMessageListenerContainer.MessageGroupExecutor` class. 
When multiple messages from the same message group are recieved and exception is thrown while
processing one them the others should not be processed. I think this is importand because 
the order should be maintained even in case of an error.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I think it solves this issue
https://github.com/awspring/spring-cloud-aws/issues/124

## :green_heart: How did you test it?
I integrated it with my app that is using SQS FIFO queue and checked if order is maintained in case of an exception.
Also I prepared a unit test.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] I updated reference documentation to reflect the change
- [ ] No breaking changes <- not sure about that.


## :crystal_ball: Next steps
