### PR TITLE
Fix property loading order for Parameter Store and Secrets Manager when used with Spring Cloud Bootstrap

### DIFF
--- a/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourceLocator.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourceLocator.java
@@ -18,6 +18,7 @@ package io.awspring.cloud.paramstore;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -76,7 +77,12 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 		AwsParamStorePropertySources sources = new AwsParamStorePropertySources(this.properties, this.logger);
 
 		List<String> profiles = Arrays.asList(env.getActiveProfiles());
-		this.contexts.addAll(sources.getAutomaticContexts(profiles));
+		List<String> contexts = sources.getAutomaticContexts(profiles);
+		// contexts are initially loaded in ascending priority order (for the
+		// compatibility with spring-config-import=)
+		// here it must be reversed to load from the most specific property source first
+		Collections.reverse(contexts);
+		this.contexts.addAll(contexts);
 
 		CompositePropertySource composite = new CompositePropertySource("aws-param-store");
 

--- a/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySources.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySources.java
@@ -43,6 +43,18 @@ public class AwsParamStorePropertySources {
 		this.log = log;
 	}
 
+	/**
+	 * Returns a list of contexts applicable to profiles in <strong>ascending priority
+	 * order</strong>.
+	 *
+	 * For example: when profile `dev1` is active and application name is set to `MyApp`,
+	 * it returns a list containing:
+	 *
+	 * [0] /config/application/ [1] /config/application_dev1/ [2] /config/MyApp/ [3]
+	 * /config/MyApp_dev1/
+	 * @param profiles - active profiles
+	 * @return list of contexts in <strong>ascending priority order</strong>
+	 */
 	public List<String> getAutomaticContexts(List<String> profiles) {
 		List<String> contexts = new ArrayList<>();
 		String prefix = this.properties.getPrefix();

--- a/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourceLocatorTest.java
+++ b/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourceLocatorTest.java
@@ -100,10 +100,10 @@ class AwsParamStorePropertySourceLocatorTest {
 
 		List<String> contextToBeTested = new ArrayList<>(locator.getContexts());
 
-		assertThat(contextToBeTested.get(0)).isEqualTo("application/application/");
-		assertThat(contextToBeTested.get(1)).isEqualTo("application/application_test/");
-		assertThat(contextToBeTested.get(2)).isEqualTo("application/messaging-service/");
-		assertThat(contextToBeTested.get(3)).isEqualTo("application/messaging-service_test/");
+		assertThat(contextToBeTested.get(0)).isEqualTo("application/messaging-service_test/");
+		assertThat(contextToBeTested.get(1)).isEqualTo("application/messaging-service/");
+		assertThat(contextToBeTested.get(2)).isEqualTo("application/application_test/");
+		assertThat(contextToBeTested.get(3)).isEqualTo("application/application/");
 	}
 
 	@Test

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
@@ -18,6 +18,7 @@ package io.awspring.cloud.secretsmanager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -84,7 +85,12 @@ public class AwsSecretsManagerPropertySourceLocator implements PropertySourceLoc
 		AwsSecretsManagerPropertySources sources = new AwsSecretsManagerPropertySources(properties, logger);
 
 		List<String> profiles = Arrays.asList(env.getActiveProfiles());
-		this.contexts.addAll(sources.getAutomaticContexts(profiles));
+		List<String> contexts = sources.getAutomaticContexts(profiles);
+		// contexts are initially loaded in ascending priority order (for the
+		// compatibility with spring-config-import=)
+		// here it must be reversed to load from the most specific property source first
+		Collections.reverse(contexts);
+		this.contexts.addAll(contexts);
 
 		CompositePropertySource composite = new CompositePropertySource(this.propertySourceName);
 

--- a/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourceLocatorTest.java
+++ b/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourceLocatorTest.java
@@ -128,10 +128,10 @@ class AwsSecretsManagerPropertySourceLocatorTest {
 
 		List<String> contextToBeTested = new ArrayList<>(locator.getContexts());
 
-		assertThat(contextToBeTested.get(0)).isEqualTo("/secret/application");
-		assertThat(contextToBeTested.get(1)).isEqualTo("/secret/application_test");
-		assertThat(contextToBeTested.get(2)).isEqualTo("/secret/messaging-service");
-		assertThat(contextToBeTested.get(3)).isEqualTo("/secret/messaging-service_test");
+		assertThat(contextToBeTested.get(0)).isEqualTo("/secret/messaging-service_test");
+		assertThat(contextToBeTested.get(1)).isEqualTo("/secret/messaging-service");
+		assertThat(contextToBeTested.get(2)).isEqualTo("/secret/application_test");
+		assertThat(contextToBeTested.get(3)).isEqualTo("/secret/application");
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Fix property loading order for Parameter Store and Secrets Manager when used with Spring Cloud Bootstrap. In 2.3.3 we've introduced a bug that changed loading order from the least important to the most important when properties were loaded in legacy way - using `spring-cloud-bootstrap`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #169 


## :green_heart: How did you test it?

Unit tests and samples.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes