### PR TITLE
Allow prefix for Secrets Manager to be empty

### DIFF
--- a/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerProperties.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerProperties.java
@@ -86,10 +86,6 @@ public class AwsSecretsManagerProperties implements InitializingBean {
 	@Override
 	public void afterPropertiesSet() throws Exception {
 
-		if (!StringUtils.hasLength(prefix)) {
-			throw new ValidationException(CONFIG_PREFIX + ".prefix", "prefix should not be empty or null.");
-		}
-
 		if (!StringUtils.hasLength(defaultContext)) {
 			throw new ValidationException(CONFIG_PREFIX + ".defaultContext",
 					"defaultContext should not be empty or null.");
@@ -100,7 +96,7 @@ public class AwsSecretsManagerProperties implements InitializingBean {
 					"profileSeparator should not be empty or null.");
 		}
 
-		if (!PREFIX_PATTERN.matcher(prefix).matches()) {
+		if (StringUtils.hasLength(prefix) && !PREFIX_PATTERN.matcher(prefix).matches()) {
 			throw new ValidationException(CONFIG_PREFIX + ".prefix",
 					"The prefix must have pattern of:  " + PREFIX_PATTERN.toString());
 		}

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySources.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySources.java
@@ -22,8 +22,6 @@ import java.util.List;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import org.apache.commons.logging.Log;
 
-import org.springframework.util.StringUtils;
-
 /**
  * Is responsible for creating {@link AwsSecretsManagerPropertySource} and determining
  * automatic contexts.
@@ -60,7 +58,7 @@ public class AwsSecretsManagerPropertySources {
 	}
 
 	private String getContext(String prefix, String context) {
-		if (StringUtils.hasLength(prefix)) {
+		if (prefix != null) {
 			return prefix + "/" + context;
 		}
 		return context;

--- a/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertiesTest.java
+++ b/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertiesTest.java
@@ -47,7 +47,8 @@ class AwsSecretsManagerPropertiesTest {
 
 	private static Stream<Arguments> validProperties() {
 		return Stream.of(
-				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("").build(), "prefix", "NotEmpty"),
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("").withDefaultContext("app")
+						.withProfileSeparator("_").build()),
 				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("/sec").withDefaultContext("app")
 						.withProfileSeparator("_").build()),
 				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("/sec/test/var")

--- a/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertiesTest.java
+++ b/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertiesTest.java
@@ -47,6 +47,7 @@ class AwsSecretsManagerPropertiesTest {
 
 	private static Stream<Arguments> validProperties() {
 		return Stream.of(
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("").build(), "prefix", "NotEmpty"),
 				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("/sec").withDefaultContext("app")
 						.withProfileSeparator("_").build()),
 				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("/sec/test/var")
@@ -61,7 +62,6 @@ class AwsSecretsManagerPropertiesTest {
 
 	private static Stream<Arguments> invalidProperties() {
 		return Stream.of(
-				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("").build(), "prefix", "NotEmpty"),
 				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("!.").build(), "prefix", "Pattern"),
 				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withDefaultContext("").build(), "defaultContext",
 						"NotEmpty"),

--- a/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourceLocatorTest.java
+++ b/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourceLocatorTest.java
@@ -135,6 +135,28 @@ class AwsSecretsManagerPropertySourceLocatorTest {
 	}
 
 	@Test
+	void contextExpectSpecificOrderAndEmptyPrefix() {
+		AwsSecretsManagerProperties properties = new AwsSecretsManagerPropertiesBuilder()
+				.withDefaultContext("application").withPrefix("").withName("messaging-service").build();
+
+		GetSecretValueResult secretValueResult = new GetSecretValueResult();
+		secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
+
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(smClient,
+				properties);
+		env.setActiveProfiles("test");
+		locator.locate(env);
+
+		List<String> contextToBeTested = new ArrayList<>(locator.getContexts());
+
+		assertThat(contextToBeTested.get(0)).isEqualTo("/messaging-service_test");
+		assertThat(contextToBeTested.get(1)).isEqualTo("/messaging-service");
+		assertThat(contextToBeTested.get(2)).isEqualTo("/application_test");
+		assertThat(contextToBeTested.get(3)).isEqualTo("/application");
+	}
+
+	@Test
 	void whenFailFastIsTrueAndSecretDoesNotExistThrowsException() {
 		AwsSecretsManagerProperties properties = new AwsSecretsManagerProperties();
 		properties.setFailFast(true);
@@ -171,6 +193,11 @@ class AwsSecretsManagerPropertySourceLocatorTest {
 
 		public AwsSecretsManagerPropertiesBuilder withDefaultContext(String defaultContext) {
 			this.properties.setDefaultContext(defaultContext);
+			return this;
+		}
+
+		public AwsSecretsManagerPropertiesBuilder withPrefix(String prefix) {
+			this.properties.setPrefix(prefix);
 			return this;
 		}
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Secrets Manager prefix in docs and code says can be empty but the validation does not allow it. #232 
 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x ] No breaking changes


## :crystal_ball: Next steps
