### PR TITLE
Exclude Slash from Encode, when calling getURL()

### DIFF
--- a/spring-cloud-aws-core/src/main/java/io/awspring/cloud/core/io/s3/SimpleStorageResource.java
+++ b/spring-cloud-aws-core/src/main/java/io/awspring/cloud/core/io/s3/SimpleStorageResource.java
@@ -144,7 +144,11 @@ public class SimpleStorageResource extends AbstractResource implements WritableR
 	@Override
 	public URL getURL() throws IOException {
 		Region region = this.amazonS3.getRegion().toAWSRegion();
-		String encodedObjectName = URLEncoder.encode(this.objectName, StandardCharsets.UTF_8.toString());
+		List<String> splits = new ArrayList<>();
+		for (String split : this.objectName.split("/")) {
+			splits.add(URLEncoder.encode(split, StandardCharsets.UTF_8.toString()));
+		}
+		String encodedObjectName = String.join("/", splits);
 		return new URL("https", region.getServiceEndpoint(AmazonS3Client.S3_SERVICE_NAME),
 				"/" + this.bucketName + "/" + encodedObjectName);
 	}

--- a/spring-cloud-aws-core/src/test/java/io/awspring/cloud/core/io/s3/SimpleStorageResourceTest.java
+++ b/spring-cloud-aws-core/src/test/java/io/awspring/cloud/core/io/s3/SimpleStorageResourceTest.java
@@ -348,7 +348,7 @@ class SimpleStorageResourceTest {
 				new SyncTaskExecutor());
 
 		assertThat(resource.getURI())
-				.isEqualTo(new URI("https://s3.us-west-2.amazonaws.com/bucketName/some%2F%5BobjectName%5D"));
+				.isEqualTo(new URI("https://s3.us-west-2.amazonaws.com/bucketName/some/%5BobjectName%5D"));
 	}
 
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ x ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
(this PR is a copy/patse from the legacy repository https://github.com/spring-attic/spring-cloud-aws/pull/805 made by @songintae)
 
In the PathResourceResolver.isResourceUnderLocation method, a slash is placed in the locationPath to verify the resource. Therefore, the slash should be excluded when encoding the object name.

PathResourceResolver class : org.springframework.web.servlet.resource.PathResourceResolver


## :bulb: Motivation and Context
I am using S3 to manage static resources.
Using the spring, I wrote the setting code as follows.

-- application.yml
spring.resources.staticLocations:
- 's3://bucketName/admin/beta/'

And I registered the following Beans.

AmazonS3
SimpleStorageProtocolResolver
SimpleStorageProtocolResolverConfigurer
In this environment, when I make a request such as "https://domain.com/index.html", the PathResourceResolver.isResourceUnderLocation method does not find the file correctly due to URL encoding problems.


## :green_heart: How did you test it?
Modified the existing test code.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ x ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ x ] All tests passing
- [ x ] No breaking changes


## :crystal_ball: Next steps
