### PR TITLE
Fix context order when loading properties

### DIFF
--- a/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySources.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySources.java
@@ -25,7 +25,11 @@ import org.apache.commons.logging.Log;
 import org.springframework.util.StringUtils;
 
 /**
+ * Is responsible for creating {@link AwsParamStorePropertySource} and determining
+ * automatic contexts.
+ *
  * @author Eddú Meléndez
+ * @author Manuel Wessner
  * @since 2.3
  */
 public class AwsParamStorePropertySources {
@@ -44,18 +48,18 @@ public class AwsParamStorePropertySources {
 		String prefix = this.properties.getPrefix();
 		String defaultContext = getContext(prefix, this.properties.getDefaultContext());
 
-		String appName = this.properties.getName();
-
-		String appContext = prefix + "/" + appName;
-		addProfiles(contexts, appContext, profiles);
-		contexts.add(appContext + "/");
-
-		addProfiles(contexts, defaultContext, profiles);
 		contexts.add(defaultContext + "/");
+		addProfiles(contexts, defaultContext, profiles);
+
+		String appName = this.properties.getName();
+		String appContext = prefix + "/" + appName;
+		contexts.add(appContext + "/");
+		addProfiles(contexts, appContext, profiles);
+
 		return contexts;
 	}
 
-	protected String getContext(String prefix, String context) {
+	private String getContext(String prefix, String context) {
 		if (StringUtils.hasLength(prefix)) {
 			return prefix + "/" + context;
 		}

--- a/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourceLocatorTest.java
+++ b/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourceLocatorTest.java
@@ -100,10 +100,10 @@ class AwsParamStorePropertySourceLocatorTest {
 
 		List<String> contextToBeTested = new ArrayList<>(locator.getContexts());
 
-		assertThat(contextToBeTested.get(0)).isEqualTo("application/messaging-service_test/");
-		assertThat(contextToBeTested.get(1)).isEqualTo("application/messaging-service/");
-		assertThat(contextToBeTested.get(2)).isEqualTo("application/application_test/");
-		assertThat(contextToBeTested.get(3)).isEqualTo("application/application/");
+		assertThat(contextToBeTested.get(0)).isEqualTo("application/application/");
+		assertThat(contextToBeTested.get(1)).isEqualTo("application/application_test/");
+		assertThat(contextToBeTested.get(2)).isEqualTo("application/messaging-service/");
+		assertThat(contextToBeTested.get(3)).isEqualTo("application/messaging-service_test/");
 	}
 
 	@Test

--- a/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourcesTest.java
+++ b/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourcesTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.paramstore;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit test for {@link AwsParamStorePropertySourceLocator}.
+ *
+ * @author Manuel Wessner
+ */
+class AwsParamStorePropertySourcesTest {
+
+	private final Log logMock = mock(Log.class);
+
+	private AwsParamStoreProperties properties;
+
+	@BeforeEach
+	void setUp() {
+		properties = new AwsParamStoreProperties();
+		properties.setDefaultContext("application");
+		properties.setName("messaging-service");
+	}
+
+	@Test
+	void getAutomaticContextsWithSingleProfile() {
+		AwsParamStorePropertySources propertySource = new AwsParamStorePropertySources(properties, logMock);
+
+		List<String> contexts = propertySource.getAutomaticContexts(Collections.singletonList("production"));
+
+		assertThat(contexts.size()).isEqualTo(4);
+		assertThat(contexts).containsExactly("/config/application/", "/config/application_production/",
+				"/config/messaging-service/", "/config/messaging-service_production/");
+	}
+
+	@Test
+	void getAutomaticContextsWithoutProfile() {
+		AwsParamStorePropertySources propertySource = new AwsParamStorePropertySources(properties, logMock);
+
+		List<String> contexts = propertySource.getAutomaticContexts(Collections.emptyList());
+
+		assertThat(contexts.size()).isEqualTo(2);
+		assertThat(contexts).containsExactly("/config/application/", "/config/messaging-service/");
+	}
+
+}

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySources.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySources.java
@@ -24,6 +24,14 @@ import org.apache.commons.logging.Log;
 
 import org.springframework.util.StringUtils;
 
+/**
+ * Is responsible for creating {@link AwsSecretsManagerPropertySource} and determining
+ * automatic contexts.
+ *
+ * @author Eddú Meléndez
+ * @author Manuel Wessner
+ * @since 2.3
+ */
 public class AwsSecretsManagerPropertySources {
 
 	private final AwsSecretsManagerProperties properties;
@@ -40,18 +48,18 @@ public class AwsSecretsManagerPropertySources {
 		String prefix = this.properties.getPrefix();
 		String defaultContext = getContext(prefix, this.properties.getDefaultContext());
 
-		String appName = this.properties.getName();
-
-		String appContext = prefix + "/" + appName;
-		addProfiles(contexts, appContext, profiles);
-		contexts.add(appContext);
-
-		addProfiles(contexts, defaultContext, profiles);
 		contexts.add(defaultContext);
+		addProfiles(contexts, defaultContext, profiles);
+
+		String appName = this.properties.getName();
+		String appContext = prefix + "/" + appName;
+		contexts.add(appContext);
+		addProfiles(contexts, appContext, profiles);
+
 		return contexts;
 	}
 
-	protected String getContext(String prefix, String context) {
+	private String getContext(String prefix, String context) {
 		if (StringUtils.hasLength(prefix)) {
 			return prefix + "/" + context;
 		}

--- a/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourceLocatorTest.java
+++ b/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourceLocatorTest.java
@@ -128,10 +128,10 @@ class AwsSecretsManagerPropertySourceLocatorTest {
 
 		List<String> contextToBeTested = new ArrayList<>(locator.getContexts());
 
-		assertThat(contextToBeTested.get(0)).isEqualTo("/secret/messaging-service_test");
-		assertThat(contextToBeTested.get(1)).isEqualTo("/secret/messaging-service");
-		assertThat(contextToBeTested.get(2)).isEqualTo("/secret/application_test");
-		assertThat(contextToBeTested.get(3)).isEqualTo("/secret/application");
+		assertThat(contextToBeTested.get(0)).isEqualTo("/secret/application");
+		assertThat(contextToBeTested.get(1)).isEqualTo("/secret/application_test");
+		assertThat(contextToBeTested.get(2)).isEqualTo("/secret/messaging-service");
+		assertThat(contextToBeTested.get(3)).isEqualTo("/secret/messaging-service_test");
 	}
 
 	@Test

--- a/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourcesTests.java
+++ b/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourcesTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.awspring.cloud.paramstore;
+package io.awspring.cloud.secretsmanager;
 
 import java.util.Collections;
 import java.util.List;
@@ -27,42 +27,42 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
- * Unit test for {@link AwsParamStorePropertySourceLocator}.
+ * Unit test for {@link AwsSecretsManagerPropertySources}.
  *
  * @author Manuel Wessner
  */
-class AwsParamStorePropertySourcesTest {
+class AwsSecretsManagerPropertySourcesTests {
 
 	private final Log logMock = mock(Log.class);
 
-	private AwsParamStoreProperties properties;
+	private AwsSecretsManagerProperties properties;
 
 	@BeforeEach
 	void setUp() {
-		properties = new AwsParamStoreProperties();
+		properties = new AwsSecretsManagerProperties();
 		properties.setDefaultContext("application");
 		properties.setName("messaging-service");
 	}
 
 	@Test
 	void getAutomaticContextsWithSingleProfile() {
-		AwsParamStorePropertySources propertySource = new AwsParamStorePropertySources(properties, logMock);
+		AwsSecretsManagerPropertySources propertySource = new AwsSecretsManagerPropertySources(properties, logMock);
 
 		List<String> contexts = propertySource.getAutomaticContexts(Collections.singletonList("production"));
 
 		assertThat(contexts.size()).isEqualTo(4);
-		assertThat(contexts).containsExactly("/config/application/", "/config/application_production/",
-				"/config/messaging-service/", "/config/messaging-service_production/");
+		assertThat(contexts).containsExactly("/secret/application", "/secret/application_production",
+				"/secret/messaging-service", "/secret/messaging-service_production");
 	}
 
 	@Test
 	void getAutomaticContextsWithoutProfile() {
-		AwsParamStorePropertySources propertySource = new AwsParamStorePropertySources(properties, logMock);
+		AwsSecretsManagerPropertySources propertySource = new AwsSecretsManagerPropertySources(properties, logMock);
 
 		List<String> contexts = propertySource.getAutomaticContexts(Collections.emptyList());
 
 		assertThat(contexts.size()).isEqualTo(2);
-		assertThat(contexts).containsExactly("/config/application/", "/config/messaging-service/");
+		assertThat(contexts).containsExactly("/secret/application", "/secret/messaging-service");
 	}
 
 }

--- a/spring-cloud-starter-aws-parameter-store-config/src/test/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolverTest.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/test/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolverTest.java
@@ -40,8 +40,8 @@ class AwsParamStoreConfigDataLocationResolverTest {
 		String location = "aws-parameterstore:";
 		List<AwsParamStoreConfigDataResource> locations = testResolveProfileSpecific(location);
 		assertThat(locations).hasSize(4);
-		assertThat(toContexts(locations)).containsExactly("/config/testapp_dev/", "/config/testapp/",
-				"/config/application_dev/", "/config/application/");
+		assertThat(toContexts(locations)).containsExactly("/config/application/", "/config/application_dev/",
+				"/config/testapp/", "/config/testapp_dev/");
 	}
 
 	@Test

--- a/spring-cloud-starter-aws-secrets-manager-config/src/test/java/io/awspring/cloud/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolverTest.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/test/java/io/awspring/cloud/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolverTest.java
@@ -41,8 +41,8 @@ class AwsSecretsManagerConfigDataLocationResolverTest {
 		String location = "aws-secretsmanager:";
 		List<AwsSecretsManagerConfigDataResource> locations = testResolveProfileSpecific(location);
 		assertThat(locations).hasSize(4);
-		assertThat(toContexts(locations)).containsExactly("/secret/testapp_dev", "/secret/testapp",
-				"/secret/application_dev", "/secret/application");
+		assertThat(toContexts(locations)).containsExactly("/secret/application", "/secret/application_dev",
+				"/secret/testapp", "/secret/testapp_dev");
 	}
 
 	@Test


### PR DESCRIPTION
Fixes gh-169

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Reverse the context order when loading properties to preserve documented order (eg service specific context "wins" over more general application context)


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #169

## :green_heart: How did you test it?
By JUnit Test(s) and in a sample project [WtfJoke/chaoskotlindemo/awsparamterstoreconfig](https://github.com/WtfJoke/chaoskotlindemo/tree/awsparamterstoreconfig)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [N/A] I updated reference documentation to reflect the change
- [x] All tests passing
- [ ] No breaking changes - well its somehow breaking as it reverse the order, but imho never actually worked like intended since the (unwanted) change


## :crystal_ball: Next steps
