### PR TITLE
Relax prefix validation rules in Parameter Store and Secrets Manager …

### DIFF
--- a/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStoreProperties.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/io/awspring/cloud/paramstore/AwsParamStoreProperties.java
@@ -42,7 +42,7 @@ public class AwsParamStoreProperties implements InitializingBean {
 	/**
 	 * Pattern used for prefix validation.
 	 */
-	private static final Pattern PREFIX_PATTERN = Pattern.compile("(/)?([a-zA-Z0-9.\\-]+)(?:/[a-zA-Z0-9]+)*");
+	private static final Pattern PREFIX_PATTERN = Pattern.compile("[a-zA-Z0-9.\\-/]+");
 
 	/**
 	 * Pattern used for profileSeparator validation.
@@ -96,11 +96,11 @@ public class AwsParamStoreProperties implements InitializingBean {
 
 		if (StringUtils.hasLength(prefix) && !PREFIX_PATTERN.matcher(prefix).matches()) {
 			throw new ValidationException(CONFIG_PREFIX + ".prefix",
-					"The prefix must have pattern of:  " + PREFIX_PATTERN.toString());
+					"The prefix value: " + prefix + " must have pattern of: " + PREFIX_PATTERN.toString());
 		}
 		if (!PROFILE_SEPARATOR_PATTERN.matcher(profileSeparator).matches()) {
 			throw new ValidationException(CONFIG_PREFIX + ".profileSeparator",
-					"The profileSeparator must have pattern of:  " + PROFILE_SEPARATOR_PATTERN.toString());
+					"The profileSeparator must have pattern of: " + PROFILE_SEPARATOR_PATTERN.toString());
 		}
 	}
 

--- a/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertiesTest.java
+++ b/spring-cloud-aws-parameter-store-config/src/test/java/io/awspring/cloud/paramstore/AwsParamStorePropertiesTest.java
@@ -23,8 +23,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Tests for {@link AwsParamStoreProperties}.
@@ -36,57 +38,51 @@ class AwsParamStorePropertiesTest {
 
 	@ParameterizedTest
 	@MethodSource("invalidProperties")
-	public void validationFails(AwsParamStoreProperties properties, String field, String errorCode) {
-		assertThatThrownBy(properties::afterPropertiesSet).isInstanceOf(ValidationException.class);
+	public void validationFails(AwsParamStoreProperties properties, String field) throws Exception {
+		try {
+			properties.afterPropertiesSet();
+			fail("validation should fail");
+		}
+		catch (ValidationException e) {
+			assertThat(e.getField()).endsWith(field);
+		}
 	}
 
-	@Test
-	void validationSucceeds() {
-		AwsParamStoreProperties properties = new AwsParamStorePropertiesBuilder().withPrefix("/con")
-				.withDefaultContext("app").withProfileSeparator("_").build();
-
+	@ParameterizedTest
+	@MethodSource("validProperties")
+	void validationSucceeds(AwsParamStoreProperties properties) {
 		assertThatNoException().isThrownBy(properties::afterPropertiesSet);
 	}
 
 	@Test
-	void validationSucceedsPrefix() {
-		AwsParamStoreProperties properties = new AwsParamStorePropertiesBuilder().withPrefix("/con/test/bla")
-				.withDefaultContext("app").withProfileSeparator("_").build();
-
-		assertThatNoException().isThrownBy(properties::afterPropertiesSet);
+	void checkExceptionLoggingForPrefix() {
+		AwsParamStoreProperties properties = new AwsParamStorePropertiesBuilder().withPrefix("!.").build();
+		assertThatThrownBy(properties::afterPropertiesSet)
+				.hasMessage("The prefix value: !. must have pattern of: [a-zA-Z0-9.\\-/]+");
 	}
 
-	@Test
-	void validationSucceedsNoPrefix() {
-		AwsParamStoreProperties properties = new AwsParamStorePropertiesBuilder().withPrefix("")
-				.withDefaultContext("app").withProfileSeparator("_").build();
-
-		assertThatNoException().isThrownBy(properties::afterPropertiesSet);
-	}
-
-	@Test
-	void acceptsForwardSlashAsProfileSeparator() {
-		AwsParamStoreProperties properties = new AwsParamStoreProperties();
-		properties.setProfileSeparator("/");
-		assertThatNoException().isThrownBy(properties::afterPropertiesSet);
-	}
-
-	@Test
-	void acceptsBackslashAsProfileSeparator() {
-		AwsParamStoreProperties properties = new AwsParamStoreProperties();
-		properties.setProfileSeparator("\\");
-		assertThatNoException().isThrownBy(properties::afterPropertiesSet);
+	private static Stream<Arguments> validProperties() {
+		return Stream.of(
+				Arguments.of(new AwsParamStorePropertiesBuilder().withPrefix("/con").withDefaultContext("app")
+						.withProfileSeparator("_").build()),
+				Arguments.of(new AwsParamStorePropertiesBuilder().withPrefix("/config/someRandomValue-dev01")
+						.withDefaultContext("app").withProfileSeparator("_").build()),
+				Arguments.of(new AwsParamStorePropertiesBuilder().withPrefix("/con/test/bla").withDefaultContext("app")
+						.withProfileSeparator("_").build()),
+				Arguments.of(new AwsParamStorePropertiesBuilder().withPrefix("").withDefaultContext("app")
+						.withProfileSeparator("_").build()),
+				Arguments.of(new AwsParamStorePropertiesBuilder().withPrefix("/config").withDefaultContext("app")
+						.withProfileSeparator("/").build()),
+				Arguments.of(new AwsParamStorePropertiesBuilder().withPrefix("/config").withDefaultContext("app")
+						.withProfileSeparator("\\").build()));
 	}
 
 	private static Stream<Arguments> invalidProperties() {
-		return Stream.of(
-				Arguments.of(new AwsParamStorePropertiesBuilder().withPrefix("!.").build(), "prefix", "Pattern"),
-				Arguments.of(new AwsParamStorePropertiesBuilder().withDefaultContext("").build(), "defaultContext",
-						"NotEmpty"),
-				Arguments.of(new AwsParamStorePropertiesBuilder().withProfileSeparator("").build(), "profileSeparator",
-						"NotEmpty"),
+		return Stream.of(Arguments.of(new AwsParamStorePropertiesBuilder().withPrefix("!.").build(), "prefix"),
+				Arguments.of(new AwsParamStorePropertiesBuilder().withDefaultContext("").build(), "defaultContext"),
+				Arguments.of(new AwsParamStorePropertiesBuilder().withProfileSeparator("").build(), "profileSeparator"),
 				Arguments.of(new AwsParamStorePropertiesBuilder().withProfileSeparator("!_").build(),
-						"profileSeparator", "Pattern"));
+						"profileSeparator"));
 	}
 
 	private static class AwsParamStorePropertiesBuilder {

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerProperties.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerProperties.java
@@ -43,7 +43,7 @@ public class AwsSecretsManagerProperties implements InitializingBean {
 	/**
 	 * Pattern used for prefix validation.
 	 */
-	private static final Pattern PREFIX_PATTERN = Pattern.compile("(/)?([a-zA-Z0-9.\\-]+)(?:/[a-zA-Z0-9]+)*");
+	private static final Pattern PREFIX_PATTERN = Pattern.compile("[a-zA-Z0-9.\\-/]+");
 
 	/**
 	 * Pattern used for profileSeparator validation.
@@ -98,11 +98,11 @@ public class AwsSecretsManagerProperties implements InitializingBean {
 
 		if (StringUtils.hasLength(prefix) && !PREFIX_PATTERN.matcher(prefix).matches()) {
 			throw new ValidationException(CONFIG_PREFIX + ".prefix",
-					"The prefix must have pattern of:  " + PREFIX_PATTERN.toString());
+					"The prefix value: " + prefix + " must have pattern of: " + PREFIX_PATTERN.toString());
 		}
 		if (!PROFILE_SEPARATOR_PATTERN.matcher(profileSeparator).matches()) {
 			throw new ValidationException(CONFIG_PREFIX + ".profileSeparator",
-					"The profileSeparator must have pattern of:  " + PROFILE_SEPARATOR_PATTERN.toString());
+					"The profileSeparator must have pattern of: " + PROFILE_SEPARATOR_PATTERN.toString());
 		}
 
 	}

--- a/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertiesTest.java
+++ b/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertiesTest.java
@@ -18,12 +18,15 @@ package io.awspring.cloud.secretsmanager;
 
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Tests for {@link AwsSecretsManagerProperties}.
@@ -35,8 +38,14 @@ class AwsSecretsManagerPropertiesTest {
 
 	@ParameterizedTest
 	@MethodSource("invalidProperties")
-	public void validationFails(AwsSecretsManagerProperties properties, String field, String errorCode) {
-		assertThatThrownBy(properties::afterPropertiesSet).isInstanceOf(ValidationException.class);
+	public void validationFails(AwsSecretsManagerProperties properties, String field) throws Exception {
+		try {
+			properties.afterPropertiesSet();
+			fail("validation should fail");
+		}
+		catch (ValidationException e) {
+			assertThat(e.getField()).endsWith(field);
+		}
 	}
 
 	@ParameterizedTest
@@ -45,10 +54,19 @@ class AwsSecretsManagerPropertiesTest {
 		assertThatNoException().isThrownBy(properties::afterPropertiesSet);
 	}
 
+	@Test
+	void checkExceptionLoggingForPrefix() {
+		AwsSecretsManagerProperties properties = new AwsSecretsManagerPropertiesBuilder().withPrefix("!.").build();
+		assertThatThrownBy(properties::afterPropertiesSet)
+				.hasMessage("The prefix value: !. must have pattern of: [a-zA-Z0-9.\\-/]+");
+	}
+
 	private static Stream<Arguments> validProperties() {
 		return Stream.of(
 				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("").withDefaultContext("app")
 						.withProfileSeparator("_").build()),
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("/secret/someRandomValue-dev01")
+						.withDefaultContext("app").withProfileSeparator("_").build()),
 				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("/sec").withDefaultContext("app")
 						.withProfileSeparator("_").build()),
 				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("/sec/test/var")
@@ -62,14 +80,12 @@ class AwsSecretsManagerPropertiesTest {
 	}
 
 	private static Stream<Arguments> invalidProperties() {
-		return Stream.of(
-				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("!.").build(), "prefix", "Pattern"),
-				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withDefaultContext("").build(), "defaultContext",
-						"NotEmpty"),
+		return Stream.of(Arguments.of(new AwsSecretsManagerPropertiesBuilder().withPrefix("!.").build(), "prefix"),
+				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withDefaultContext("").build(), "defaultContext"),
 				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withProfileSeparator("").build(),
-						"profileSeparator", "NotEmpty"),
+						"profileSeparator"),
 				Arguments.of(new AwsSecretsManagerPropertiesBuilder().withProfileSeparator("!_").build(),
-						"profileSeparator", "Pattern"));
+						"profileSeparator"));
 	}
 
 	private static class AwsSecretsManagerPropertiesBuilder {


### PR DESCRIPTION
Applies PR #303 for 2.3.x, basically it was a cherry-pick and check that tests passes

All credits to Maciej Walkowiak @MatejNedic 

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
