### PR TITLE
Allow plain text in AWS Secrets

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
@@ -142,7 +142,7 @@ class SecretsManagerConfigDataLoaderIntegrationTests {
 		try (ConfigurableApplicationContext context = runApplication(application,
 				"aws-secretsmanager:/config/spring;/config/second")) {
 			context.getEnvironment().getProperty("message");
-			assertThat(output.getAll()).contains("Populating property retrieved from AWS Parameter Store: message");
+			assertThat(output.getAll()).contains("Populating property retrieved from AWS Secrets Manager: message");
 		}
 	}
 

--- a/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
+++ b/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.secretsmanager;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -75,16 +76,20 @@ public class SecretsManagerPropertySource extends EnumerablePropertySource<Secre
 	}
 
 	private void readSecretValue(GetSecretValueRequest secretValueRequest) {
+		GetSecretValueResponse secretValueResponse = source.getSecretValue(secretValueRequest);
 		try {
-			GetSecretValueResponse secretValueResponse = source.getSecretValue(secretValueRequest);
 			Map<String, Object> secretMap = jsonMapper.readValue(secretValueResponse.secretString(),
 					new TypeReference<Map<String, Object>>() {
 					});
 
 			for (Map.Entry<String, Object> secretEntry : secretMap.entrySet()) {
-				LOG.debug("Populating property retrieved from AWS Parameter Store: " + secretEntry.getKey());
+				LOG.debug("Populating property retrieved from AWS Secrets Manager: " + secretEntry.getKey());
 				properties.put(secretEntry.getKey(), secretEntry.getValue());
 			}
+		} catch (JsonParseException e) {
+			// If the secret is not a JSON string, then it is a simple "plain text" string
+			LOG.debug("Populating property retrieved from AWS Secrets Manager: " + secretValueResponse.name());
+			properties.put(secretValueResponse.name(), secretValueResponse.secretString());
 		}
 		catch (JsonProcessingException e) {
 			throw new RuntimeException(e);

--- a/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
+++ b/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
@@ -86,7 +86,8 @@ public class SecretsManagerPropertySource extends EnumerablePropertySource<Secre
 				LOG.debug("Populating property retrieved from AWS Secrets Manager: " + secretEntry.getKey());
 				properties.put(secretEntry.getKey(), secretEntry.getValue());
 			}
-		} catch (JsonParseException e) {
+		}
+		catch (JsonParseException e) {
 			// If the secret is not a JSON string, then it is a simple "plain text" string
 			LOG.debug("Populating property retrieved from AWS Secrets Manager: " + secretValueResponse.name());
 			properties.put(secretValueResponse.name(), secretValueResponse.secretString());

--- a/spring-cloud-aws-secrets-manager/src/test/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySourceTest.java
+++ b/spring-cloud-aws-secrets-manager/src/test/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySourceTest.java
@@ -53,6 +53,19 @@ class SecretsManagerPropertySourceTest {
 	}
 
 	@Test
+	void shouldParsePlainTextSecretValue() {
+		GetSecretValueResponse secretValueResult = GetSecretValueResponse.builder()
+			.secretString("my secret").name("secret name").build();
+
+		when(client.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
+
+		propertySource.init();
+
+		assertThat(propertySource.getPropertyNames()).containsExactly("secret name");
+		assertThat(propertySource.getProperty("secret name")).isEqualTo("my secret");
+	}
+
+	@Test
 	void throwsExceptionWhenSecretNotFound() {
 		when(client.getSecretValue(any(GetSecretValueRequest.class)))
 				.thenThrow(ResourceNotFoundException.builder().message("secret not found").build());

--- a/spring-cloud-aws-secrets-manager/src/test/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySourceTest.java
+++ b/spring-cloud-aws-secrets-manager/src/test/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySourceTest.java
@@ -54,8 +54,8 @@ class SecretsManagerPropertySourceTest {
 
 	@Test
 	void shouldParsePlainTextSecretValue() {
-		GetSecretValueResponse secretValueResult = GetSecretValueResponse.builder()
-			.secretString("my secret").name("secret name").build();
+		GetSecretValueResponse secretValueResult = GetSecretValueResponse.builder().secretString("my secret")
+				.name("secret name").build();
 
 		when(client.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Change `AwsSecretsManagerPropertySource` to handle plain text AWS Secrets if a json is not detected, by adding a `catch (JsonParseException e) block` that will handle the plain text.

## :bulb: Motivation and Context
Fix for #337


## :green_heart: How did you test it?
A Junit test is associated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
