### PR TITLE
Adds array properties support to parameter store. (#245)

### DIFF
--- a/docs/src/main/asciidoc/parameter-store.adoc
+++ b/docs/src/main/asciidoc/parameter-store.adoc
@@ -38,6 +38,10 @@ Can be overridden with a service-specific property.
 |`/config/my-service_production/cloud/aws/stack/auto`
 |`cloud.aws.stack.auto`
 |Specific to the `my-service` service when a `production` Spring profile is activated.
+
+|`/config/application/cloud.aws.stack_0_.name`
+|`cloud.aws.stack[0].name`
+|Array indexes for lists properties are denoted by `_INDEX_`.
 |===
 
 Note that this module does not support full configuration files to be used as parameter values like e.g. Spring Cloud

--- a/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySource.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStorePropertySource.java
@@ -18,7 +18,6 @@ package io.awspring.cloud.paramstore;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
 import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest;
@@ -58,8 +57,7 @@ public class AwsParamStorePropertySource extends EnumerablePropertySource<AWSSim
 
 	@Override
 	public String[] getPropertyNames() {
-		Set<String> strings = this.properties.keySet();
-		return strings.toArray(new String[strings.size()]);
+		return this.properties.keySet().stream().toArray(String[]::new);
 	}
 
 	@Override
@@ -70,7 +68,7 @@ public class AwsParamStorePropertySource extends EnumerablePropertySource<AWSSim
 	private void getParameters(GetParametersByPathRequest paramsRequest) {
 		GetParametersByPathResult paramsResult = this.source.getParametersByPath(paramsRequest);
 		for (Parameter parameter : paramsResult.getParameters()) {
-			String key = parameter.getName().replace(this.context, "").replace('/', '.');
+			String key = parameter.getName().replace(this.context, "").replace('/', '.').replaceAll("_(\\d)_", "[$1]");
 			LOG.debug("Populating property retrieved from AWS Parameter Store: " + key);
 			this.properties.put(key, parameter.getValue());
 		}

--- a/spring-cloud-aws-samples/spring-cloud-aws-parameter-store-sample/infrastructure/lib/infrastructure-stack.ts
+++ b/spring-cloud-aws-samples/spring-cloud-aws-parameter-store-sample/infrastructure/lib/infrastructure-stack.ts
@@ -9,5 +9,15 @@ export class InfrastructureStack extends cdk.Stack {
 		  parameterName: '/config/spring/message',
 		  stringValue: 'Spring-cloud-aws value!'
 	  });
+
+	  new ssm.StringParameter(this, 'Parameter2', {
+		  parameterName: '/config/spring/messages_0_',
+		  stringValue: 'Spring-cloud-aws msg0!'
+	  });
+
+	  new ssm.StringParameter(this, 'Parameter3', {
+		  parameterName: '/config/spring/messages_1_',
+		  stringValue: 'Spring-cloud-aws msg1!'
+	  });
   }
 }

--- a/spring-cloud-aws-samples/spring-cloud-aws-parameter-store-sample/src/main/java/io/awspring/cloud/parameterstore/sample/SpringCloudAwsParameterStoreSample.java
+++ b/spring-cloud-aws-samples/spring-cloud-aws-parameter-store-sample/src/main/java/io/awspring/cloud/parameterstore/sample/SpringCloudAwsParameterStoreSample.java
@@ -35,10 +35,10 @@ public class SpringCloudAwsParameterStoreSample {
 	}
 
 	@Bean
-	ApplicationRunner applicationRunner(@Value("${message}") String message) {
-		return args -> {
-			LOGGER.info("`message` loaded from the AWS Parameter store: {}", message);
-		};
+	ApplicationRunner applicationRunner(@Value("${message}") String message, @Value("${messages[0]}") String msg1,
+			@Value("${messages[1]}") String msg2) {
+		return args -> LOGGER.info("`messages` loaded from the AWS Parameter store: {}, {} and {}", message, msg1,
+				msg2);
 	}
 
 }

