### PR TITLE
167 - Prefix for paramstore cannot be empty

### DIFF
--- a/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStoreProperties.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStoreProperties.java
@@ -84,10 +84,6 @@ public class AwsParamStoreProperties implements InitializingBean {
 
 	public void afterPropertiesSet() throws Exception {
 
-		if (!StringUtils.hasLength(prefix)) {
-			throw new ValidationException(CONFIG_PREFIX + ".prefix", "prefix should not be empty or null.");
-		}
-
 		if (!StringUtils.hasLength(defaultContext)) {
 			throw new ValidationException(CONFIG_PREFIX + ".defaultContext",
 					"defaultContext should not be empty or null.");
@@ -98,7 +94,7 @@ public class AwsParamStoreProperties implements InitializingBean {
 					"profileSeparator should not be empty or null.");
 		}
 
-		if (!PREFIX_PATTERN.matcher(prefix).matches()) {
+		if (StringUtils.hasLength(prefix) && !PREFIX_PATTERN.matcher(prefix).matches()) {
 			throw new ValidationException(CONFIG_PREFIX + ".prefix",
 					"The prefix must have pattern of:  " + PREFIX_PATTERN.toString());
 		}

--- a/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySources.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySources.java
@@ -60,7 +60,7 @@ public class AwsParamStorePropertySources {
 	}
 
 	private String getContext(String prefix, String context) {
-		if (StringUtils.hasLength(prefix)) {
+		if (prefix != null) {
 			return prefix + "/" + context;
 		}
 		return context;

--- a/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySources.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySources.java
@@ -22,8 +22,6 @@ import java.util.List;
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
 import org.apache.commons.logging.Log;
 
-import org.springframework.util.StringUtils;
-
 /**
  * Is responsible for creating {@link AwsParamStorePropertySource} and determining
  * automatic contexts.

--- a/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertiesTest.java
+++ b/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertiesTest.java
@@ -57,6 +57,14 @@ class AwsParamStorePropertiesTest {
 	}
 
 	@Test
+	void validationSucceedsNoPrefix() {
+		AwsParamStoreProperties properties = new AwsParamStorePropertiesBuilder().withPrefix("")
+				.withDefaultContext("app").withProfileSeparator("_").build();
+
+		assertThatNoException().isThrownBy(properties::afterPropertiesSet);
+	}
+
+	@Test
 	void acceptsForwardSlashAsProfileSeparator() {
 		AwsParamStoreProperties properties = new AwsParamStoreProperties();
 		properties.setProfileSeparator("/");
@@ -72,7 +80,6 @@ class AwsParamStorePropertiesTest {
 
 	private static Stream<Arguments> invalidProperties() {
 		return Stream.of(
-				Arguments.of(new AwsParamStorePropertiesBuilder().withPrefix("").build(), "prefix", "NotEmpty"),
 				Arguments.of(new AwsParamStorePropertiesBuilder().withPrefix("!.").build(), "prefix", "Pattern"),
 				Arguments.of(new AwsParamStorePropertiesBuilder().withDefaultContext("").build(), "defaultContext",
 						"NotEmpty"),

--- a/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourcesTest.java
+++ b/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourcesTest.java
@@ -75,8 +75,8 @@ class AwsParamStorePropertySourcesTest {
 		List<String> contexts = propertySource.getAutomaticContexts(Collections.singletonList("production"));
 
 		assertThat(contexts.size()).isEqualTo(4);
-		assertThat(contexts).containsExactly("/application/", "/application_production/",
-			"/messaging-service/", "/messaging-service_production/");
+		assertThat(contexts).containsExactly("/application/", "/application_production/", "/messaging-service/",
+				"/messaging-service_production/");
 	}
 
 }

--- a/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourcesTest.java
+++ b/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourcesTest.java
@@ -65,4 +65,18 @@ class AwsParamStorePropertySourcesTest {
 		assertThat(contexts).containsExactly("/config/application/", "/config/messaging-service/");
 	}
 
+	@Test
+	void getAutomaticContextsWithSingleProfileWithPrefixEmpty() {
+		AwsParamStoreProperties properties = new AwsParamStoreProperties();
+		properties.setName("messaging-service");
+		properties.setPrefix("");
+		AwsParamStorePropertySources propertySource = new AwsParamStorePropertySources(properties, logMock);
+
+		List<String> contexts = propertySource.getAutomaticContexts(Collections.singletonList("production"));
+
+		assertThat(contexts.size()).isEqualTo(4);
+		assertThat(contexts).containsExactly("/application/", "/application_production/",
+			"/messaging-service/", "/messaging-service_production/");
+	}
+
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Allow empty values for aws.paramstore.prefix.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes bug #167 (https://github.com/awspring/spring-cloud-aws/issues/167)
Necessary fix for certain setups to be able to update aws parameter store version.

## :green_heart: How did you test it?
Only local tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
Merge this bad boy so I can update the general aws version in my company.