### PR TITLE
Evaluate region when custom endpoint is provided

### DIFF
--- a/spring-cloud-aws-core/src/main/java/io/awspring/cloud/core/config/AmazonWebserviceClientFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/io/awspring/cloud/core/config/AmazonWebserviceClientFactoryBean.java
@@ -112,18 +112,10 @@ public class AmazonWebserviceClientFactoryBean<T extends AmazonWebServiceClient>
 
 		if (this.customEndpoint != null) {
 			builder.withEndpointConfiguration(
-					new AwsClientBuilder.EndpointConfiguration(this.customEndpoint.toString(), null));
+					new AwsClientBuilder.EndpointConfiguration(this.customEndpoint.toString(), findRegion()));
 		}
 		else {
-			if (this.customRegion != null) {
-				builder.withRegion(this.customRegion.getName());
-			}
-			else if (this.regionProvider != null) {
-				builder.withRegion(this.regionProvider.getRegion().getName());
-			}
-			else {
-				builder.withRegion(Regions.DEFAULT_REGION);
-			}
+			builder.withRegion(findRegion());
 		}
 		return builder.build();
 	}
@@ -151,6 +143,21 @@ public class AmazonWebserviceClientFactoryBean<T extends AmazonWebServiceClient>
 	@Override
 	protected void destroyInstance(T instance) throws Exception {
 		instance.shutdown();
+	}
+
+	private String findRegion() {
+		String res;
+		if (this.customRegion != null) {
+			res = this.customRegion.getName();
+		}
+		else if (this.regionProvider != null) {
+			res = this.regionProvider.getRegion().getName();
+		}
+		else {
+			res = Regions.DEFAULT_REGION.name();
+		}
+
+		return res;
 	}
 
 }


### PR DESCRIPTION
When user specify the properties "cloud.aws.sqs.region" and "cloud.aws.sqs.endpoint" we need to build the sqs client with the provided region and endpoint.
The typical use is when there is a @SpringBootTest with localstack in which developer can specify either endpoint and region

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
When user specify the properties "cloud.aws.sqs.region" and "cloud.aws.sqs.endpoint" we need to build the sqs client with the provided region and endpoint.


## :bulb: Motivation and Context
The typical use is when there is a @SpringBootTest with localstack in which developer can specify either endpoint and region


## :green_heart: How did you test it?
I've tried against my spring boot 2.6.1 project. If the modification makes sense I will provide you all the needed unit tests


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
