### PR TITLE
Add nullability annotations.

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/AwsClientProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/AwsClientProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package io.awspring.cloud.autoconfigure;
 
 import java.net.URI;
 
+import org.springframework.lang.Nullable;
+
 /**
  * Base properties for AWS Service client.
  *
@@ -28,13 +30,16 @@ public abstract class AwsClientProperties {
 	/**
 	 * Overrides the default endpoint.
 	 */
+	@Nullable
 	private URI endpoint;
 
 	/**
 	 * Overrides the default region.
 	 */
+	@Nullable
 	private String region;
 
+	@Nullable
 	public URI getEndpoint() {
 		return endpoint;
 	}
@@ -43,6 +48,7 @@ public abstract class AwsClientProperties {
 		this.endpoint = endpoint;
 	}
 
+	@Nullable
 	public String getRegion() {
 		return region;
 	}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/package-info.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/package-info.java
@@ -14,46 +14,10 @@
  * limitations under the License.
  */
 
-package io.awspring.cloud.autoconfigure.core;
-
-import org.springframework.lang.Nullable;
-
 /**
- * Properties related to AWS Profile.
- *
- * @author Tom Gianos
- * @author Siva Katamreddy
+ * {@link org.springframework.boot.context.config.ConfigDataLoader} implementations for
+ * AWS services.
  */
-public class Profile {
-
-	/**
-	 * Profile name.
-	 */
-	@Nullable
-	private String name;
-
-	/**
-	 * Profile file path.
-	 */
-	@Nullable
-	private String path;
-
-	@Nullable
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	@Nullable
-	public String getPath() {
-		return path;
-	}
-
-	public void setPath(String path) {
-		this.path = path;
-	}
-
-}
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package io.awspring.cloud.autoconfigure.config;

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoader.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.boot.context.config.ConfigDataLoader;
 import org.springframework.boot.context.config.ConfigDataLoaderContext;
 import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
 import org.springframework.boot.logging.DeferredLogFactory;
+import org.springframework.lang.Nullable;
 
 /**
  * {@link ConfigDataLoader} for AWS Parameter Store.
@@ -44,6 +45,7 @@ public class ParameterStoreConfigDataLoader implements ConfigDataLoader<Paramete
 	}
 
 	@Override
+	@Nullable
 	public ConfigData load(ConfigDataLoaderContext context, ParameterStoreConfigDataResource resource) {
 		try {
 			SsmClient ssm = context.getBootstrapContext().get(SsmClient.class);

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStorePropertySources.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStorePropertySources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import software.amazon.awssdk.services.ssm.SsmClient;
 
+import org.springframework.lang.Nullable;
+
 /**
  * @author Eddú Meléndez
  * @since 2.3
@@ -38,6 +40,7 @@ public class ParameterStorePropertySources {
 	 * @return a property source or null if parameter could not be loaded and optional is
 	 * set to true
 	 */