--- a/spring-cloud-starter-aws-parameter-store-config/pom.xml
+++ b/spring-cloud-starter-aws-parameter-store-config/pom.xml
@@ -45,5 +45,17 @@
 			<groupId>io.awspring.cloud</groupId>
 			<artifactId>spring-cloud-aws-core</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>localstack</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-starter-aws-parameter-store-config/src/test/java/io/awspring/cloud/autoconfigure/paramstore/ParameterStoreConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/test/java/io/awspring/cloud/autoconfigure/paramstore/ParameterStoreConfigDataLoaderIntegrationTests.java
@@ -18,6 +18,7 @@ package io.awspring.cloud.autoconfigure.paramstore;
 
 import java.io.IOException;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.localstack.LocalStackContainer;
@@ -45,14 +46,24 @@ class ParameterStoreConfigDataLoaderIntegrationTests {
 
 	private static final String REGION = "us-east-1";
 
+	private static final String AWS_ACCESS_KEY_ID = "aws.accessKeyId";
+
+	private static final String AWS_SECRET_KEY = "aws.secretKey";
+
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
 			DockerImageName.parse("localstack/localstack:0.14.0")).withServices(SSM).withReuse(true);
 
 	@BeforeAll
 	public static void setUpCredentials() {
-		System.setProperty("aws.accessKeyId", "accesskey");
-		System.setProperty("aws.secretKey", "secretkey");
+		System.setProperty(AWS_ACCESS_KEY_ID, "accesskey");
+		System.setProperty(AWS_SECRET_KEY, "secretkey");
+	}
+
+	@AfterAll
+	public static void cleanUpCredentials() {
+		System.clearProperty(AWS_ACCESS_KEY_ID);
+		System.clearProperty(AWS_SECRET_KEY);
 	}
 
 	@Test

--- a/spring-cloud-starter-aws-parameter-store-config/src/test/java/io/awspring/cloud/autoconfigure/paramstore/ParameterStoreConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/test/java/io/awspring/cloud/autoconfigure/paramstore/ParameterStoreConfigDataLoaderIntegrationTests.java
@@ -16,6 +16,8 @@
 
 package io.awspring.cloud.autoconfigure.paramstore;
 
+import java.io.IOException;
+
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -26,8 +28,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
-
-import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SSM;

--- a/spring-cloud-starter-aws-parameter-store-config/src/test/java/io/awspring/cloud/autoconfigure/paramstore/ParameterStoreConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/test/java/io/awspring/cloud/autoconfigure/paramstore/ParameterStoreConfigDataLoaderIntegrationTests.java
@@ -18,6 +18,7 @@ package io.awspring.cloud.autoconfigure.paramstore;
 
 import java.io.IOException;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -47,6 +48,12 @@ class ParameterStoreConfigDataLoaderIntegrationTests {
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
 			DockerImageName.parse("localstack/localstack:0.14.0")).withServices(SSM).withReuse(true);
