### PR TITLE
Add Makefile for common tasks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: format build
+
+format:
+	mvnd spring-javaformat:apply
+
+build:
+	mvnd spring-javaformat:apply verify
+
+clean:
+	mvnd clean


### PR DESCRIPTION
To simplify development for contributors, added `Makefile` with common tasks. 

It also encourages using [mvnd](https://github.com/apache/maven-mvnd).

CI should continue executing tasks with Maven Wrapper.