### PR TITLE
Exclude Slash from Encode, when calling getURL() on S3 Resource

### DIFF
--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Resource.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Resource.java
@@ -23,6 +23,9 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.WritableResource;
 import org.springframework.lang.Nullable;
@@ -76,7 +79,11 @@ public class S3Resource extends AbstractResource implements WritableResource {
 
 	@Override
 	public URL getURL() throws IOException {
-		String encodedObjectName = URLEncoder.encode(location.getObject(), StandardCharsets.UTF_8.toString());
+		List<String> splits = new ArrayList<>();
+		for (String split : location.getObject().split("/")) {
+			splits.add(URLEncoder.encode(split, StandardCharsets.UTF_8.toString()));
+		}
+		String encodedObjectName = String.join("/", splits);
 		return new URL("https", location.getBucket() + ".s3.amazonaws.com", "/" + encodedObjectName);
 	}
 

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ResourceIntegrationTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ResourceIntegrationTests.java
@@ -129,9 +129,9 @@ class S3ResourceIntegrationTests {
 	void returnsEncodedResourceUrlAndUri() throws IOException, URISyntaxException {
 		S3Resource resource = s3Resource("s3://first-bucket/some/[objectName]");
 		assertThat(resource.getURL().toString())
-				.isEqualTo("https://first-bucket.s3.amazonaws.com/some%2F%5BobjectName%5D");
+				.isEqualTo("https://first-bucket.s3.amazonaws.com/some/%5BobjectName%5D");
 		assertThat(resource.getURI())
-				.isEqualTo(new URI("https://first-bucket.s3.amazonaws.com/some%2F%5BobjectName%5D"));
+				.isEqualTo(new URI("https://first-bucket.s3.amazonaws.com/some/%5BobjectName%5D"));
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ x ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

This is a new PR replacing the old one on the legacy repository :  https://github.com/spring-attic/spring-cloud-aws/pull/805 made by @songintae 

In the PathResourceResolver.isResourceUnderLocation method, a slash is placed in the locationPath to verify the resource. Therefore, the slash should be excluded when encoding the object name.

PathResourceResolver class : org.springframework.web.servlet.resource.PathResourceResolver


## :bulb: Motivation and Context
I am using S3 to manage static resources.
Using the spring, I wrote the setting code as follows.

-- application.yml
spring.resources.staticLocations:
- 's3://bucketName/admin/beta/'

And I registered the following Beans.

AmazonS3
SimpleStorageProtocolResolver
SimpleStorageProtocolResolverConfigurer
In this environment, when I make a request such as "https://domain.com/index.html", the PathResourceResolver.isResourceUnderLocation method does not find the file correctly due to URL encoding problems.

## :green_heart: How did you test it?
Modified the existing test code.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ x ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ x ] All tests passing
- [ x ] No breaking changes


## :crystal_ball: Next steps
