### PR TITLE
Fixes logging for Parameter Store and Secrets Manager integrations

### DIFF
--- a/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySource.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySource.java
@@ -24,8 +24,8 @@ import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement
 import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest;
 import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathResult;
 import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.core.env.EnumerablePropertySource;
 
@@ -39,7 +39,7 @@ import org.springframework.core.env.EnumerablePropertySource;
  */
 public class AwsParamStorePropertySource extends EnumerablePropertySource<AWSSimpleSystemsManagement> {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(AwsParamStorePropertySource.class);
+	private static Log LOG = LogFactory.getLog(AwsParamStorePropertySource.class);
 
 	private final String context;
 
@@ -71,7 +71,7 @@ public class AwsParamStorePropertySource extends EnumerablePropertySource<AWSSim
 		GetParametersByPathResult paramsResult = this.source.getParametersByPath(paramsRequest);
 		for (Parameter parameter : paramsResult.getParameters()) {
 			String key = parameter.getName().replace(this.context, "").replace('/', '.');
-			LOGGER.debug("Populating property retrieved from AWS Parameter Store: {}", key);
+			LOG.debug("Populating property retrieved from AWS Parameter Store: " + key);
 			this.properties.put(key, parameter.getValue());
 		}
 		if (paramsResult.getNextToken() != null) {

--- a/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourceLocator.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourceLocator.java
@@ -24,8 +24,6 @@ import java.util.List;
 import java.util.Set;
 
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
 import org.springframework.core.env.CompositePropertySource;
@@ -54,8 +52,6 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 
 	private final Set<String> contexts = new LinkedHashSet<>();
 
-	private Log logger = LogFactory.getLog(getClass());
-
 	public AwsParamStorePropertySourceLocator(AWSSimpleSystemsManagement ssmClient,
 			AwsParamStoreProperties properties) {
 		this.ssmClient = ssmClient;
@@ -74,7 +70,7 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 
 		ConfigurableEnvironment env = (ConfigurableEnvironment) environment;
 
-		AwsParamStorePropertySources sources = new AwsParamStorePropertySources(this.properties, this.logger);
+		AwsParamStorePropertySources sources = new AwsParamStorePropertySources(this.properties);
 
 		List<String> profiles = Arrays.asList(env.getActiveProfiles());
 		List<String> contexts = sources.getAutomaticContexts(profiles);

--- a/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySources.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySources.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
 import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.util.StringUtils;
 
@@ -34,13 +35,12 @@ import org.springframework.util.StringUtils;
  */
 public class AwsParamStorePropertySources {
 
+	private static Log LOG = LogFactory.getLog(AwsParamStorePropertySources.class);
+
 	private final AwsParamStoreProperties properties;
 
-	private final Log log;
-
-	public AwsParamStorePropertySources(AwsParamStoreProperties properties, Log log) {
+	public AwsParamStorePropertySources(AwsParamStoreProperties properties) {
 		this.properties = properties;
-		this.log = log;
 	}
 
 	/**
@@ -95,7 +95,7 @@ public class AwsParamStorePropertySources {
 	 */
 	public AwsParamStorePropertySource createPropertySource(String context, boolean optional,
 			AWSSimpleSystemsManagement client) {
-		log.info("Loading property from AWS Parameter Store with name: " + context + ", optional: " + optional);
+		LOG.info("Loading property from AWS Parameter Store with name: " + context + ", optional: " + optional);
 		try {
 			AwsParamStorePropertySource propertySource = new AwsParamStorePropertySource(context, client);
 			propertySource.init();
@@ -107,7 +107,7 @@ public class AwsParamStorePropertySources {
 				throw new AwsParameterPropertySourceNotFoundException(e);
 			}
 			else {
-				log.warn("Unable to load AWS parameter from " + context + ". " + e.getMessage());
+				LOG.warn("Unable to load AWS parameter from " + context + ". " + e.getMessage());
 			}
 		}
 		return null;

--- a/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourcesTest.java
+++ b/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourcesTest.java
@@ -66,7 +66,7 @@ class AwsParamStorePropertySourcesTest {
 		AwsParamStoreProperties properties = new AwsParamStoreProperties();
 		properties.setName("messaging-service");
 		properties.setPrefix("");
-		AwsParamStorePropertySources propertySource = new AwsParamStorePropertySources(properties, logMock);
+		AwsParamStorePropertySources propertySource = new AwsParamStorePropertySources(properties);
 
 		List<String> contexts = propertySource.getAutomaticContexts(Collections.singletonList("production"));
 

--- a/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourcesTest.java
+++ b/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertySourcesTest.java
@@ -19,12 +19,10 @@ package io.awspring.cloud.paramstore;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 /**
  * Unit test for {@link AwsParamStorePropertySourceLocator}.
@@ -32,8 +30,6 @@ import static org.mockito.Mockito.mock;
  * @author Manuel Wessner
  */
 class AwsParamStorePropertySourcesTest {
-
-	private final Log logMock = mock(Log.class);
 
 	private AwsParamStoreProperties properties;
 
@@ -46,7 +42,7 @@ class AwsParamStorePropertySourcesTest {
 
 	@Test
 	void getAutomaticContextsWithSingleProfile() {
-		AwsParamStorePropertySources propertySource = new AwsParamStorePropertySources(properties, logMock);
+		AwsParamStorePropertySources propertySource = new AwsParamStorePropertySources(properties);
 
 		List<String> contexts = propertySource.getAutomaticContexts(Collections.singletonList("production"));
 
@@ -57,7 +53,7 @@ class AwsParamStorePropertySourcesTest {
 
 	@Test
 	void getAutomaticContextsWithoutProfile() {
-		AwsParamStorePropertySources propertySource = new AwsParamStorePropertySources(properties, logMock);
+		AwsParamStorePropertySources propertySource = new AwsParamStorePropertySources(properties);
 
 		List<String> contexts = propertySource.getAutomaticContexts(Collections.emptyList());
 

--- a/spring-cloud-aws-samples/spring-cloud-aws-parameter-store-sample/pom.xml
+++ b/spring-cloud-aws-samples/spring-cloud-aws-parameter-store-sample/pom.xml
@@ -18,12 +18,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-bootstrap</artifactId>
-			<version>3.0.0</version>
-		</dependency>
-
-		<dependency>
 			<groupId>io.awspring.cloud</groupId>
 			<artifactId>spring-cloud-starter-aws-parameter-store-config</artifactId>
 		</dependency>

--- a/spring-cloud-aws-samples/spring-cloud-aws-parameter-store-sample/pom.xml
+++ b/spring-cloud-aws-samples/spring-cloud-aws-parameter-store-sample/pom.xml
@@ -18,6 +18,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-bootstrap</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+
+		<dependency>
 			<groupId>io.awspring.cloud</groupId>
 			<artifactId>spring-cloud-starter-aws-parameter-store-config</artifactId>
 		</dependency>

--- a/spring-cloud-aws-samples/spring-cloud-aws-parameter-store-sample/src/main/resources/application.properties
+++ b/spring-cloud-aws-samples/spring-cloud-aws-parameter-store-sample/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # importing single parameter
-spring.config.import=aws-parameterstore:/config/spring/
+#spring.config.import=aws-parameterstore:/config/spring/
+logging.level.io.awspring.cloud=debug
 
 # importing multiple parameters
 # spring.config.import: aws-parameterstore:/config/spring;/config/common

--- a/spring-cloud-aws-samples/spring-cloud-aws-parameter-store-sample/src/main/resources/application.properties
+++ b/spring-cloud-aws-samples/spring-cloud-aws-parameter-store-sample/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 # importing single parameter
-#spring.config.import=aws-parameterstore:/config/spring/
-logging.level.io.awspring.cloud=debug
+spring.config.import=aws-parameterstore:/config/spring/
+logging.level.io.awspring.cloud.paramstore=debug
 
 # importing multiple parameters
 # spring.config.import: aws-parameterstore:/config/spring;/config/common

--- a/spring-cloud-aws-samples/spring-cloud-aws-secrets-manager-sample/infrastructure/lib/infrastructure-stack.ts
+++ b/spring-cloud-aws-samples/spring-cloud-aws-secrets-manager-sample/infrastructure/lib/infrastructure-stack.ts
@@ -10,6 +10,7 @@ export class InfrastructureStack extends cdk.Stack {
 			generateSecretString: {
 				secretStringTemplate: '{}',
 				generateStringKey: 'password',
+				excludeCharacters: '#$' // Spring tries to interpolate any ${} and #{}
 			}
 		});
 	}

--- a/spring-cloud-aws-samples/spring-cloud-aws-secrets-manager-sample/src/main/resources/application.yml
+++ b/spring-cloud-aws-samples/spring-cloud-aws-secrets-manager-sample/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 # importing single secret
 spring.config.import: aws-secretsmanager:/secrets/spring-cloud-aws-sample-app
+logging.level.io.awspring.cloud.secretsmanager: debug
 
 # importing multiple secrets
 # spring.config.import: aws-secretsmanager:/secrets/spring-cloud-aws-sample-app;/secret/common

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySource.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySource.java
@@ -27,6 +27,8 @@ import com.amazonaws.services.secretsmanager.model.ResourceNotFoundException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.core.env.EnumerablePropertySource;
 
@@ -39,6 +41,8 @@ import org.springframework.core.env.EnumerablePropertySource;
  * @since 2.0.0
  */
 public class AwsSecretsManagerPropertySource extends EnumerablePropertySource<AWSSecretsManager> {
+
+	private static Log LOG = LogFactory.getLog(AwsSecretsManagerPropertySource.class);
 
 	private final ObjectMapper jsonMapper = new ObjectMapper();
 
@@ -79,6 +83,7 @@ public class AwsSecretsManagerPropertySource extends EnumerablePropertySource<AW
 					});
 
 			for (Map.Entry<String, Object> secretEntry : secretMap.entrySet()) {
+				LOG.debug("Populating property retrieved from AWS Secrets Manager: " + secretEntry.getKey());
 				properties.put(secretEntry.getKey(), secretEntry.getValue());
 			}
 		}

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
@@ -24,8 +24,6 @@ import java.util.List;
 import java.util.Set;
 
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
 import org.springframework.core.env.CompositePropertySource;
@@ -57,8 +55,6 @@ public class AwsSecretsManagerPropertySourceLocator implements PropertySourceLoc
 
 	private final Set<String> contexts = new LinkedHashSet<>();
 
-	private Log logger = LogFactory.getLog(getClass());
-
 	public AwsSecretsManagerPropertySourceLocator(String propertySourceName, AWSSecretsManager smClient,
 			AwsSecretsManagerProperties properties) {
 		this.propertySourceName = propertySourceName;
@@ -82,7 +78,7 @@ public class AwsSecretsManagerPropertySourceLocator implements PropertySourceLoc
 
 		ConfigurableEnvironment env = (ConfigurableEnvironment) environment;
 
-		AwsSecretsManagerPropertySources sources = new AwsSecretsManagerPropertySources(properties, logger);
+		AwsSecretsManagerPropertySources sources = new AwsSecretsManagerPropertySources(properties);
 
 		List<String> profiles = Arrays.asList(env.getActiveProfiles());
 		List<String> contexts = sources.getAutomaticContexts(profiles);

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySources.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySources.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.util.StringUtils;
 
@@ -34,13 +35,12 @@ import org.springframework.util.StringUtils;
  */
 public class AwsSecretsManagerPropertySources {
 
+	private static Log LOG = LogFactory.getLog(AwsSecretsManagerPropertySources.class);
+
 	private final AwsSecretsManagerProperties properties;
 
-	private final Log log;
-
-	public AwsSecretsManagerPropertySources(AwsSecretsManagerProperties properties, Log log) {
+	public AwsSecretsManagerPropertySources(AwsSecretsManagerProperties properties) {
 		this.properties = properties;
-		this.log = log;
 	}
 
 	public List<String> getAutomaticContexts(List<String> profiles) {
@@ -83,7 +83,7 @@ public class AwsSecretsManagerPropertySources {
 	 */
 	public AwsSecretsManagerPropertySource createPropertySource(String context, boolean optional,
 			AWSSecretsManager client) {
-		log.info("Loading secrets from AWS Secret Manager secret with name: " + context + ", optional: " + optional);
+		LOG.info("Loading secrets from AWS Secret Manager secret with name: " + context + ", optional: " + optional);
 		try {
 			AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource(context, client);
 			propertySource.init();
@@ -95,7 +95,7 @@ public class AwsSecretsManagerPropertySources {
 				throw new AwsSecretsManagerPropertySourceNotFoundException(e);
 			}
 			else {
-				log.warn("Unable to load AWS secret from " + context + ". " + e.getMessage());
+				LOG.warn("Unable to load AWS secret from " + context + ". " + e.getMessage());
 			}
 		}
 		return null;

--- a/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourcesTests.java
+++ b/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourcesTests.java
@@ -19,12 +19,10 @@ package io.awspring.cloud.secretsmanager;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 /**
  * Unit test for {@link AwsSecretsManagerPropertySources}.
@@ -32,8 +30,6 @@ import static org.mockito.Mockito.mock;
  * @author Manuel Wessner
  */
 class AwsSecretsManagerPropertySourcesTests {
-
-	private final Log logMock = mock(Log.class);
 
 	private AwsSecretsManagerProperties properties;
 
@@ -46,7 +42,7 @@ class AwsSecretsManagerPropertySourcesTests {
 
 	@Test
 	void getAutomaticContextsWithSingleProfile() {
-		AwsSecretsManagerPropertySources propertySource = new AwsSecretsManagerPropertySources(properties, logMock);
+		AwsSecretsManagerPropertySources propertySource = new AwsSecretsManagerPropertySources(properties);
 
 		List<String> contexts = propertySource.getAutomaticContexts(Collections.singletonList("production"));
 
@@ -57,7 +53,7 @@ class AwsSecretsManagerPropertySourcesTests {
 
 	@Test
 	void getAutomaticContextsWithoutProfile() {
-		AwsSecretsManagerPropertySources propertySource = new AwsSecretsManagerPropertySources(properties, logMock);
+		AwsSecretsManagerPropertySources propertySource = new AwsSecretsManagerPropertySources(properties);
 
 		List<String> contexts = propertySource.getAutomaticContexts(Collections.emptyList());
 

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLoader.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLoader.java
@@ -42,7 +42,7 @@ public class AwsParamStoreConfigDataLoader implements ConfigDataLoader<AwsParamS
 
 	private final DeferredLogFactory logFactory;
 
-	AwsParamStoreConfigDataLoader(DeferredLogFactory logFactory) {
+	public AwsParamStoreConfigDataLoader(DeferredLogFactory logFactory) {
 		this.logFactory = logFactory;
 		reconfigureLoggers(logFactory);
 	}
@@ -66,13 +66,13 @@ public class AwsParamStoreConfigDataLoader implements ConfigDataLoader<AwsParamS
 	}
 
 	private void reconfigureLoggers(DeferredLogFactory logFactory) {
+		// loggers in these classes must be static non-final
 		List<Class<?>> loggers = Arrays.asList(AwsParamStorePropertySource.class, AwsParamStorePropertySources.class);
 
 		loggers.forEach(it -> reconfigureLogger(it, logFactory));
 	}
 
 	static void reconfigureLogger(Class<?> type, DeferredLogFactory logFactory) {
-
 		ReflectionUtils.doWithFields(type, field -> {
 
 			field.setAccessible(true);

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLoader.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLoader.java
@@ -16,21 +16,36 @@
 
 package io.awspring.cloud.autoconfigure.paramstore;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
 import io.awspring.cloud.paramstore.AwsParamStorePropertySource;
+import io.awspring.cloud.paramstore.AwsParamStorePropertySources;
+import org.apache.commons.logging.Log;
 
 import org.springframework.boot.context.config.ConfigData;
 import org.springframework.boot.context.config.ConfigDataLoader;
 import org.springframework.boot.context.config.ConfigDataLoaderContext;
 import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
+import org.springframework.boot.logging.DeferredLogFactory;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Eddú Meléndez
  * @since 2.3.0
  */
 public class AwsParamStoreConfigDataLoader implements ConfigDataLoader<AwsParamStoreConfigDataResource> {
+
+	private final DeferredLogFactory logFactory;
+
+	AwsParamStoreConfigDataLoader(DeferredLogFactory logFactory) {
+		this.logFactory = logFactory;
+		reconfigureLoggers(logFactory);
+	}
 
 	@Override
 	public ConfigData load(ConfigDataLoaderContext context, AwsParamStoreConfigDataResource resource) {
@@ -48,6 +63,26 @@ public class AwsParamStoreConfigDataLoader implements ConfigDataLoader<AwsParamS
 		catch (Exception e) {
 			throw new ConfigDataResourceNotFoundException(resource, e);
 		}
+	}
+
+	private void reconfigureLoggers(DeferredLogFactory logFactory) {
+		List<Class<?>> loggers = Arrays.asList(AwsParamStorePropertySource.class, AwsParamStorePropertySources.class);
+
+		loggers.forEach(it -> reconfigureLogger(it, logFactory));
+	}
+
+	static void reconfigureLogger(Class<?> type, DeferredLogFactory logFactory) {
+
+		ReflectionUtils.doWithFields(type, field -> {
+
+			field.setAccessible(true);
+			field.set(null, logFactory.getLog(type));
+
+		}, AwsParamStoreConfigDataLoader::isUpdateableLogField);
+	}
+
+	private static boolean isUpdateableLogField(Field field) {
+		return !Modifier.isFinal(field.getModifiers()) && field.getType().isAssignableFrom(Log.class);
 	}
 
 }

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/io/awspring/cloud/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
@@ -24,8 +24,6 @@ import java.util.List;
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
 import io.awspring.cloud.paramstore.AwsParamStoreProperties;
 import io.awspring.cloud.paramstore.AwsParamStorePropertySources;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import org.springframework.boot.BootstrapContext;
 import org.springframework.boot.BootstrapRegistry;
@@ -53,8 +51,6 @@ public class AwsParamStoreConfigDataLocationResolver
 	 */
 	public static final String PREFIX = "aws-parameterstore:";
 
-	private final Log log = LogFactory.getLog(AwsParamStoreConfigDataLocationResolver.class);
-
 	@Override
 	public boolean isResolvable(ConfigDataLocationResolverContext context, ConfigDataLocation location) {
 		if (!location.hasPrefix(PREFIX)) {
@@ -80,7 +76,7 @@ public class AwsParamStoreConfigDataLocationResolver
 
 		AwsParamStoreProperties properties = loadConfigProperties(resolverContext.getBinder());
 
-		AwsParamStorePropertySources sources = new AwsParamStorePropertySources(properties, log);
+		AwsParamStorePropertySources sources = new AwsParamStorePropertySources(properties);
 
 		List<String> contexts = location.getValue().equals(PREFIX)
 				? sources.getAutomaticContexts(profiles.getAccepted())

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/io/awspring/cloud/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLoader.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/io/awspring/cloud/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLoader.java
@@ -16,15 +16,23 @@
 
 package io.awspring.cloud.autoconfigure.secretsmanager;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import io.awspring.cloud.secretsmanager.AwsSecretsManagerPropertySource;
+import io.awspring.cloud.secretsmanager.AwsSecretsManagerPropertySources;
+import org.apache.commons.logging.Log;
 
 import org.springframework.boot.context.config.ConfigData;
 import org.springframework.boot.context.config.ConfigDataLoader;
 import org.springframework.boot.context.config.ConfigDataLoaderContext;
 import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
+import org.springframework.boot.logging.DeferredLogFactory;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * Loads config data from AWS Secret Manager.
@@ -34,6 +42,13 @@ import org.springframework.boot.context.config.ConfigDataResourceNotFoundExcepti
  * @since 2.3.0
  */
 public class AwsSecretsManagerConfigDataLoader implements ConfigDataLoader<AwsSecretsManagerConfigDataResource> {
+
+	private final DeferredLogFactory logFactory;
+
+	public AwsSecretsManagerConfigDataLoader(DeferredLogFactory logFactory) {
+		this.logFactory = logFactory;
+		reconfigureLoggers(logFactory);
+	}
 
 	@Override
 	public ConfigData load(ConfigDataLoaderContext context, AwsSecretsManagerConfigDataResource resource) {
@@ -51,6 +66,27 @@ public class AwsSecretsManagerConfigDataLoader implements ConfigDataLoader<AwsSe
 		catch (Exception e) {
 			throw new ConfigDataResourceNotFoundException(resource, e);
 		}
+	}
+
+	private void reconfigureLoggers(DeferredLogFactory logFactory) {
+		List<Class<?>> loggers = Arrays.asList(AwsSecretsManagerPropertySource.class,
+				AwsSecretsManagerPropertySources.class);
+
+		loggers.forEach(it -> reconfigureLogger(it, logFactory));
+	}
+
+	static void reconfigureLogger(Class<?> type, DeferredLogFactory logFactory) {
+		// loggers in these classes must be static non-final
+		ReflectionUtils.doWithFields(type, field -> {
+
+			field.setAccessible(true);
+			field.set(null, logFactory.getLog(type));
+
+		}, AwsSecretsManagerConfigDataLoader::isUpdateableLogField);
+	}
+
+	private static boolean isUpdateableLogField(Field field) {
+		return !Modifier.isFinal(field.getModifiers()) && field.getType().isAssignableFrom(Log.class);
 	}
 
 }

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/io/awspring/cloud/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolver.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/io/awspring/cloud/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolver.java
@@ -24,7 +24,6 @@ import java.util.List;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import io.awspring.cloud.secretsmanager.AwsSecretsManagerProperties;
 import io.awspring.cloud.secretsmanager.AwsSecretsManagerPropertySources;
-import org.apache.commons.logging.Log;
 
 import org.springframework.boot.BootstrapContext;
 import org.springframework.boot.BootstrapRegistry;
@@ -50,16 +49,10 @@ import org.springframework.util.StringUtils;
 public class AwsSecretsManagerConfigDataLocationResolver
 		implements ConfigDataLocationResolver<AwsSecretsManagerConfigDataResource> {
 
-	private final Log log;
-
 	/**
 	 * AWS Secrets Manager Config Data prefix.
 	 */
 	public static final String PREFIX = "aws-secretsmanager:";
-
-	public AwsSecretsManagerConfigDataLocationResolver(Log log) {
-		this.log = log;
-	}
 
 	@Override
 	public boolean isResolvable(ConfigDataLocationResolverContext context, ConfigDataLocation location) {
@@ -86,7 +79,7 @@ public class AwsSecretsManagerConfigDataLocationResolver
 
 		AwsSecretsManagerProperties properties = loadConfigProperties(resolverContext.getBinder());
 
-		AwsSecretsManagerPropertySources propertySources = new AwsSecretsManagerPropertySources(properties, log);
+		AwsSecretsManagerPropertySources propertySources = new AwsSecretsManagerPropertySources(properties);
 
 		List<String> contexts = location.getValue().equals(PREFIX)
 				? propertySources.getAutomaticContexts(profiles.getAccepted())

--- a/spring-cloud-starter-aws-secrets-manager-config/src/test/java/io/awspring/cloud/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolverTest.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/test/java/io/awspring/cloud/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolverTest.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.BootstrapRegistry;
@@ -69,7 +68,7 @@ class AwsSecretsManagerConfigDataLocationResolverTest {
 	}
 
 	private AwsSecretsManagerConfigDataLocationResolver createResolver() {
-		return new AwsSecretsManagerConfigDataLocationResolver(LogFactory.getLog("any")) {
+		return new AwsSecretsManagerConfigDataLocationResolver() {
 			@Override
 			public <T> void registerBean(ConfigDataLocationResolverContext context, Class<T> type, T instance) {
 				// do nothing


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Fixes logging for Parameter Store and Secrets Manager integrations when used with `spring.config.import`. Implemented in similar way it's been done to Spring Vault integration https://github.com/spring-cloud/spring-cloud-vault/issues/565

Fixes #194 
Fixes #165