### PR TITLE
Add Note About Missing Aurora RDS Support (#172) 

### DIFF
--- a/docs/src/main/asciidoc/rds.adoc
+++ b/docs/src/main/asciidoc/rds.adoc
@@ -9,6 +9,11 @@ Cloud AWS for JDBC data access are:
 * Automatic read-replica detection and configuration for Amazon RDS database instances.
 * Retry-support to handle exception during Multi-AZ failover inside the data center.
 
+[NOTE]
+====
+Amazon Aurora database clusters (both serverless and provisioned) are not supported by Spring Cloud AWS. Please follow https://github.com/awspring/spring-cloud-aws/issues/50[this issue] for more information.
+====
+
 === Configuring data source
 Before using and configuring the database support, the application has to include the respective module dependency
 into its Maven configuration. Spring Cloud AWS JDBC support comes as a separate module to allow the modularized use of the


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
Amazon Aurora database cluster support is not available in Spring Cloud AWS for now. Added a note at the beginning of the documentation to indicate the same.

## :bulb: Motivation and Context
Amazon Aurora is part of RDS and hence there might be confusion on whether it is actually supported or not. 
Fixes https://github.com/awspring/spring-cloud-aws/issues/172

## :green_heart: How did you test it?
Viewed the markdown preview. That's all.

## :pencil: Checklist
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
If the link to the open issue about RDS Aurora support is unnecessary in the documentation, we can remove it.