+
+	@BeforeAll
+	public static void setUpCredentials() {
+		System.setProperty("aws.accessKeyId", "accesskey");
+		System.setProperty("aws.secretKey", "secretkey");
+	}
 
 	@Test
 	void followsNextToken() {

--- a/spring-cloud-starter-aws-parameter-store-config/src/test/java/io/awspring/cloud/autoconfigure/paramstore/ParameterStoreConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/test/java/io/awspring/cloud/autoconfigure/paramstore/ParameterStoreConfigDataLoaderIntegrationTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.autoconfigure.paramstore;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SSM;
+
+/**
+ * Integration tests for loading configuration properties as List from AWS Parameter
+ * Store.
+ *
+ * @author Maciej Walkowiak
+ * @author Matej Nedić
+ */
+@Testcontainers
+class ParameterStoreConfigDataLoaderIntegrationTests {
+
+	private static final String REGION = "us-east-1";
+
+	@Container
+	static LocalStackContainer localstack = new LocalStackContainer(
+			DockerImageName.parse("localstack/localstack:0.14.0")).withServices(SSM).withReuse(true);
+
+	@Test
+	void followsNextToken() {
+		SpringApplication application = new SpringApplication(App.class);
+		application.setWebApplicationType(WebApplicationType.NONE);
+		putParameter(localstack, "/config/myservice/key1", "value1", REGION);
+		putParameter(localstack, "/config/myservice/key2", "value2", REGION);
+		putParameter(localstack, "/config/myservice/key3", "value3", REGION);
+		putParameter(localstack, "/config/myservice/key4", "value4", REGION);
+
+		try (ConfigurableApplicationContext context = runApplication(application,
+				"aws-parameterstore:/config/myservice/")) {
+			assertThat(context.getEnvironment().getProperty("key1")).isEqualTo("value1");
+			assertThat(context.getEnvironment().getProperty("key2")).isEqualTo("value2");
+			assertThat(context.getEnvironment().getProperty("key3")).isEqualTo("value3");
+			assertThat(context.getEnvironment().getProperty("key4")).isEqualTo("value4");
+		}
+	}
+
+	@Test
+	void arrayParameterNames() {
+		SpringApplication application = new SpringApplication(App.class);
+		application.setWebApplicationType(WebApplicationType.NONE);
+
+		putParameter(localstack, "/config/myservice/key_0_.value", "value1", REGION);
+		putParameter(localstack, "/config/myservice/key_0_.nested_0_.nestedValue", "key_nestedValue1", REGION);
+		putParameter(localstack, "/config/myservice/key_0_.nested_1_.nestedValue", "key_nestedValue2", REGION);
+		putParameter(localstack, "/config/myservice/key_1_.value", "value2", REGION);
+		putParameter(localstack, "/config/myservice/key_1_.nested_0_.nestedValue", "key_nestedValue3", REGION);
+		putParameter(localstack, "/config/myservice/key_1_.nested_1_.nestedValue", "key_nestedValue4", REGION);
+
+		try (ConfigurableApplicationContext context = runApplication(application,
+				"aws-parameterstore:/config/myservice/")) {
+			assertThat(context.getEnvironment().getProperty("key[0].value")).isEqualTo("value1");
+			assertThat(context.getEnvironment().getProperty("key[0].nested[0].nestedValue"))
+					.isEqualTo("key_nestedValue1");
+			assertThat(context.getEnvironment().getProperty("key[0].nested[1].nestedValue"))
+					.isEqualTo("key_nestedValue2");
+			assertThat(context.getEnvironment().getProperty("key[1].value")).isEqualTo("value2");
+			assertThat(context.getEnvironment().getProperty("key[1].nested[0].nestedValue"))
+					.isEqualTo("key_nestedValue3");
+			assertThat(context.getEnvironment().getProperty("key[1].nested[1].nestedValue"))
+					.isEqualTo("key_nestedValue4");
+		}
+	}
+
+	private ConfigurableApplicationContext runApplication(SpringApplication application, String springConfigImport) {
+		return application.run("--spring.config.import=" + springConfigImport,
+				"--aws.paramstore.endpoint=" + localstack.getEndpointOverride(SSM).toString(),
+				"--cloud.aws.credentials.accessKey=noop", "--cloud.aws.credentials.secretKey=noop");
+	}
+
+	private static void putParameter(LocalStackContainer localstack, String parameterName, String parameterValue,
+			String region) {
+		try {
+			localstack.execInContainer("awslocal", "ssm", "put-parameter", "--name", parameterName, "--type", "String",
+					"--value", parameterValue, "--region", region);
+		}
+		catch (IOException | InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@SpringBootApplication
+	static class App {
+
+	}
+
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

This is a draft PR, the approach still needs to be discussed. Right now it's replacing the property names that follow the format `_INDEX_`  by `[INDEX]`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The main idea is to be able to represent array properties in aws parameter store params names, details in #245 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes - ~It can break applications that have `_ANY INTEGER_` pattern in their parameter store param names~ It shouldn't break any existing apps as we changed only the internal representation of how we store list properties.


## :crystal_ball: Next steps
