### PR TITLE
Add logger to log exception

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/listener/SimpleMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/listener/SimpleMessageListenerContainer.java
@@ -427,7 +427,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 					applyDeletionPolicyOnSuccess(receiptHandle);
 				}
 				catch (MessagingException messagingException) {
-					getLogger().warn("An exception occurred while handling message", messagingException);
+					getLogger().warn("An exception occurred while handling message with id: {}", message.getMessageId(),
+							messagingException);
 					applyDeletionPolicyOnError(receiptHandle);
 				}
 			}

--- a/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/listener/SimpleMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/listener/SimpleMessageListenerContainer.java
@@ -427,6 +427,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 					applyDeletionPolicyOnSuccess(receiptHandle);
 				}
 				catch (MessagingException messagingException) {
+					getLogger().warn("An exception occurred while handling message", messagingException);
 					applyDeletionPolicyOnError(receiptHandle);
 				}
 			}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ X ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
I added a logging message to show the exception that is occurring when a message cannot be processed. I had a problem while trying to create a message to SQS which has a maximum of 10 attributes. The exception was never logged and I was forced to debug the entire framework to determine what was occurring.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ X ] I reviewed submitted code
- [ X ] I added tests to verify changes
- [ X ] I updated reference documentation to reflect the change
- [ X ] All tests passing
- [ X ] No breaking changes


## :crystal_ball: Next steps
