### PR TITLE
Add `@SqsTest` annotation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
 		<module>spring-cloud-aws-integration-test</module>
 		<module>docs</module>
 		<module>spring-cloud-aws-samples</module>
+		<module>spring-cloud-aws-test</module>
 		</modules>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,13 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
+			<dependency>
+				<groupId>org.testcontainers</groupId>
+				<artifactId>testcontainers-bom</artifactId>
+				<version>1.16.3</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -151,6 +151,11 @@
 				<artifactId>spring-cloud-aws-ses</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>io.awspring.cloud</groupId>
+				<artifactId>spring-cloud-aws-test</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<profiles>

--- a/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/pom.xml
+++ b/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/pom.xml
@@ -45,6 +45,18 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>localstack</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/pom.xml
+++ b/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/pom.xml
@@ -23,6 +23,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>io.awspring.cloud</groupId>
+			<artifactId>spring-cloud-starter-aws-messaging</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -30,14 +35,15 @@
 
 		<dependency>
 			<groupId>io.awspring.cloud</groupId>
-			<artifactId>spring-cloud-starter-aws-messaging</artifactId>
+			<artifactId>spring-cloud-aws-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
 		</dependency>
-
 
 	</dependencies>
 

--- a/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/main/java/io/awspring/cloud/sqs/sample/MessageSender.java
+++ b/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/main/java/io/awspring/cloud/sqs/sample/MessageSender.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.sqs.sample;
+
+import java.time.LocalDate;
+
+import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MessageSender {
+
+	private final QueueMessagingTemplate queueMessagingTemplate;
+
+	MessageSender(QueueMessagingTemplate queueMessagingTemplate) {
+		this.queueMessagingTemplate = queueMessagingTemplate;
+	}
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void sendMessage() {
+		this.queueMessagingTemplate.send("InfrastructureStack-spring-aws",
+				MessageBuilder.withPayload("Spring cloud Aws SQS sample!").build());
+		this.queueMessagingTemplate.convertAndSend("InfrastructureStack-aws-pojo",
+				new Person("Joe", "Doe", LocalDate.of(2000, 1, 12)));
+	}
+
+}

--- a/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/main/java/io/awspring/cloud/sqs/sample/MessageSender.java
+++ b/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/main/java/io/awspring/cloud/sqs/sample/MessageSender.java
@@ -26,7 +26,7 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Component;
 
 @Component
