### PR TITLE
upgrade aws sdk version to 1.12.132

### DIFF
--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -32,7 +32,7 @@
 	<name>Spring Cloud AWS Dependencies</name>
 	<description>Spring Cloud AWS Dependencies</description>
 	<properties>
-		<aws-java-sdk.version>1.12.129</aws-java-sdk.version>
+		<aws-java-sdk.version>1.12.132</aws-java-sdk.version>
 		<elasticache.version>1.1.1</elasticache.version>
 		<jmemcached.version>1.0.0</jmemcached.version>
 		<maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Upgrade dependency of aws java sdk to 1.12.132

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The related sdk version now support new region `ap-southeast-3`  Asia Pacific (Jakarta). As the current version is not yet supported on this region.

See changes:
https://github.com/aws/aws-sdk-java/blame/004bb46aa8b3912f172a1240c3f622336e167921/aws-java-sdk-core/src/main/java/com/amazonaws/regions/Regions.java

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