+	@Nullable
 	public ParameterStorePropertySource createPropertySource(String context, boolean optional, SsmClient client) {
 		LOG.info("Loading property from AWS Parameter Store with name: " + context + ", optional: " + optional);
 		try {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/package-info.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/package-info.java
@@ -14,46 +14,10 @@
  * limitations under the License.
  */
 
-package io.awspring.cloud.autoconfigure.core;
-
-import org.springframework.lang.Nullable;
-
 /**
- * Properties related to AWS Profile.
- *
- * @author Tom Gianos
- * @author Siva Katamreddy
+ * {@link org.springframework.boot.context.config.ConfigDataLoader} implementation for AWS
+ * Parameter Store.
  */
-public class Profile {
-
-	/**
-	 * Profile name.
-	 */
-	@Nullable
-	private String name;
-
-	/**
-	 * Profile file path.
-	 */
-	@Nullable
-	private String path;
-
-	@Nullable
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	@Nullable
-	public String getPath() {
-		return path;
-	}
-
-	public void setPath(String path) {
-		this.path = path;
-	}
-
-}
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package io.awspring.cloud.autoconfigure.config.parameterstore;

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoader.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.boot.context.config.ConfigDataLoader;
 import org.springframework.boot.context.config.ConfigDataLoaderContext;
 import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
 import org.springframework.boot.logging.DeferredLogFactory;
+import org.springframework.lang.Nullable;
 
 /**
  * Loads config data from AWS Secret Manager.
@@ -45,6 +46,7 @@ public class SecretsManagerConfigDataLoader implements ConfigDataLoader<SecretsM
 	}
 
 	@Override
+	@Nullable
 	public ConfigData load(ConfigDataLoaderContext context, SecretsManagerConfigDataResource resource) {
 		try {
 			SecretsManagerClient sm = context.getBootstrapContext().get(SecretsManagerClient.class);

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerPropertySources.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerPropertySources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
+import org.springframework.lang.Nullable;
+
 /**
  * Provides prefix config import support.
  *
@@ -41,6 +43,7 @@ public class SecretsManagerPropertySources {
 	 * @return a property source or null if secret could not be loaded and optional is set
 	 * to true
 	 */
+	@Nullable
 	public SecretsManagerPropertySource createPropertySource(String context, boolean optional,
 			SecretsManagerClient client) {
 		LOG.info("Loading secrets from AWS Secret Manager secret with name: " + context + ", optional: " + optional);

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/package-info.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/package-info.java
@@ -14,46 +14,10 @@
  * limitations under the License.
  */
 
-package io.awspring.cloud.autoconfigure.core;
-
-import org.springframework.lang.Nullable;
-
 /**
- * Properties related to AWS Profile.
- *
- * @author Tom Gianos
- * @author Siva Katamreddy
+ * {@link org.springframework.boot.context.config.ConfigDataLoader} implementation for AWS
+ * Secrets Manager.
  */
-public class Profile {
-
-	/**
-	 * Profile name.
-	 */
-	@Nullable
-	private String name;
-
-	/**
-	 * Profile file path.
-	 */
-	@Nullable
-	private String path;
-
-	@Nullable
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	@Nullable
-	public String getPath() {
-		return path;
-	}
-
-	public void setPath(String path) {
-		this.path = path;
-	}
-
-}
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package io.awspring.cloud.autoconfigure.config.secretsmanager;

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.awspring.cloud.autoconfigure.core;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.lang.Nullable;
 
 /**
  * Properties related to AWS credentials.
@@ -35,11 +36,13 @@ public class CredentialsProperties {
 	/**
 	 * The access key to be used with a static provider.
 	 */
+	@Nullable
 	private String accessKey;
 
 	/**
 	 * The secret key to be used with a static provider.
 	 */
+	@Nullable
 	private String secretKey;
 
 	/**
@@ -50,8 +53,10 @@ public class CredentialsProperties {
 	/**
 	 * The AWS profile.
 	 */
+	@Nullable
 	private Profile profile;
 
+	@Nullable
 	public String getAccessKey() {
 		return this.accessKey;
 	}
@@ -60,6 +65,7 @@ public class CredentialsProperties {
 		this.accessKey = accessKey;
 	}
 
+	@Nullable
 	public String getSecretKey() {
 		return this.secretKey;
 	}
@@ -76,6 +82,7 @@ public class CredentialsProperties {
 		this.instanceProfile = instanceProfile;
 	}
 
+	@Nullable
 	public Profile getProfile() {
 		return profile;
 	}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProviderAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public class CredentialsProviderAutoConfiguration {
 
 		Profile profile = properties.getProfile();
 		if (profile != null && profile.getName() != null) {
-			providers.add(createProfileCredentialProvider(properties));
+			providers.add(createProfileCredentialProvider(profile));
 		}
 
 		if (providers.isEmpty()) {
@@ -87,8 +87,7 @@ public class CredentialsProviderAutoConfiguration {
 				.create(AwsBasicCredentials.create(properties.getAccessKey(), properties.getSecretKey()));
 	}
 
-	private static ProfileCredentialsProvider createProfileCredentialProvider(CredentialsProperties properties) {
-		Profile profile = properties.getProfile();
+	private static ProfileCredentialsProvider createProfileCredentialProvider(Profile profile) {
 		ProfileFile credentialProfileFile = ProfileFile.builder().type(ProfileFile.Type.CREDENTIALS)
 				.content(Paths.get(profile.getPath())).build();
 		ProfileFile defaultProfileFile = ProfileFile.defaultProfileFile();

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/RegionProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/RegionProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.awspring.cloud.autoconfigure.core;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
 /**
@@ -40,6 +41,7 @@ public class RegionProperties {
 	 * ap-southeast-1, ap-northeast-1, sa-east-1, cn-north-1 and any custom region
 	 * configured with own region meta data.
 	 */
+	@Nullable
 	private String staticRegion;
 
 	/**
@@ -50,8 +52,10 @@ public class RegionProperties {
 	/**
 	 * The AWS profile.
 	 */
+	@Nullable
 	private Profile profile;
 
+	@Nullable
 	public Profile getProfile() {
 		return profile;
 	}
@@ -60,6 +64,7 @@ public class RegionProperties {
 		this.profile = profile;
 	}
 
+	@Nullable
 	public String getStatic() {
 		return this.staticRegion;
 	}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/RegionProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/RegionProviderAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ public class RegionProviderAutoConfiguration {
 	public AwsRegionProvider regionProvider() {
 		final List<AwsRegionProvider> providers = new ArrayList<>();
 
-		if (this.properties.isStatic()) {
+		if (this.properties.getStatic() != null && this.properties.isStatic()) {
 			providers.add(new StaticRegionProvider(this.properties.getStatic()));
 		}
 
@@ -66,7 +66,7 @@ public class RegionProviderAutoConfiguration {
 
 		Profile profile = this.properties.getProfile();
 		if (profile != null && profile.getName() != null) {
-			providers.add(createProfileRegionProvider());
+			providers.add(createProfileRegionProvider(profile));
 		}
 
 		if (providers.isEmpty()) {
@@ -77,13 +77,15 @@ public class RegionProviderAutoConfiguration {
 		}
 	}
 
-	private AwsProfileRegionProvider createProfileRegionProvider() {
-		Profile profile = this.properties.getProfile();
+	private AwsProfileRegionProvider createProfileRegionProvider(Profile profile) {
 		Supplier<ProfileFile> profileFileFn = () -> {
-			ProfileFile profileFile = ProfileFile.builder().type(ProfileFile.Type.CONFIGURATION)
-					.content(Paths.get(profile.getPath())).build();
-			ProfileFile defaultProfileFile = ProfileFile.defaultProfileFile();
-			return profile.getPath() != null ? profileFile : defaultProfileFile;
+			if (profile.getPath() != null) {
+				return ProfileFile.builder().type(ProfileFile.Type.CONFIGURATION).content(Paths.get(profile.getPath()))
+						.build();
+			}
+			else {
+				return ProfileFile.defaultProfileFile();
+			}
 		};
 		return new AwsProfileRegionProvider(profileFileFn, profile.getName());
 	}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/package-info.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/package-info.java
@@ -14,46 +14,11 @@
  * limitations under the License.
  */
 
-package io.awspring.cloud.autoconfigure.core;
-
-import org.springframework.lang.Nullable;
-
 /**
- * Properties related to AWS Profile.
- *
- * @author Tom Gianos
- * @author Siva Katamreddy
+ * Auto-configurations for core Spring Cloud AWS components -
+ * {@link software.amazon.awssdk.auth.credentials.AwsCredentialsProvider} and
+ * {@link software.amazon.awssdk.regions.providers.AwsRegionProvider}.
  */
-public class Profile {
-
-	/**
-	 * Profile name.
-	 */
-	@Nullable
-	private String name;
-
-	/**
-	 * Profile file path.
-	 */
-	@Nullable
-	private String path;
-
-	@Nullable
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	@Nullable
-	public String getPath() {
-		return path;
-	}
-
-	public void setPath(String path) {
-		this.path = path;
-	}
-
-}
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package io.awspring.cloud.autoconfigure.core;

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/package-info.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/package-info.java
@@ -14,46 +14,9 @@
  * limitations under the License.
  */
 
-package io.awspring.cloud.autoconfigure.core;
-
-import org.springframework.lang.Nullable;
-
 /**
- * Properties related to AWS Profile.
- *
- * @author Tom Gianos
- * @author Siva Katamreddy
+ * Auto-configurations for AWS services integrations.
  */
-public class Profile {
-
-	/**
-	 * Profile name.
-	 */
-	@Nullable
-	private String name;
-
-	/**
-	 * Profile file path.
-	 */
-	@Nullable
-	private String path;
-
-	@Nullable
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	@Nullable
-	public String getPath() {
-		return path;
-	}
-
-	public void setPath(String path) {
-		this.path = path;
-	}
-
-}
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package io.awspring.cloud.autoconfigure;

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/package-info.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/package-info.java
@@ -14,46 +14,9 @@
  * limitations under the License.
  */
 
-package io.awspring.cloud.autoconfigure.core;
-
-import org.springframework.lang.Nullable;
-
 /**
- * Properties related to AWS Profile.
- *
- * @author Tom Gianos
- * @author Siva Katamreddy
+ * Auto-configuration for Amazon SES (Simple Email Service) integrations.
  */
-public class Profile {
-
-	/**
-	 * Profile name.
-	 */
-	@Nullable
-	private String name;
-
-	/**
-	 * Profile file path.
-	 */
-	@Nullable
-	private String path;
-
-	@Nullable
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	@Nullable
-	public String getPath() {
-		return path;
-	}
-
-	public void setPath(String path) {
-		this.path = path;
-	}
-
-}
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package io.awspring.cloud.autoconfigure.ses;

--- a/spring-cloud-aws-core/pom.xml
+++ b/spring-cloud-aws-core/pom.xml
@@ -34,5 +34,9 @@
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>regions</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-core</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-aws-core/src/main/java/io/awspring/cloud/core/package-info.java
+++ b/spring-cloud-aws-core/src/main/java/io/awspring/cloud/core/package-info.java
@@ -14,46 +14,9 @@
  * limitations under the License.
  */
 
-package io.awspring.cloud.autoconfigure.core;
-
-import org.springframework.lang.Nullable;
-
 /**
- * Properties related to AWS Profile.
- *
- * @author Tom Gianos
- * @author Siva Katamreddy
+ * Common infrastructure for all Spring Cloud AWS modules.
  */
-public class Profile {
-
-	/**
-	 * Profile name.
-	 */
-	@Nullable
-	private String name;
-
-	/**
-	 * Profile file path.
-	 */
-	@Nullable
-	private String path;
-
-	@Nullable
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	@Nullable
-	public String getPath() {
-		return path;
-	}
-
-	public void setPath(String path) {
-		this.path = path;
-	}
-
-}
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package io.awspring.cloud.core;

--- a/spring-cloud-aws-core/src/main/java/io/awspring/cloud/core/region/package-info.java
+++ b/spring-cloud-aws-core/src/main/java/io/awspring/cloud/core/region/package-info.java
@@ -14,46 +14,9 @@
  * limitations under the License.
  */
 
-package io.awspring.cloud.autoconfigure.core;
-
-import org.springframework.lang.Nullable;
-
 /**
- * Properties related to AWS Profile.
- *
- * @author Tom Gianos
- * @author Siva Katamreddy
+ * Utilities for handling AWS region selection.
  */
-public class Profile {
-
-	/**
-	 * Profile name.
-	 */
-	@Nullable
-	private String name;
-
-	/**
-	 * Profile file path.
-	 */
-	@Nullable
-	private String path;
-
-	@Nullable
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	@Nullable
-	public String getPath() {
-		return path;
-	}
-
-	public void setPath(String path) {
-		this.path = path;
-	}
-
-}
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package io.awspring.cloud.core.region;

--- a/spring-cloud-aws-parameter-store/src/main/java/io/awspring/cloud/parameterstore/ParameterStorePropertySource.java
+++ b/spring-cloud-aws-parameter-store/src/main/java/io/awspring/cloud/parameterstore/ParameterStorePropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import software.amazon.awssdk.services.ssm.model.GetParametersByPathResponse;
 import software.amazon.awssdk.services.ssm.model.Parameter;
 
 import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.lang.Nullable;
 
 /**
  * Recursively retrieves all parameters under the given context / path with decryption
@@ -66,6 +67,7 @@ public class ParameterStorePropertySource extends EnumerablePropertySource<SsmCl
 	}
 
 	@Override
+	@Nullable
 	public Object getProperty(String name) {
 		return this.properties.get(name);
 	}

--- a/spring-cloud-aws-parameter-store/src/main/java/io/awspring/cloud/parameterstore/package-info.java
+++ b/spring-cloud-aws-parameter-store/src/main/java/io/awspring/cloud/parameterstore/package-info.java
@@ -14,46 +14,9 @@
  * limitations under the License.
  */
 
-package io.awspring.cloud.autoconfigure.core;
-
-import org.springframework.lang.Nullable;
-
 /**
- * Properties related to AWS Profile.
- *
- * @author Tom Gianos
- * @author Siva Katamreddy
+ * Integration with AWS Parameter Store.
  */
-public class Profile {
-
-	/**
-	 * Profile name.
-	 */
-	@Nullable
-	private String name;
-
-	/**
-	 * Profile file path.
-	 */
-	@Nullable
-	private String path;
-
-	@Nullable
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	@Nullable
-	public String getPath() {
-		return path;
-	}
-
-	public void setPath(String path) {
-		this.path = path;
-	}
-
-}
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package io.awspring.cloud.parameterstore;

--- a/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
+++ b/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRespon
 import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
 
 import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.lang.Nullable;
 
 /**
  * Retrieves secret value under the given context / path from the AWS Secrets Manager
@@ -72,6 +73,7 @@ public class SecretsManagerPropertySource extends EnumerablePropertySource<Secre
 	}
 
 	@Override
+	@Nullable
 	public Object getProperty(String name) {
 		return properties.get(name);
 	}

--- a/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/package-info.java
+++ b/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/package-info.java
@@ -14,46 +14,9 @@
  * limitations under the License.
  */
 
-package io.awspring.cloud.autoconfigure.core;
-
-import org.springframework.lang.Nullable;
-
 /**
- * Properties related to AWS Profile.
- *
- * @author Tom Gianos
- * @author Siva Katamreddy
+ * Integration with AWS Secrets Manager.
  */
-public class Profile {
-
-	/**
-	 * Profile name.
-	 */
-	@Nullable
-	private String name;
-
-	/**
-	 * Profile file path.
-	 */
-	@Nullable
-	private String path;
-
-	@Nullable
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	@Nullable
-	public String getPath() {
-		return path;
-	}
-
-	public void setPath(String path) {
-		this.path = path;
-	}
-
-}
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package io.awspring.cloud.secretsmanager;

--- a/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/SimpleEmailServiceJavaMailSender.java
+++ b/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/SimpleEmailServiceJavaMailSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import software.amazon.awssdk.services.ses.model.SendRawEmailRequest;
 import software.amazon.awssdk.services.ses.model.SendRawEmailResponse;
 
 import org.springframework.beans.BeanUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.mail.MailException;
 import org.springframework.mail.MailParseException;
 import org.springframework.mail.MailPreparationException;
@@ -68,10 +69,13 @@ public class SimpleEmailServiceJavaMailSender extends SimpleEmailServiceMailSend
 
 	private Properties javaMailProperties = new Properties();
 
+	@Nullable
 	private volatile Session session;
 
+	@Nullable
 	private String defaultEncoding;
 
+	@Nullable
 	private FileTypeMap defaultFileTypeMap;
 
 	public SimpleEmailServiceJavaMailSender(SesClient sesClient) {
@@ -108,6 +112,7 @@ public class SimpleEmailServiceJavaMailSender extends SimpleEmailServiceMailSend
 	 * specified explicitly.
 	 * @return cached session or a new one from java mail properties
 	 */
+	@Nullable
 	protected Session getSession() {
 		if (this.session == null) {
 			this.session = Session.getInstance(getJavaMailProperties());

--- a/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/package-info.java
+++ b/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/package-info.java
@@ -14,46 +14,9 @@
  * limitations under the License.
  */
 
-package io.awspring.cloud.autoconfigure.core;
-
-import org.springframework.lang.Nullable;
-
 /**
- * Properties related to AWS Profile.
- *
- * @author Tom Gianos
- * @author Siva Katamreddy
+ * Integration with AWS SES (Simple Email Service).
  */
-public class Profile {
-
-	/**
-	 * Profile name.
-	 */
-	@Nullable
-	private String name;
-
-	/**
-	 * Profile file path.
-	 */
-	@Nullable
-	private String path;
-
-	@Nullable
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	@Nullable
-	public String getPath() {
-		return path;
-	}
-
-	public void setPath(String path) {
-		this.path = path;
-	}
-
-}
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package io.awspring.cloud.ses;


### PR DESCRIPTION
Add nullability annotations for better Kotlin compatibility and also simple reasoning when using Java.

Each method parameter and return value by default is marked as not-null, if anything is nullable is has to be explicitly marked with `@Nullable`.

Fixes #257