### PR TITLE
Configure endpoint for all integrations with single property

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ master, 2.3.x, 2.4.x, 3.0.x ]
+    branches: [ main, 2.3.x, 2.4.x, 3.0.x ]
   pull_request:
-    branches: [ master, 2.3.x, 2.4.x, 3.0.x ]
+    branches: [ main, 2.3.x, 2.4.x, 3.0.x ]
 
 jobs:
   build:

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/AbstractAwsConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/AbstractAwsConfigDataLocationResolver.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.autoconfigure.config;
 
+import io.awspring.cloud.autoconfigure.core.AwsProperties;
 import io.awspring.cloud.autoconfigure.core.CredentialsProperties;
 import java.util.Arrays;
 import java.util.Collections;
@@ -85,6 +86,10 @@ public abstract class AbstractAwsConfigDataLocationResolver<T extends ConfigData
 	protected CredentialsProperties loadCredentialsProperties(Binder binder) {
 		return binder.bind(CredentialsProperties.PREFIX, Bindable.of(CredentialsProperties.class))
 				.orElseGet(CredentialsProperties::new);
+	}
+
+	protected AwsProperties loadAwsProperties(Binder binder) {
+		return binder.bind(AwsProperties.CONFIG_PREFIX, Bindable.of(AwsProperties.class)).orElseGet(AwsProperties::new);
 	}
 
 	protected List<String> getCustomContexts(String keys) {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLocationResolver.java
@@ -56,6 +56,7 @@ public class ParameterStoreConfigDataLocationResolver
 	public List<ParameterStoreConfigDataResource> resolveProfileSpecific(
 			ConfigDataLocationResolverContext resolverContext, ConfigDataLocation location, Profiles profiles)
 			throws ConfigDataLocationNotFoundException {
+		registerBean(resolverContext, AwsProperties.class, loadAwsProperties(resolverContext.getBinder()));
 		registerBean(resolverContext, ParameterStoreProperties.class, loadProperties(resolverContext.getBinder()));
 		registerBean(resolverContext, CredentialsProperties.class,
 				loadCredentialsProperties(resolverContext.getBinder()));
@@ -99,7 +100,8 @@ public class ParameterStoreConfigDataLocationResolver
 		}
 		if (awsProperties.getEndpoint() != null) {
 			builder.endpointOverride(awsProperties.getEndpoint());
-		} else if (properties.getEndpoint() != null) {
+		}
+		else if (properties.getEndpoint() != null) {
 			builder.endpointOverride(properties.getEndpoint());
 		}
 		builder.credentialsProvider(credentialsProvider);
@@ -110,5 +112,4 @@ public class ParameterStoreConfigDataLocationResolver
 		return binder.bind(ParameterStoreProperties.CONFIG_PREFIX, Bindable.of(ParameterStoreProperties.class))
 				.orElseGet(ParameterStoreProperties::new);
 	}
-
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLocationResolver.java
@@ -98,11 +98,11 @@ public class ParameterStoreConfigDataLocationResolver
 		if (StringUtils.hasLength(properties.getRegion())) {
 			builder.region(Region.of(properties.getRegion()));
 		}
-		if (awsProperties.getEndpoint() != null) {
-			builder.endpointOverride(awsProperties.getEndpoint());
-		}
-		else if (properties.getEndpoint() != null) {
+		if (properties.getEndpoint() != null) {
 			builder.endpointOverride(properties.getEndpoint());
+		}
+		else if (awsProperties.getEndpoint() != null) {
+			builder.endpointOverride(awsProperties.getEndpoint());
 		}
 		builder.credentialsProvider(credentialsProvider);
 		return builder.build();

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLocationResolver.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.autoconfigure.config.parameterstore;
 
 import io.awspring.cloud.autoconfigure.config.AbstractAwsConfigDataLocationResolver;
+import io.awspring.cloud.autoconfigure.core.AwsProperties;
 import io.awspring.cloud.autoconfigure.core.CredentialsProperties;
 import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
 import io.awspring.cloud.core.SpringCloudClientConfiguration;
@@ -89,12 +90,16 @@ public class ParameterStoreConfigDataLocationResolver
 			credentialsProvider = CredentialsProviderAutoConfiguration.createCredentialsProvider(credentialsProperties);
 		}
 
