### PR TITLE
Configure signing region when endpoint is overwritten.

### DIFF
--- a/spring-cloud-aws-core/src/test/java/io/awspring/cloud/core/config/AmazonTestWebserviceClient.java
+++ b/spring-cloud-aws-core/src/test/java/io/awspring/cloud/core/config/AmazonTestWebserviceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,14 @@
 
 package io.awspring.cloud.core.config;
 
+import java.net.URI;
+
 import com.amazonaws.AmazonWebServiceClient;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.regions.Region;
 import io.awspring.cloud.core.SpringCloudClientConfiguration;
+
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.springframework.util.Assert.notNull;
 
@@ -46,6 +50,18 @@ class AmazonTestWebserviceClient extends AmazonWebServiceClient {
 	@Override
 	public void setRegion(Region region) {
 		this.region = region;
+	}
+
+	public String getSigningRegion() {
+		return super.getSigningRegion();
+	}
+
+	public URI getEndpoint() {
+		return (URI) ReflectionTestUtils.getField(this, "endpoint");
+	}
+
+	public boolean isEndpointOverridden() {
+		return isEndpointOverridden;
 	}
 
 }

--- a/spring-cloud-aws-core/src/test/java/io/awspring/cloud/core/config/AmazonWebserviceClientFactoryBeanTest.java
+++ b/spring-cloud-aws-core/src/test/java/io/awspring/cloud/core/config/AmazonWebserviceClientFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package io.awspring.cloud.core.config;
+
+import java.net.URI;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -80,7 +82,26 @@ class AmazonWebserviceClientFactoryBeanTest {
 
 		// Assert
 		assertThat(webserviceClient.getClientConfiguration().getUserAgentSuffix()).startsWith("spring-cloud-aws/");
+	}
 
+	@Test
+	void getObject_withCustomEndpointAndStaticRegion() throws Exception {
+		// Arrange
+		AmazonWebserviceClientFactoryBean<AmazonTestWebserviceClient> factoryBean = new AmazonWebserviceClientFactoryBean<>(
+				AmazonTestWebserviceClient.class,
+				new AWSStaticCredentialsProvider(new BasicAWSCredentials("aaa", "bbb")));
+		factoryBean.setRegionProvider(new StaticRegionProvider("us-east-2"));
+		URI customEndpoint = URI.create("http://localhost:8080");
+		factoryBean.setCustomEndpoint(customEndpoint);
+
+		// Act
+		factoryBean.afterPropertiesSet();
+		AmazonTestWebserviceClient webserviceClient = factoryBean.getObject();
+
+		// Assert
+		assertThat(webserviceClient.isEndpointOverridden()).isTrue();
+		assertThat(webserviceClient.getEndpoint()).isEqualTo(customEndpoint);
+		assertThat(webserviceClient.getSigningRegion()).isEqualTo("us-east-2");
 	}
 
 }

--- a/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/test/java/io/awspring/cloud/sqs/sample/SqsSampleApplicationTests.java
+++ b/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/test/java/io/awspring/cloud/sqs/sample/SqsSampleApplicationTests.java
@@ -36,8 +36,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.verify;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
 
-@SqsTest(properties = { "cloud.aws.credentials.access-key=noop", "cloud.aws.credentials.secret-key=noop",
-		"cloud.aws.region.static=eu-west-1" })
+@SqsTest(properties = { "cloud.aws.credentials.access-key=noop", "cloud.aws.credentials.secret-key=noop" })
 @Testcontainers
 class SqsSampleApplicationTests {
 

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/BaseSqsIntegrationTest.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/BaseSqsIntegrationTest.java
@@ -40,7 +40,8 @@ abstract class BaseSqsIntegrationTest {
 	@BeforeAll
 	static void beforeAll() throws IOException, InterruptedException {
 		// create needed queues in SQS
-		localstack.execInContainer("awslocal", "sqs", "create-queue", "--queue-name", QUEUE_NAME);
+		localstack.execInContainer("awslocal", "sqs", "create-queue", "--queue-name", QUEUE_NAME, "--region",
+				"us-east-2");
 	}
 
 	@DynamicPropertySource

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestListenersDefinedTest.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/SqsTestListenersDefinedTest.java
@@ -29,7 +29,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.verify;
 
 @SqsTest(listeners = SqsSampleListener.class, properties = { "cloud.aws.credentials.access-key=noop",
-		"cloud.aws.credentials.secret-key=noop", "cloud.aws.region.static=eu-west-1" })
+		"cloud.aws.credentials.secret-key=noop", "cloud.aws.region.static=us-east-2" })
 class SqsTestListenersDefinedTest extends BaseSqsIntegrationTest {
 
 	@Autowired


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

When endpoint is overwritten, sets a signing region. Made primarily for Localstack compatibility after Localstack introduced multi-region support.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#202