-public class MessageSender {
+class MessageSender {
 
 	private final QueueMessagingTemplate queueMessagingTemplate;
 

--- a/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/main/java/io/awspring/cloud/sqs/sample/SampleListener.java
+++ b/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/main/java/io/awspring/cloud/sqs/sample/SampleListener.java
@@ -16,14 +16,25 @@
 
 package io.awspring.cloud.sqs.sample;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import io.awspring.cloud.messaging.listener.annotation.SqsListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-@SpringBootApplication
-public class SqsSampleApplication {
+import org.springframework.stereotype.Component;
 
-	public static void main(String[] args) {
-		SpringApplication.run(SqsSampleApplication.class, args);
+@Component
+class SampleListener {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(SampleListener.class);
+
+	@SqsListener("InfrastructureStack-spring-aws")
+	public void listenToMessage(String message) {
+		LOGGER.info("This is message you want to see: {}", message);
+	}
+
+	@SqsListener("InfrastructureStack-aws-pojo")
+	public void listenToPerson(Person person) {
+		LOGGER.info(person.toString());
 	}
 
 }

--- a/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/test/java/io/awspring/cloud/sqs/sample/SqsSampleApplicationTests.java
+++ b/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/test/java/io/awspring/cloud/sqs/sample/SqsSampleApplicationTests.java
@@ -36,7 +36,8 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.verify;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
 
-@SqsTest
+@SqsTest(properties = { "cloud.aws.credentials.access-key=noop", "cloud.aws.credentials.secret-key=noop",
+		"cloud.aws.region.static=eu-west-1" })
 @Testcontainers
 class SqsSampleApplicationTests {
 

--- a/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/test/java/io/awspring/cloud/sqs/sample/SqsSampleApplicationTests.java
+++ b/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/test/java/io/awspring/cloud/sqs/sample/SqsSampleApplicationTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.sqs.sample;
+
+import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
+import io.awspring.cloud.test.sqs.SqsTest;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.messaging.support.MessageBuilder;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.verify;
+
+@SqsTest
+class SqsSampleApplicationTests {
+
+	@Autowired
+	private QueueMessagingTemplate queueMessagingTemplate;
+
+	@SpyBean
+	private SampleListener sampleListener;
+
+	@Test
+	void foo() {
+		queueMessagingTemplate.send("InfrastructureStack-spring-aws", MessageBuilder.withPayload("hello").build());
+
+		await().untilAsserted(() -> verify(sampleListener).listenToMessage("hello"));
+	}
+
+}

--- a/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/test/java/io/awspring/cloud/sqs/sample/SqsSampleApplicationTests.java
+++ b/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/test/java/io/awspring/cloud/sqs/sample/SqsSampleApplicationTests.java
@@ -16,19 +16,37 @@
 
 package io.awspring.cloud.sqs.sample;
 
+import java.io.IOException;
+
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
 import io.awspring.cloud.test.sqs.SqsTest;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.verify;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
 
 @SqsTest
+@Testcontainers
 class SqsSampleApplicationTests {
+
+	private static final String QUEUE_NAME = "InfrastructureStack-spring-aws";
+
+	// create an SQS locally running equivalent with Localstack and Testcontainers
+	@Container
+	static LocalStackContainer localstack = new LocalStackContainer(
+			DockerImageName.parse("localstack/localstack:0.14.0")).withServices(SQS);
 
 	@Autowired
 	private QueueMessagingTemplate queueMessagingTemplate;
@@ -36,11 +54,25 @@ class SqsSampleApplicationTests {
 	@SpyBean
 	private SampleListener sampleListener;
 
-	@Test
-	void foo() {
-		queueMessagingTemplate.send("InfrastructureStack-spring-aws", MessageBuilder.withPayload("hello").build());
+	@BeforeAll
+	static void beforeAll() throws IOException, InterruptedException {
+		// create needed queues in SQS
+		localstack.execInContainer("awslocal", "sqs", "create-queue", "--queue-name", QUEUE_NAME);
+	}
 
+	@Test
+	void receivesMessage() {
+		// send a message
+		queueMessagingTemplate.send(QUEUE_NAME, MessageBuilder.withPayload("hello").build());
+
+		// verify that bean handling the message was invoked
 		await().untilAsserted(() -> verify(sampleListener).listenToMessage("hello"));
+	}
+
+	@DynamicPropertySource
+	static void registerPgProperties(DynamicPropertyRegistry registry) {
+		// overwrite SQS endpoint with one provided by Localstack
+		registry.add("cloud.aws.sqs.endpoint", () -> localstack.getEndpointOverride(SQS).toString());
 	}
 
 }

--- a/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/test/resources/logback-test.xml
+++ b/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="INFO">
+		<appender-ref ref="STDOUT"/>
+	</root>
+
+	<logger name="org.testcontainers" level="INFO"/>
+	<logger name="com.github.dockerjava" level="WARN"/>
+	<logger name="io.awspring" level="INFO"/>
+</configuration>

--- a/spring-cloud-aws-test/pom.xml
+++ b/spring-cloud-aws-test/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>io.awspring.cloud</groupId>
 		<artifactId>spring-cloud-aws</artifactId>
-		<version>2.3.3</version>
+		<version>2.4.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-aws-test</artifactId>
 	<name>Spring Cloud AWS Test</name>

--- a/spring-cloud-aws-test/pom.xml
+++ b/spring-cloud-aws-test/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>io.awspring.cloud</groupId>
+		<artifactId>spring-cloud-aws</artifactId>
+		<version>2.3.3</version>
+	</parent>
+	<artifactId>spring-cloud-aws-test</artifactId>
+	<name>Spring Cloud AWS Test</name>
+	<description>Spring Cloud AWS Test</description>
+	<url>https://projects.spring.io/spring-cloud</url>
+
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>io.awspring.cloud</groupId>
+			<artifactId>spring-cloud-aws-autoconfigure</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.awspring.cloud</groupId>
+			<artifactId>spring-cloud-aws-messaging</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-test-autoconfigure</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-cloud-aws-test/pom.xml
+++ b/spring-cloud-aws-test/pom.xml
@@ -58,5 +58,21 @@
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>localstack</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/AutoConfigureSqs.java
+++ b/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/AutoConfigureSqs.java
@@ -14,16 +14,22 @@
  * limitations under the License.
  */
 
-package io.awspring.cloud.sqs.sample;
+package io.awspring.cloud.test.sqs;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-@SpringBootApplication
-public class SqsSampleApplication {
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 
-	public static void main(String[] args) {
-		SpringApplication.run(SqsSampleApplication.class, args);
-	}
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ImportAutoConfiguration
+public @interface AutoConfigureSqs {
 
 }

--- a/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/AutoConfigureSqs.java
+++ b/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/AutoConfigureSqs.java
@@ -25,6 +25,15 @@ import java.lang.annotation.Target;
 
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 
+/**
+ * {@link ImportAutoConfiguration Auto-configuration imports} for typical SQS tests. Most
+ * tests should consider using {@link SqsTest @SqsTest} rather than using this annotation
+ * directly.
+ *
+ * @author Maciej Walkowiak
+ * @since 2.4.0
+ * @see SqsTest
+ */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented

--- a/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTest.java
+++ b/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTest.java
@@ -33,6 +33,19 @@ import org.springframework.core.env.Environment;
 import org.springframework.test.context.BootstrapWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+/**
+ * Annotation for a SQS test that focuses <strong>only</strong> on SQS-based components.
+ * <p>
+ * Using this annotation will disable full auto-configuration and instead apply only
+ * configuration relevant to SQS tests.
+ * <p>
+ * When using JUnit 4, this annotation should be used in combination with
+ * {@code @RunWith(SpringRunner.class)}.
+ *
+ * @author Maciej Walkowiak
+ * @since 2.4.0
+ * @see AutoConfigureSqs
+ */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
@@ -49,7 +62,6 @@ public @interface SqsTest {
 	 * Properties in form {@literal key=value} that should be added to the Spring
 	 * {@link Environment} before the test runs.
 	 * @return the properties to add
-	 * @since 2.1.0
 	 */
 	String[] properties() default {};
 

--- a/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTest.java
+++ b/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.test.sqs;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@BootstrapWith(SqsTestContextBootstrapper.class)
+@OverrideAutoConfiguration(enabled = false)
+@TypeExcludeFilters(SqsTypeExcludeFilter.class)
+@ExtendWith(SpringExtension.class)
+@AutoConfigureSqs
+@ImportAutoConfiguration
+public @interface SqsTest {
+
+	/**
+	 * Properties in form {@literal key=value} that should be added to the Spring
+	 * {@link Environment} before the test runs.
+	 * @return the properties to add
+	 * @since 2.1.0
+	 */
+	String[] properties() default {};
+
+	/**
+	 * A set of include filters which can be used to add otherwise filtered beans to the
+	 * application context.
+	 * @return include filters to apply
+	 */
+	ComponentScan.Filter[] includeFilters() default {};
+
+	/**
+	 * A set of exclude filters which can be used to filter beans that would otherwise be
+	 * added to the application context.
+	 * @return exclude filters to apply
+	 */
+	ComponentScan.Filter[] excludeFilters() default {};
+
+}

--- a/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTest.java
+++ b/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTest.java
@@ -26,9 +26,11 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.BootstrapWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -57,6 +59,34 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @AutoConfigureSqs
 @ImportAutoConfiguration
 public @interface SqsTest {
+
+	/**
+	 * Determines if default filtering should be used with
+	 * {@link SpringBootApplication @SpringBootApplication}. By default no beans are
+	 * included.
+	 * @see #includeFilters()
+	 * @see #excludeFilters()
+	 * @return if default filters should be used
+	 */
+	boolean useDefaultFilters() default true;
+
+	/**
+	 * Specifies the listeners to test. This is an alias of {@link #listeners()} which can
+	 * be used for brevity if no other attributes are defined. See {@link #listeners()}
+	 * for details.
+	 * @see #listeners()
+	 * @return the listeners to test
+	 */
+	@AliasFor("listeners")
+	Class<?>[] value() default {};
+
+	/**
+	 * Specifies the listeners to test.
+	 * @see #value()
+	 * @return the listeners to test
+	 */
+	@AliasFor("value")
+	Class<?>[] listeners() default {};
 
 	/**
 	 * Properties in form {@literal key=value} that should be added to the Spring

--- a/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTestContextBootstrapper.java
+++ b/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTestContextBootstrapper.java
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-package io.awspring.cloud.sqs.sample;
+package io.awspring.cloud.test.sqs;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTestContextBootstrapper;
+import org.springframework.core.annotation.MergedAnnotations;
 
-@SpringBootApplication
-public class SqsSampleApplication {
+public class SqsTestContextBootstrapper extends SpringBootTestContextBootstrapper {
 
-	public static void main(String[] args) {
-		SpringApplication.run(SqsSampleApplication.class, args);
+	@Override
+	protected String[] getProperties(Class<?> testClass) {
+		return MergedAnnotations.from(testClass, MergedAnnotations.SearchStrategy.INHERITED_ANNOTATIONS)
+				.get(SqsTest.class).getValue("properties", String[].class).orElse(null);
 	}
 
 }

--- a/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTestContextBootstrapper.java
+++ b/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTestContextBootstrapper.java
@@ -18,7 +18,14 @@ package io.awspring.cloud.test.sqs;
 
 import org.springframework.boot.test.context.SpringBootTestContextBootstrapper;
 import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.test.context.TestContextBootstrapper;
 
+/**
+ * {@link TestContextBootstrapper} for {@link SqsTest @SqsTest} support.
+ *
+ * @author Maciej Walkowiak
+ * @since 2.4.0
+ */
 public class SqsTestContextBootstrapper extends SpringBootTestContextBootstrapper {
 
 	@Override

--- a/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTypeExcludeFilter.java
+++ b/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTypeExcludeFilter.java
@@ -16,8 +16,15 @@
 
 package io.awspring.cloud.test.sqs;
 
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.test.autoconfigure.filter.StandardAnnotationCustomizableTypeExcludeFilter;
 
+/**
+ * {@link TypeExcludeFilter} for {@link SqsTest @SqsTest}.
+ *
+ * @author Maciej Walkowiak
+ * @since 2.4.0
+ */
 public class SqsTypeExcludeFilter extends StandardAnnotationCustomizableTypeExcludeFilter<SqsTest> {
 
 	SqsTypeExcludeFilter(Class<?> testClass) {

--- a/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTypeExcludeFilter.java
+++ b/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTypeExcludeFilter.java
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-package io.awspring.cloud.sqs.sample;
+package io.awspring.cloud.test.sqs;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.filter.StandardAnnotationCustomizableTypeExcludeFilter;
 
-@SpringBootApplication
-public class SqsSampleApplication {
+public class SqsTypeExcludeFilter extends StandardAnnotationCustomizableTypeExcludeFilter<SqsTest> {
 
-	public static void main(String[] args) {
-		SpringApplication.run(SqsSampleApplication.class, args);
+	SqsTypeExcludeFilter(Class<?> testClass) {
+		super(testClass);
 	}
 
 }

--- a/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTypeExcludeFilter.java
+++ b/spring-cloud-aws-test/src/main/java/io/awspring/cloud/test/sqs/SqsTypeExcludeFilter.java
@@ -16,6 +16,10 @@
 
 package io.awspring.cloud.test.sqs;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.test.autoconfigure.filter.StandardAnnotationCustomizableTypeExcludeFilter;
 
@@ -27,8 +31,18 @@ import org.springframework.boot.test.autoconfigure.filter.StandardAnnotationCust
  */
 public class SqsTypeExcludeFilter extends StandardAnnotationCustomizableTypeExcludeFilter<SqsTest> {
 
+	private static final Class<?>[] NO_LISTENERS = {};
+
+	private final Class<?>[] listeners;
+
 	SqsTypeExcludeFilter(Class<?> testClass) {
 		super(testClass);
+		this.listeners = getAnnotation().getValue("listeners", Class[].class).orElse(NO_LISTENERS);
+	}
+
+	@Override
+	protected Set<Class<?>> getComponentIncludes() {
+		return new LinkedHashSet<>(Arrays.asList(this.listeners));
 	}
 
 }

--- a/spring-cloud-aws-test/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-aws-test/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,5 @@
+io.awspring.cloud.test.sqs.AutoConfigureSqs=\
+org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration,\
+io.awspring.cloud.autoconfigure.messaging.SqsAutoConfiguration,\
+io.awspring.cloud.autoconfigure.context.ContextRegionProviderAutoConfiguration,\
+io.awspring.cloud.autoconfigure.context.ContextCredentialsAutoConfiguration

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/BaseSqsIntegrationTest.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/BaseSqsIntegrationTest.java
@@ -1,0 +1,36 @@
+package io.awspring.cloud.test.sqs;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import static io.awspring.cloud.test.sqs.SqsSampleListener.QUEUE_NAME;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
+
+@Testcontainers
+abstract class BaseSqsIntegrationTest {
+
+	@Container
+	static LocalStackContainer localstack = new LocalStackContainer(
+			DockerImageName.parse("localstack/localstack:0.14.0")).withServices(SQS).withReuse(true);
+
+	@BeforeAll
+	static void beforeAll() throws IOException, InterruptedException {
+		// create needed queues in SQS
+		localstack.execInContainer("awslocal", "sqs", "create-queue", "--queue-name", QUEUE_NAME);
+	}
+
+	@DynamicPropertySource
+	static void registerSqsProperties(DynamicPropertyRegistry registry) {
+		// overwrite SQS endpoint with one provided by Localstack
+		registry.add("cloud.aws.sqs.endpoint", () -> localstack.getEndpointOverride(SQS).toString());
+	}
+
+}

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/BaseSqsIntegrationTest.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/BaseSqsIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.awspring.cloud.test.sqs;
 
 import java.io.IOException;

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SampleComponent.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SampleComponent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.test.sqs;
+
+import org.springframework.stereotype.Component;
+
+@Component
+class SampleComponent {
+
+	void save(String message) {
+
+	}
+
+}

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsSampleListener.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsSampleListener.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.test.sqs;
+
+import io.awspring.cloud.messaging.listener.annotation.SqsListener;
+
+import org.springframework.stereotype.Component;
+
+@Component
+class SqsSampleListener {
+
+	static final String QUEUE_NAME = "my-queue";
+
+	private final SampleComponent sampleComponent;
+
+	SqsSampleListener(SampleComponent sampleComponent) {
+		this.sampleComponent = sampleComponent;
+	}
+
+	@SqsListener(QUEUE_NAME)
+	void handle(String message) {
+		sampleComponent.save(message);
+	}
+
+}

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestApplication.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.test.sqs;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SqsTestApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SqsTestApplication.class, args);
+	}
+
+}

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestApplication.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestApplication.java
@@ -19,6 +19,9 @@ package io.awspring.cloud.test.sqs;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * A sample application used in integration tests.
+ */
 @SpringBootApplication
 public class SqsTestApplication {
 

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestApplication.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestApplication.java
@@ -19,9 +19,6 @@ package io.awspring.cloud.test.sqs;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-/**
- * A sample application used in integration tests.
- */
 @SpringBootApplication
 public class SqsTestApplication {
 

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestListenersDefinedTest.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestListenersDefinedTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.test.sqs;
+
+import java.io.IOException;
+
+import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import static io.awspring.cloud.test.sqs.SqsSampleListener.QUEUE_NAME;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.verify;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
+
+@SqsTest(listeners = SqsSampleListener.class)
+@Testcontainers
+class SqsTestListenersDefinedTest {
+
+	@Container
+	static LocalStackContainer localstack = new LocalStackContainer(
+			DockerImageName.parse("localstack/localstack:0.14.0")).withServices(SQS).withReuse(true);
+
+	@Autowired
+	private ApplicationContext ctx;
+
+	@Autowired
+	private QueueMessagingTemplate queueMessagingTemplate;
+
+	@MockBean
+	private SampleComponent sampleComponent;
+
+	@BeforeAll
+	static void beforeAll() throws IOException, InterruptedException {
+		// create needed queues in SQS
+		localstack.execInContainer("awslocal", "sqs", "create-queue", "--queue-name", QUEUE_NAME);
+	}
+
+	@DynamicPropertySource
+	static void registerSqsProperties(DynamicPropertyRegistry registry) {
+		// overwrite SQS endpoint with one provided by Localstack
+		registry.add("cloud.aws.sqs.endpoint", () -> localstack.getEndpointOverride(SQS).toString());
+	}
+
+	@Test
+	void createsQueueMessagingTemplate() {
+		assertThatNoException().isThrownBy(() -> this.ctx.getBean(QueueMessagingTemplate.class));
+	}
+
+	@Test
+	void createsListener() {
+		assertThatNoException().isThrownBy(() -> this.ctx.getBean(SqsSampleListener.class));
+	}
+
+	@Test
+	void listenerHandlesMessage() {
+		queueMessagingTemplate.convertAndSend(QUEUE_NAME, "message");
+
+		await().untilAsserted(() -> verify(sampleComponent).save("message"));
+	}
+
+}

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestListenersDefinedTest.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestListenersDefinedTest.java
@@ -38,7 +38,8 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.verify;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
 
-@SqsTest(listeners = SqsSampleListener.class)
+@SqsTest(listeners = SqsSampleListener.class,
+		properties = { "cloud.aws.credentials.access-key=noop", "cloud.aws.credentials.secret-key=noop" })
 @Testcontainers
 class SqsTestListenersDefinedTest {
 

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestListenersDefinedTest.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestListenersDefinedTest.java
@@ -38,8 +38,8 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.verify;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
 
-@SqsTest(listeners = SqsSampleListener.class,
-		properties = { "cloud.aws.credentials.access-key=noop", "cloud.aws.credentials.secret-key=noop" })
+@SqsTest(listeners = SqsSampleListener.class, properties = { "cloud.aws.credentials.access-key=noop",
+		"cloud.aws.credentials.secret-key=noop", "cloud.aws.region.static-region=eu-west-1" })
 @Testcontainers
 class SqsTestListenersDefinedTest {
 

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestListenersDefinedTest.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestListenersDefinedTest.java
@@ -16,36 +16,21 @@
 
 package io.awspring.cloud.test.sqs;
 
-import java.io.IOException;
-
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 import static io.awspring.cloud.test.sqs.SqsSampleListener.QUEUE_NAME;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.verify;
-import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
 
 @SqsTest(listeners = SqsSampleListener.class, properties = { "cloud.aws.credentials.access-key=noop",
 		"cloud.aws.credentials.secret-key=noop", "cloud.aws.region.static=eu-west-1" })
-@Testcontainers
-class SqsTestListenersDefinedTest {
-
-	@Container
-	static LocalStackContainer localstack = new LocalStackContainer(
-			DockerImageName.parse("localstack/localstack:0.14.0")).withServices(SQS).withReuse(true);
+class SqsTestListenersDefinedTest extends BaseSqsIntegrationTest {
 
 	@Autowired
 	private ApplicationContext ctx;
@@ -55,18 +40,6 @@ class SqsTestListenersDefinedTest {
 
 	@MockBean
 	private SampleComponent sampleComponent;
-
-	@BeforeAll
-	static void beforeAll() throws IOException, InterruptedException {
-		// create needed queues in SQS
-		localstack.execInContainer("awslocal", "sqs", "create-queue", "--queue-name", QUEUE_NAME);
-	}
-
-	@DynamicPropertySource
-	static void registerSqsProperties(DynamicPropertyRegistry registry) {
-		// overwrite SQS endpoint with one provided by Localstack
-		registry.add("cloud.aws.sqs.endpoint", () -> localstack.getEndpointOverride(SQS).toString());
-	}
 
 	@Test
 	void createsQueueMessagingTemplate() {

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestListenersDefinedTest.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestListenersDefinedTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.verify;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
 
 @SqsTest(listeners = SqsSampleListener.class, properties = { "cloud.aws.credentials.access-key=noop",
-		"cloud.aws.credentials.secret-key=noop", "cloud.aws.region.static-region=eu-west-1" })
+		"cloud.aws.credentials.secret-key=noop", "cloud.aws.region.static=eu-west-1" })
 @Testcontainers
 class SqsTestListenersDefinedTest {
 

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestNoListenersDefinedTest.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestNoListenersDefinedTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SqsTest
-class SqsTestNoListenersDefinedTest {
+class SqsTestNoListenersDefinedTest extends BaseSqsIntegrationTest {
 
 	private static final Class<?>[] EXPECTED_AUTOCONFIGURATION_CLASSES = { SqsAutoConfiguration.class,
 			JacksonAutoConfiguration.class, ContextRegionProviderAutoConfiguration.class,

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestNoListenersDefinedTest.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestNoListenersDefinedTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.test.sqs;
+
+import io.awspring.cloud.autoconfigure.context.ContextCredentialsAutoConfiguration;
+import io.awspring.cloud.autoconfigure.context.ContextRegionProviderAutoConfiguration;
+import io.awspring.cloud.autoconfigure.messaging.SqsAutoConfiguration;
+import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SqsTest
+class SqsTestNoListenersDefinedTest {
+
+	private static final Class<?>[] EXPECTED_AUTOCONFIGURATION_CLASSES = { SqsAutoConfiguration.class,
+			JacksonAutoConfiguration.class, ContextRegionProviderAutoConfiguration.class,
+			ContextCredentialsAutoConfiguration.class };
+
+	@Autowired
+	private ApplicationContext ctx;
+
+	@Test
+	void usesAutoConfigurations() {
+		for (Class<?> clazz : EXPECTED_AUTOCONFIGURATION_CLASSES) {
+			assertThatNoException().isThrownBy(() -> this.ctx.getBean(clazz));
+		}
+	}
+
+	@Test
+	void createsQueueMessagingTemplate() {
+		assertThatNoException().isThrownBy(() -> this.ctx.getBean(QueueMessagingTemplate.class));
+	}
+
+	@Test
+	void doesNotCreateListenerBean() {
+		assertThatThrownBy(() -> this.ctx.getBean(SqsSampleListener.class))
+				.isInstanceOf(NoSuchBeanDefinitionException.class);
+	}
+
+	@Test
+	void doesNotCreateOtherBeans() {
+		assertThatThrownBy(() -> this.ctx.getBean(SampleComponent.class))
+				.isInstanceOf(NoSuchBeanDefinitionException.class);
+	}
+
+}

--- a/spring-cloud-aws-test/src/test/resources/logback-test.xml
+++ b/spring-cloud-aws-test/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="INFO">
+		<appender-ref ref="STDOUT"/>
+	</root>
+
+	<logger name="org.testcontainers" level="INFO"/>
+	<logger name="com.github.dockerjava" level="WARN"/>
+	<logger name="io.awspring" level="INFO"/>
+</configuration>


### PR DESCRIPTION
Adds `spring-cloud-aws-test` module containing `@SqsTest` that simplifies testing SQS listeners. Also brings Testcontainers to the project and updates sample to use Testcontainers and `@SqsTest`.