+		AwsProperties awsProperties = context.get(AwsProperties.class);
+
 		SsmClientBuilder builder = SsmClient.builder()
 				.overrideConfiguration(SpringCloudClientConfiguration.clientOverrideConfiguration());
 		if (StringUtils.hasLength(properties.getRegion())) {
 			builder.region(Region.of(properties.getRegion()));
 		}
-		if (properties.getEndpoint() != null) {
+		if (awsProperties.getEndpoint() != null) {
+			builder.endpointOverride(awsProperties.getEndpoint());
+		} else if (properties.getEndpoint() != null) {
 			builder.endpointOverride(properties.getEndpoint());
 		}
 		builder.credentialsProvider(credentialsProvider);

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLocationResolver.java
@@ -104,11 +104,11 @@ public class SecretsManagerConfigDataLocationResolver
 		if (StringUtils.hasLength(properties.getRegion())) {
 			builder.region(Region.of(properties.getRegion()));
 		}
-		if (awsProperties.getEndpoint() != null) {
-			builder.endpointOverride(awsProperties.getEndpoint());
-		}
-		else if (properties.getEndpoint() != null) {
+		if (properties.getEndpoint() != null) {
 			builder.endpointOverride(properties.getEndpoint());
+		}
+		else if (awsProperties.getEndpoint() != null) {
+			builder.endpointOverride(awsProperties.getEndpoint());
 		}
 		builder.credentialsProvider(credentialsProvider);
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLocationResolver.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.autoconfigure.config.secretsmanager;
 
 import io.awspring.cloud.autoconfigure.config.AbstractAwsConfigDataLocationResolver;
+import io.awspring.cloud.autoconfigure.core.AwsProperties;
 import io.awspring.cloud.autoconfigure.core.CredentialsProperties;
 import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
 import io.awspring.cloud.core.SpringCloudClientConfiguration;
@@ -59,6 +60,7 @@ public class SecretsManagerConfigDataLocationResolver
 	public List<SecretsManagerConfigDataResource> resolveProfileSpecific(
 			ConfigDataLocationResolverContext resolverContext, ConfigDataLocation location, Profiles profiles)
 			throws ConfigDataLocationNotFoundException {
+		registerBean(resolverContext, AwsProperties.class, loadAwsProperties(resolverContext.getBinder()));
 		registerBean(resolverContext, SecretsManagerProperties.class, loadProperties(resolverContext.getBinder()));
 		registerBean(resolverContext, CredentialsProperties.class,
 				loadCredentialsProperties(resolverContext.getBinder()));
@@ -94,13 +96,18 @@ public class SecretsManagerConfigDataLocationResolver
 			credentialsProvider = CredentialsProviderAutoConfiguration.createCredentialsProvider(credentialsProperties);
 		}
 
+		AwsProperties awsProperties = context.get(AwsProperties.class);
+
 		SecretsManagerClientBuilder builder = SecretsManagerClient.builder()
 				.overrideConfiguration(SpringCloudClientConfiguration.clientOverrideConfiguration());
 
 		if (StringUtils.hasLength(properties.getRegion())) {
 			builder.region(Region.of(properties.getRegion()));
 		}
-		if (properties.getEndpoint() != null) {
+		if (awsProperties.getEndpoint() != null) {
+			builder.endpointOverride(awsProperties.getEndpoint());
+		}
+		else if (properties.getEndpoint() != null) {
 			builder.endpointOverride(properties.getEndpoint());
 		}
 		builder.credentialsProvider(credentialsProvider);

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsAutoConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.core;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(AwsProperties.class)
+public class AwsAutoConfiguration {
+
+	private final AwsProperties awsProperties;
+
+	public AwsAutoConfiguration(AwsProperties awsProperties) {
+		this.awsProperties = awsProperties;
+	}
+
+	@Bean
+	AwsClientBuilderConfigurer awsClientBuilderConfigurer(AwsCredentialsProvider credentialsProvider,
+			AwsRegionProvider awsRegionProvider) {
+		return new AwsClientBuilderConfigurer(credentialsProvider, awsRegionProvider, awsProperties);
+	}
+}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsAutoConfiguration.java
@@ -21,6 +21,12 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 
+/**
+ * Autoconfigures AWS environment.
+ *
+ * @author Maciej Walkowiak
+ * @since 3.0
+ */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(AwsProperties.class)
 public class AwsAutoConfiguration {
@@ -32,7 +38,7 @@ public class AwsAutoConfiguration {
 	}
 
 	@Bean
-	AwsClientBuilderConfigurer awsClientBuilderConfigurer(AwsCredentialsProvider credentialsProvider,
+	public AwsClientBuilderConfigurer awsClientBuilderConfigurer(AwsCredentialsProvider credentialsProvider,
 			AwsRegionProvider awsRegionProvider) {
 		return new AwsClientBuilderConfigurer(credentialsProvider, awsRegionProvider, awsProperties);
 	}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsClientBuilderConfigurer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsClientBuilderConfigurer.java
@@ -24,6 +24,12 @@ import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 
+/**
+ * Provides a convenience method to apply common configuration to any {@link AwsClientBuilder}.
+ *
+ * @author Maciej Walkowiak
+ * @since 3.0
+ */
 public class AwsClientBuilderConfigurer {
 	private final AwsCredentialsProvider credentialsProvider;
 	private final AwsRegionProvider regionProvider;

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsClientBuilderConfigurer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsClientBuilderConfigurer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.core;
+
+import io.awspring.cloud.autoconfigure.AwsClientProperties;
+import io.awspring.cloud.core.SpringCloudClientConfiguration;
+import java.util.Optional;
+import org.springframework.util.StringUtils;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+
+public class AwsClientBuilderConfigurer {
+	private final AwsCredentialsProvider credentialsProvider;
+	private final AwsRegionProvider regionProvider;
+	private final AwsProperties awsProperties;
+
+	AwsClientBuilderConfigurer(AwsCredentialsProvider credentialsProvider, AwsRegionProvider regionProvider,
+			AwsProperties awsProperties) {
+		this.credentialsProvider = credentialsProvider;
+		this.regionProvider = regionProvider;
+		this.awsProperties = awsProperties;
+	}
+
+	public AwsClientBuilder<?, ?> configure(AwsClientBuilder<?, ?> builder, AwsClientProperties clientProperties) {
+		Region region = StringUtils.hasLength(clientProperties.getRegion()) ? Region.of(clientProperties.getRegion())
+				: regionProvider.getRegion();
+		builder.credentialsProvider(credentialsProvider).region(region)
+				.overrideConfiguration(SpringCloudClientConfiguration.clientOverrideConfiguration());
+		Optional.ofNullable(awsProperties.getEndpoint()).ifPresent(builder::endpointOverride);
+		Optional.ofNullable(clientProperties.getEndpoint()).ifPresent(builder::endpointOverride);
+		return builder;
+	}
+}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsProperties.java
@@ -15,6 +15,8 @@
  */
 package io.awspring.cloud.autoconfigure.core;
 
+import static io.awspring.cloud.autoconfigure.core.AwsProperties.CONFIG_PREFIX;
+
 import java.net.URI;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.lang.Nullable;
@@ -25,8 +27,12 @@ import org.springframework.lang.Nullable;
  * @author Maciej Walkowiak
  * @since 3.0
  */
-@ConfigurationProperties("spring.cloud.aws")
+@ConfigurationProperties(CONFIG_PREFIX)
 public class AwsProperties {
+	/**
+	 * Configuration prefix.
+	 */
+	public static final String CONFIG_PREFIX = "spring.cloud.aws";
 
 	/**
 	 * Overrides the default endpoint for all auto-configured AWS clients.

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsProperties.java
@@ -1,7 +1,21 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.autoconfigure.core;
 
 import java.net.URI;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.lang.Nullable;
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsProperties.java
@@ -19,11 +19,17 @@ import java.net.URI;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.lang.Nullable;
 
+/**
+ * Configuration properties for AWS environment.
+ *
+ * @author Maciej Walkowiak
+ * @since 3.0
+ */
 @ConfigurationProperties("spring.cloud.aws")
 public class AwsProperties {
 
 	/**
-	 * Overrides the default endpoint.
+	 * Overrides the default endpoint for all auto-configured AWS clients.
 	 */
 	@Nullable
 	private URI endpoint;

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsProperties.java
@@ -1,0 +1,25 @@
+package io.awspring.cloud.autoconfigure.core;
+
+import java.net.URI;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.lang.Nullable;
+
+@ConfigurationProperties("spring.cloud.aws")
+public class AwsProperties {
+
+	/**
+	 * Overrides the default endpoint.
+	 */
+	@Nullable
+	private URI endpoint;
+
+	@Nullable
+	public URI getEndpoint() {
+		return endpoint;
+	}
+
+	public void setEndpoint(@Nullable URI endpoint) {
+		this.endpoint = endpoint;
+	}
+}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.autoconfigure.ses;
 
+import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
 import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
 import io.awspring.cloud.core.SpringCloudClientConfiguration;
@@ -55,21 +56,10 @@ import software.amazon.awssdk.services.ses.SesClientBuilder;
 @ConditionalOnProperty(name = "spring.cloud.aws.ses.enabled", havingValue = "true", matchIfMissing = true)
 public class SesAutoConfiguration {
 
-	private final SesProperties properties;
-
-	public SesAutoConfiguration(SesProperties properties) {
-		this.properties = properties;
-	}
-
 	@Bean
 	@ConditionalOnMissingBean
-	public SesClient sesClient(AwsCredentialsProvider credentialsProvider, AwsRegionProvider regionProvider) {
-		Region region = StringUtils.hasLength(this.properties.getRegion()) ? Region.of(this.properties.getRegion())
-				: regionProvider.getRegion();
-		SesClientBuilder client = SesClient.builder().credentialsProvider(credentialsProvider).region(region)
-				.overrideConfiguration(SpringCloudClientConfiguration.clientOverrideConfiguration());
-		Optional.ofNullable(this.properties.getEndpoint()).ifPresent(client::endpointOverride);
-		return client.build();
+	public SesClient sesClient(SesProperties properties, AwsClientBuilderConfigurer awsClientBuilderConfigurer) {
+		return (SesClient) awsClientBuilderConfigurer.configure(SesClient.builder(), properties).build();
 	}
 
 	@Bean

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesAutoConfiguration.java
@@ -18,10 +18,8 @@ package io.awspring.cloud.autoconfigure.ses;
 import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
 import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
-import io.awspring.cloud.core.SpringCloudClientConfiguration;
 import io.awspring.cloud.ses.SimpleEmailServiceJavaMailSender;
 import io.awspring.cloud.ses.SimpleEmailServiceMailSender;
-import java.util.Optional;
 import javax.mail.Session;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -34,12 +32,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.MailSender;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.util.StringUtils;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 import software.amazon.awssdk.services.ses.SesClient;
-import software.amazon.awssdk.services.ses.SesClientBuilder;
 
 /**
  * {@link EnableAutoConfiguration} for {@link SimpleEmailServiceMailSender} and

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration,\
 io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration,\
 io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration,\
 io.awspring.cloud.autoconfigure.ses.SesAutoConfiguration,\

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/ConfiguredAwsClient.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/ConfiguredAwsClient.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure;
+
+import java.net.URI;
+import java.util.Objects;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.core.SdkClient;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.utils.AttributeMap;
+
+public class ConfiguredAwsClient {
+
+	private final AttributeMap clientConfigurationAttributes;
+
+	public ConfiguredAwsClient(SdkClient sdkClient) {
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(sdkClient,
+				"clientConfiguration");
+		this.clientConfigurationAttributes = (AttributeMap) ReflectionTestUtils
+				.getField(Objects.requireNonNull(clientConfiguration), "attributes");
+	}
+
+	public URI getEndpoint() {
+		return clientConfigurationAttributes.get(SdkClientOption.ENDPOINT);
+	}
+
+	public boolean isEndpointOverridden() {
+		return clientConfigurationAttributes.get(SdkClientOption.ENDPOINT_OVERRIDDEN);
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoaderIntegrationTests.java
@@ -146,12 +146,27 @@ class ParameterStoreConfigDataLoaderIntegrationTests {
 		}
 	}
 
-	private ConfigurableApplicationContext runApplication(SpringApplication application, String springConfigImport) {
+	@Test
+	void endpointCanBeOverwrittenWithGlobalAwsProperties() {
+		SpringApplication application = new SpringApplication(App.class);
+		application.setWebApplicationType(WebApplicationType.NONE);
+
+		try (ConfigurableApplicationContext context = runApplication(application,
+			"aws-parameterstore:/config/spring/", "spring.cloud.aws.endpoint")) {
+			assertThat(context.getEnvironment().getProperty("message")).isEqualTo("value from tests");
+		}
+	}
+
+	private ConfigurableApplicationContext runApplication(SpringApplication application, String springConfigImport, String endpointProperty) {
 		return application.run("--spring.config.import=" + springConfigImport,
-				"--spring.cloud.aws.parameterstore.region=" + REGION,
-				"--spring.cloud.aws.parameterstore.endpoint=" + localstack.getEndpointOverride(SSM).toString(),
-				"--spring.cloud.aws.credentials.access-key=noop", "--spring.cloud.aws.credentials.secret-key=noop",
-				"--spring.cloud.aws.region.static=eu-west-1", "--logging.level.io.awspring.cloud.parameterstore=debug");
+			"--spring.cloud.aws.parameterstore.region=" + REGION,
+			"--" + endpointProperty + "=" + localstack.getEndpointOverride(SSM).toString(),
+			"--spring.cloud.aws.credentials.access-key=noop", "--spring.cloud.aws.credentials.secret-key=noop",
+			"--spring.cloud.aws.region.static=eu-west-1", "--logging.level.io.awspring.cloud.parameterstore=debug");
+	}
+
+	private ConfigurableApplicationContext runApplication(SpringApplication application, String springConfigImport) {
+		return runApplication(application, springConfigImport, "spring.cloud.aws.parameterstore.endpoint");
 	}
 
 	private static void putParameter(LocalStackContainer localstack, String parameterName, String parameterValue,

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoaderIntegrationTests.java
@@ -151,18 +151,19 @@ class ParameterStoreConfigDataLoaderIntegrationTests {
 		SpringApplication application = new SpringApplication(App.class);
 		application.setWebApplicationType(WebApplicationType.NONE);
 
-		try (ConfigurableApplicationContext context = runApplication(application,
-			"aws-parameterstore:/config/spring/", "spring.cloud.aws.endpoint")) {
+		try (ConfigurableApplicationContext context = runApplication(application, "aws-parameterstore:/config/spring/",
+				"spring.cloud.aws.endpoint")) {
 			assertThat(context.getEnvironment().getProperty("message")).isEqualTo("value from tests");
 		}
 	}
 
-	private ConfigurableApplicationContext runApplication(SpringApplication application, String springConfigImport, String endpointProperty) {
+	private ConfigurableApplicationContext runApplication(SpringApplication application, String springConfigImport,
+			String endpointProperty) {
 		return application.run("--spring.config.import=" + springConfigImport,
-			"--spring.cloud.aws.parameterstore.region=" + REGION,
-			"--" + endpointProperty + "=" + localstack.getEndpointOverride(SSM).toString(),
-			"--spring.cloud.aws.credentials.access-key=noop", "--spring.cloud.aws.credentials.secret-key=noop",
-			"--spring.cloud.aws.region.static=eu-west-1", "--logging.level.io.awspring.cloud.parameterstore=debug");
+				"--spring.cloud.aws.parameterstore.region=" + REGION,
+				"--" + endpointProperty + "=" + localstack.getEndpointOverride(SSM).toString(),
+				"--spring.cloud.aws.credentials.access-key=noop", "--spring.cloud.aws.credentials.secret-key=noop",
+				"--spring.cloud.aws.region.static=eu-west-1", "--logging.level.io.awspring.cloud.parameterstore=debug");
 	}
 
 	private ConfigurableApplicationContext runApplication(SpringApplication application, String springConfigImport) {

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoaderIntegrationTests.java
@@ -157,6 +157,23 @@ class ParameterStoreConfigDataLoaderIntegrationTests {
 		}
 	}
 
+	@Test
+	void serviceSpecificEndpointTakesPrecedenceOverGlobalAwsRegion() {
+		SpringApplication application = new SpringApplication(App.class);
+		application.setWebApplicationType(WebApplicationType.NONE);
+
+		try (ConfigurableApplicationContext context = application.run(
+				"--spring.config.import=aws-parameterstore:/config/spring/",
+				"--spring.cloud.aws.parameterstore.region=" + REGION,
+				"--spring.cloud.aws.endpoint=http://non-existing-host/",
+				"--spring.cloud.aws.parameterstore.endpoint=" + localstack.getEndpointOverride(SSM).toString(),
+				"--spring.cloud.aws.credentials.access-key=noop", "--spring.cloud.aws.credentials.secret-key=noop",
+				"--spring.cloud.aws.region.static=eu-west-1",
+				"--logging.level.io.awspring.cloud.parameterstore=debug")) {
+			assertThat(context.getEnvironment().getProperty("message")).isEqualTo("value from tests");
+		}
+	}
+
 	private ConfigurableApplicationContext runApplication(SpringApplication application, String springConfigImport,
 			String endpointProperty) {
 		return application.run("--spring.config.import=" + springConfigImport,

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
@@ -146,11 +146,26 @@ class SecretsManagerConfigDataLoaderIntegrationTests {
 		}
 	}
 
+	@Test
+	void endpointCanBeOverwrittenWithGlobalAwsProperties() {
+		SpringApplication application = new SpringApplication(SecretsManagerConfigDataLoaderIntegrationTests.App.class);
+		application.setWebApplicationType(WebApplicationType.NONE);
+
+		try (ConfigurableApplicationContext context = runApplication(application,
+				"aws-secretsmanager:/config/spring;/config/second", "spring.cloud.aws.endpoint")) {
+			assertThat(context.getEnvironment().getProperty("message")).isEqualTo("value from tests");
+		}
+	}
+
 	private ConfigurableApplicationContext runApplication(SpringApplication application, String springConfigImport) {
+		return runApplication(application, springConfigImport, "spring.cloud.aws.secretsmanager.endpoint");
+	}
+
+	private ConfigurableApplicationContext runApplication(SpringApplication application, String springConfigImport,
+			String endpointProperty) {
 		return application.run("--spring.config.import=" + springConfigImport,
 				"--spring.cloud.aws.secretsmanager.region=" + REGION,
-				"--spring.cloud.aws.secretsmanager.endpoint="
-						+ localstack.getEndpointOverride(SECRETSMANAGER).toString(),
+				"--" + endpointProperty + "=" + localstack.getEndpointOverride(SECRETSMANAGER).toString(),
 				"--spring.cloud.aws.credentials.access-key=noop", "--spring.cloud.aws.credentials.secret-key=noop",
 				"--spring.cloud.aws.region.static=eu-west-1", "--logging.level.io.awspring.cloud.secretsmanager=debug");
 	}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
@@ -157,6 +157,23 @@ class SecretsManagerConfigDataLoaderIntegrationTests {
 		}
 	}
 
+	@Test
+	void serviceSpecificEndpointTakesPrecedenceOverGlobalAwsRegion() {
+		SpringApplication application = new SpringApplication(SecretsManagerConfigDataLoaderIntegrationTests.App.class);
+		application.setWebApplicationType(WebApplicationType.NONE);
+
+		try (ConfigurableApplicationContext context = application.run(
+				"--spring.config.import=aws-secretsmanager:/config/spring;/config/second",
+				"--spring.cloud.aws.secretsmanager.region=" + REGION,
+				"--spring.cloud.aws.endpoint=http://non-existing-host/",
+				"--spring.cloud.aws.secretsmanager.endpoint="
+						+ localstack.getEndpointOverride(SECRETSMANAGER).toString(),
+				"--spring.cloud.aws.credentials.access-key=noop", "--spring.cloud.aws.credentials.secret-key=noop",
+				"--spring.cloud.aws.region.static=eu-west-1")) {
+			assertThat(context.getEnvironment().getProperty("message")).isEqualTo("value from tests");
+		}
+	}
+
 	private ConfigurableApplicationContext runApplication(SpringApplication application, String springConfigImport) {
 		return runApplication(application, springConfigImport, "spring.cloud.aws.secretsmanager.endpoint");
 	}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfigurationTests.java
@@ -71,6 +71,15 @@ class S3AutoConfigurationTests {
 	}
 
 	@Test
+	void s3AutoConfigurationIsDisabled2() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.endpoint:http://localhost:3333")
+			.withUserConfiguration(NoTimeoutClientConfiguration.class)
+			.run(context -> {
+			S3Client s3Client = context.getBean(S3Client.class);
+		});
+	}
+
+	@Test
 	void autoconfigurationIsNotTriggeredWhenS3ModuleIsNotOnClasspath() {
 		this.contextRunner.withClassLoader(new FilteredClassLoader(S3OutputStreamProvider.class)).run(context -> {
 			assertThat(context).doesNotHaveBean(S3Client.class);

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfigurationTests.java
@@ -18,6 +18,7 @@ package io.awspring.cloud.autoconfigure.s3;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
 import io.awspring.cloud.s3.DiskBufferingS3OutputStreamProvider;
@@ -45,7 +46,7 @@ class S3AutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withPropertyValues("spring.cloud.aws.region.static:eu-west-1")
-			.withConfiguration(AutoConfigurations.of(RegionProviderAutoConfiguration.class,
+			.withConfiguration(AutoConfigurations.of(AwsAutoConfiguration.class, RegionProviderAutoConfiguration.class,
 					CredentialsProviderAutoConfiguration.class, S3AutoConfiguration.class));
 
 	@Test
@@ -67,15 +68,6 @@ class S3AutoConfigurationTests {
 			assertThat(context).doesNotHaveBean(S3Client.class);
 			assertThat(context).doesNotHaveBean(S3ClientBuilder.class);
 			assertThat(context).doesNotHaveBean(S3Properties.class);
-		});
-	}
-
-	@Test
-	void s3AutoConfigurationIsDisabled2() {
-		this.contextRunner.withPropertyValues("spring.cloud.aws.endpoint:http://localhost:3333")
-			.withUserConfiguration(NoTimeoutClientConfiguration.class)
-			.run(context -> {
-			S3Client s3Client = context.getBean(S3Client.class);
 		});
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfigurationTests.java
@@ -18,6 +18,7 @@ package io.awspring.cloud.autoconfigure.s3;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import io.awspring.cloud.autoconfigure.ConfiguredAwsClient;
 import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
@@ -27,6 +28,7 @@ import io.awspring.cloud.s3.S3OutputStream;
 import io.awspring.cloud.s3.S3OutputStreamProvider;
 import io.awspring.cloud.s3.crossregion.CrossRegionS3Client;
 import java.io.IOException;
+import java.net.URI;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -111,6 +113,37 @@ class S3AutoConfigurationTests {
 			assertThat(context).doesNotHaveBean(CrossRegionS3Client.class);
 			assertThat(context).hasSingleBean(S3Client.class);
 		});
+	}
+
+	@Test
+	void withCustomEndpoint() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.s3.endpoint:http://localhost:8090").run(context -> {
+			S3ClientBuilder builder = context.getBean(S3ClientBuilder.class);
+			ConfiguredAwsClient client = new ConfiguredAwsClient(builder.build());
+			assertThat(client.getEndpoint()).isEqualTo(URI.create("http://localhost:8090"));
+			assertThat(client.isEndpointOverridden()).isTrue();
+		});
+	}
+
+	@Test
+	void withCustomGlobalEndpoint() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.endpoint:http://localhost:8090").run(context -> {
+			S3ClientBuilder builder = context.getBean(S3ClientBuilder.class);
+			ConfiguredAwsClient client = new ConfiguredAwsClient(builder.build());
+			assertThat(client.getEndpoint()).isEqualTo(URI.create("http://localhost:8090"));
+			assertThat(client.isEndpointOverridden()).isTrue();
+		});
+	}
+
+	@Test
+	void withCustomGlobalEndpointAndS3Endpoint() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.endpoint:http://localhost:8090",
+				"spring.cloud.aws.s3.endpoint:http://localhost:9999").run(context -> {
+					S3ClientBuilder builder = context.getBean(S3ClientBuilder.class);
+					ConfiguredAwsClient client = new ConfiguredAwsClient(builder.build());
+					assertThat(client.getEndpoint()).isEqualTo(URI.create("http://localhost:9999"));
+					assertThat(client.isEndpointOverridden()).isTrue();
+				});
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/ses/SesAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/ses/SesAutoConfigurationTest.java
@@ -17,22 +17,18 @@ package io.awspring.cloud.autoconfigure.ses;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.awspring.cloud.autoconfigure.ConfiguredAwsClient;
+import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
 import java.net.URI;
-import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.mail.MailSender;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.test.util.ReflectionTestUtils;
-import software.amazon.awssdk.core.SdkClient;
-import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
-import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.services.ses.SesClient;
-import software.amazon.awssdk.utils.AttributeMap;
 
 /**
  * Tests for class {@link SesAutoConfiguration}
@@ -45,7 +41,7 @@ class SesAutoConfigurationTest {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withPropertyValues("spring.cloud.aws.region.static:eu-west-1")
-			.withConfiguration(AutoConfigurations.of(RegionProviderAutoConfiguration.class,
+			.withConfiguration(AutoConfigurations.of(AwsAutoConfiguration.class, RegionProviderAutoConfiguration.class,
 					CredentialsProviderAutoConfiguration.class, SesAutoConfiguration.class));
 
 	@Test
@@ -92,25 +88,23 @@ class SesAutoConfigurationTest {
 		});
 	}
 
-	private static class ConfiguredAwsClient {
+	@Test
+	void withCustomGlobalEndpoint() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.endpoint:http://localhost:8090").run(context -> {
+			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(SesClient.class));
+			assertThat(client.getEndpoint()).isEqualTo(URI.create("http://localhost:8090"));
+			assertThat(client.isEndpointOverridden()).isTrue();
+		});
+	}
 
-		private final AttributeMap clientConfigurationAttributes;
-
-		ConfiguredAwsClient(SdkClient sdkClient) {
-			SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
-					.getField(sdkClient, "clientConfiguration");
-			this.clientConfigurationAttributes = (AttributeMap) ReflectionTestUtils
-					.getField(Objects.requireNonNull(clientConfiguration), "attributes");
-		}
-
-		URI getEndpoint() {
-			return clientConfigurationAttributes.get(SdkClientOption.ENDPOINT);
-		}
-
-		boolean isEndpointOverridden() {
-			return clientConfigurationAttributes.get(SdkClientOption.ENDPOINT_OVERRIDDEN);
-		}
-
+	@Test
+	void withCustomGlobalEndpointAndSesEndpoint() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.endpoint:http://localhost:8090",
+				"spring.cloud.aws.ses.endpoint:http://localhost:9999").run(context -> {
+					ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(SesClient.class));
+					assertThat(client.getEndpoint()).isEqualTo(URI.create("http://localhost:9999"));
+					assertThat(client.isEndpointOverridden()).isTrue();
+				});
 	}
 
 }

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/main/java/io/awspring/cloud/s3/crossregion/CrossRegionS3Client.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/main/java/io/awspring/cloud/s3/crossregion/CrossRegionS3Client.java
@@ -330,8 +330,8 @@ public class CrossRegionS3Client implements S3Client {
     }
 
     @Override
-    public software.amazon.awssdk.core.ResponseInputStream<software.amazon.awssdk.services.s3.model.GetObjectResponse> getObject(software.amazon.awssdk.services.s3.model.GetObjectRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0));
+    public <ReturnT> ReturnT getObject(software.amazon.awssdk.services.s3.model.GetObjectRequest p0, software.amazon.awssdk.core.sync.ResponseTransformer<software.amazon.awssdk.services.s3.model.GetObjectResponse, ReturnT> p1) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0, p1));
     }
 
     @Override
@@ -340,8 +340,8 @@ public class CrossRegionS3Client implements S3Client {
     }
 
     @Override
-    public <ReturnT> ReturnT getObject(software.amazon.awssdk.services.s3.model.GetObjectRequest p0, software.amazon.awssdk.core.sync.ResponseTransformer<software.amazon.awssdk.services.s3.model.GetObjectResponse, ReturnT> p1) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0, p1));
+    public software.amazon.awssdk.core.ResponseInputStream<software.amazon.awssdk.services.s3.model.GetObjectResponse> getObject(software.amazon.awssdk.services.s3.model.GetObjectRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0));
     }
 
     @Override


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Adds `spring.cloud.aws.endpoint` property that can be used to configure endpoint for each autoconfigured client.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes  #287