### PR TITLE
Force Spring Boot 2.6.3 in integration tests.

### DIFF
--- a/spring-cloud-aws-integration-test/pom.xml
+++ b/spring-cloud-aws-integration-test/pom.xml
@@ -29,6 +29,22 @@
 	<name>Spring Cloud AWS Integration Tests</name>
 	<description>Spring Cloud AWS Integration Tests</description>
 
+	<!--
+	force 2.6.3 version instead of one resolved by spring-cloud-build.
+	perhaps there is a better place to do it
+	-->
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>2.6.3</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>io.awspring.cloud</groupId>


### PR DESCRIPTION
... instead of one resolved by spring-cloud-build.

**Motivation**

Spring Boot 2.6.1 contains a bug (https://github.com/spring-projects/spring-boot/commit/2fec06ac7ebfe99f545e63c13bc9c294e24e85cf) which causes SPEL resolution in `@EnableRdsInstance` to fail.