### PR TITLE
Fix using globally configured region in Parameter Store & Secrets Manager integrations

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/AbstractAwsConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/AbstractAwsConfigDataLocationResolver.java
@@ -17,6 +17,7 @@ package io.awspring.cloud.autoconfigure.config;
 
 import io.awspring.cloud.autoconfigure.core.AwsProperties;
 import io.awspring.cloud.autoconfigure.core.CredentialsProperties;
+import io.awspring.cloud.autoconfigure.core.RegionProperties;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -86,6 +87,11 @@ public abstract class AbstractAwsConfigDataLocationResolver<T extends ConfigData
 	protected CredentialsProperties loadCredentialsProperties(Binder binder) {
 		return binder.bind(CredentialsProperties.PREFIX, Bindable.of(CredentialsProperties.class))
 				.orElseGet(CredentialsProperties::new);
+	}
+
+	protected RegionProperties loadRegionProperties(Binder binder) {
+		return binder.bind(RegionProperties.PREFIX, Bindable.of(RegionProperties.class))
+				.orElseGet(RegionProperties::new);
 	}
 
 	protected AwsProperties loadAwsProperties(Binder binder) {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/AbstractAwsConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/AbstractAwsConfigDataLocationResolver.java
@@ -15,12 +15,17 @@
  */
 package io.awspring.cloud.autoconfigure.config;
 
+import io.awspring.cloud.autoconfigure.AwsClientProperties;
 import io.awspring.cloud.autoconfigure.core.AwsProperties;
 import io.awspring.cloud.autoconfigure.core.CredentialsProperties;
+import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.RegionProperties;
+import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
+import io.awspring.cloud.core.SpringCloudClientConfiguration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.springframework.boot.BootstrapContext;
 import org.springframework.boot.BootstrapRegistry;
 import org.springframework.boot.ConfigurableBootstrapContext;
 import org.springframework.boot.context.config.ConfigDataLocation;
@@ -33,6 +38,10 @@ import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.util.StringUtils;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 
 /**
  * Base class for AWS specific {@link ConfigDataLocationResolver}s.
@@ -103,6 +112,47 @@ public abstract class AbstractAwsConfigDataLocationResolver<T extends ConfigData
 			return Arrays.asList(keys.split(";"));
 		}
 		return Collections.emptyList();
+	}
+
+	protected <T extends AwsClientBuilder<?, ?>> T configure(T builder, AwsClientProperties properties,
+			BootstrapContext context) {
+		AwsCredentialsProvider credentialsProvider;
+
+		try {
+			credentialsProvider = context.get(AwsCredentialsProvider.class);
+		}
+		catch (IllegalStateException e) {
+			CredentialsProperties credentialsProperties = context.get(CredentialsProperties.class);
+			credentialsProvider = CredentialsProviderAutoConfiguration.createCredentialsProvider(credentialsProperties);
+		}
+
+		AwsRegionProvider regionProvider;
+
+		try {
+			regionProvider = context.get(AwsRegionProvider.class);
+		}
+		catch (IllegalStateException e) {
+			RegionProperties regionProperties = context.get(RegionProperties.class);
+			regionProvider = RegionProviderAutoConfiguration.createRegionProvider(regionProperties);
+		}
+
+		AwsProperties awsProperties = context.get(AwsProperties.class);
+
+		if (StringUtils.hasLength(properties.getRegion())) {
+			builder.region(Region.of(properties.getRegion()));
+		}
+		else {
+			builder.region(regionProvider.getRegion());
+		}
+		if (properties.getEndpoint() != null) {
+			builder.endpointOverride(properties.getEndpoint());
+		}
+		else if (awsProperties.getEndpoint() != null) {
+			builder.endpointOverride(awsProperties.getEndpoint());
+		}
+		builder.credentialsProvider(credentialsProvider);
+		builder.overrideConfiguration(new SpringCloudClientConfiguration().clientOverrideConfiguration());
+		return builder;
 	}
 
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLocationResolver.java
@@ -18,10 +18,7 @@ package io.awspring.cloud.autoconfigure.config.parameterstore;
 import io.awspring.cloud.autoconfigure.config.AbstractAwsConfigDataLocationResolver;
 import io.awspring.cloud.autoconfigure.core.AwsProperties;
 import io.awspring.cloud.autoconfigure.core.CredentialsProperties;
-import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.RegionProperties;
-import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
-import io.awspring.cloud.core.SpringCloudClientConfiguration;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.boot.BootstrapContext;
@@ -31,12 +28,7 @@ import org.springframework.boot.context.config.ConfigDataLocationResolverContext
 import org.springframework.boot.context.config.Profiles;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
-import org.springframework.util.StringUtils;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 import software.amazon.awssdk.services.ssm.SsmClient;
-import software.amazon.awssdk.services.ssm.SsmClientBuilder;
 
 /**
  * @author Eddú Meléndez
@@ -83,46 +75,7 @@ public class ParameterStoreConfigDataLocationResolver
 	}
 
 	protected SsmClient createSimpleSystemManagementClient(BootstrapContext context) {
-		ParameterStoreProperties properties = context.get(ParameterStoreProperties.class);
-
-		AwsCredentialsProvider credentialsProvider;
-
-		try {
-			credentialsProvider = context.get(AwsCredentialsProvider.class);
-		}
-		catch (IllegalStateException e) {
-			CredentialsProperties credentialsProperties = context.get(CredentialsProperties.class);
-			credentialsProvider = CredentialsProviderAutoConfiguration.createCredentialsProvider(credentialsProperties);
-		}
-
-		AwsRegionProvider regionProvider;
-
-		try {
-			regionProvider = context.get(AwsRegionProvider.class);
-		}
-		catch (IllegalStateException e) {
-			RegionProperties regionProperties = context.get(RegionProperties.class);
-			regionProvider = RegionProviderAutoConfiguration.createRegionProvider(regionProperties);
-		}
-
-		AwsProperties awsProperties = context.get(AwsProperties.class);
-
-		SsmClientBuilder builder = SsmClient.builder()
-				.overrideConfiguration(new SpringCloudClientConfiguration().clientOverrideConfiguration());
-		if (StringUtils.hasLength(properties.getRegion())) {
-			builder.region(Region.of(properties.getRegion()));
-		}
-		else {
-			builder.region(regionProvider.getRegion());
-		}
-		if (properties.getEndpoint() != null) {
-			builder.endpointOverride(properties.getEndpoint());
-		}
-		else if (awsProperties.getEndpoint() != null) {
-			builder.endpointOverride(awsProperties.getEndpoint());
-		}
-		builder.credentialsProvider(credentialsProvider);
-		return builder.build();
+		return configure(SsmClient.builder(), context.get(ParameterStoreProperties.class), context).build();
 	}
 
 	protected ParameterStoreProperties loadProperties(Binder binder) {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLocationResolver.java
@@ -18,10 +18,7 @@ package io.awspring.cloud.autoconfigure.config.secretsmanager;
 import io.awspring.cloud.autoconfigure.config.AbstractAwsConfigDataLocationResolver;
 import io.awspring.cloud.autoconfigure.core.AwsProperties;
 import io.awspring.cloud.autoconfigure.core.CredentialsProperties;
-import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.RegionProperties;
-import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
-import io.awspring.cloud.core.SpringCloudClientConfiguration;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.boot.BootstrapContext;
@@ -31,12 +28,7 @@ import org.springframework.boot.context.config.ConfigDataLocationResolverContext
 import org.springframework.boot.context.config.Profiles;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
-import org.springframework.util.StringUtils;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
-import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
 
 /**
  * Resolves config data locations in AWS Secrets Manager.
@@ -88,48 +80,7 @@ public class SecretsManagerConfigDataLocationResolver
 	}
 
 	protected SecretsManagerClient createAwsSecretsManagerClient(BootstrapContext context) {
-		SecretsManagerProperties properties = context.get(SecretsManagerProperties.class);
-
-		AwsCredentialsProvider credentialsProvider;
-
-		try {
-			credentialsProvider = context.get(AwsCredentialsProvider.class);
-		}
-		catch (IllegalStateException e) {
-			CredentialsProperties credentialsProperties = context.get(CredentialsProperties.class);
-			credentialsProvider = CredentialsProviderAutoConfiguration.createCredentialsProvider(credentialsProperties);
-		}
-
-		AwsRegionProvider regionProvider;
-
-		try {
-			regionProvider = context.get(AwsRegionProvider.class);
-		}
-		catch (IllegalStateException e) {
-			RegionProperties regionProperties = context.get(RegionProperties.class);
-			regionProvider = RegionProviderAutoConfiguration.createRegionProvider(regionProperties);
-		}
-
-		AwsProperties awsProperties = context.get(AwsProperties.class);
-
-		SecretsManagerClientBuilder builder = SecretsManagerClient.builder()
-				.overrideConfiguration(new SpringCloudClientConfiguration().clientOverrideConfiguration());
-
-		if (StringUtils.hasLength(properties.getRegion())) {
-			builder.region(Region.of(properties.getRegion()));
-		}
-		else {
-			builder.region(regionProvider.getRegion());
-		}
-		if (properties.getEndpoint() != null) {
-			builder.endpointOverride(properties.getEndpoint());
-		}
-		else if (awsProperties.getEndpoint() != null) {
-			builder.endpointOverride(awsProperties.getEndpoint());
-		}
-		builder.credentialsProvider(credentialsProvider);
-
-		return builder.build();
+		return configure(SecretsManagerClient.builder(), context.get(SecretsManagerProperties.class), context).build();
 	}
 
 	protected SecretsManagerProperties loadProperties(Binder binder) {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/RegionProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/RegionProviderAutoConfiguration.java
@@ -53,17 +53,21 @@ public class RegionProviderAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public AwsRegionProvider regionProvider() {
+		return createRegionProvider(this.properties);
+	}
+
+	public static AwsRegionProvider createRegionProvider(RegionProperties properties) {
 		final List<AwsRegionProvider> providers = new ArrayList<>();
 
-		if (this.properties.getStatic() != null && this.properties.isStatic()) {
-			providers.add(new StaticRegionProvider(this.properties.getStatic()));
+		if (properties.getStatic() != null && properties.isStatic()) {
+			providers.add(new StaticRegionProvider(properties.getStatic()));
 		}
 
-		if (this.properties.isInstanceProfile()) {
+		if (properties.isInstanceProfile()) {
 			providers.add(new InstanceProfileRegionProvider());
 		}
 
-		Profile profile = this.properties.getProfile();
+		Profile profile = properties.getProfile();
 		if (profile != null && profile.getName() != null) {
 			providers.add(createProfileRegionProvider(profile));
 		}
@@ -76,7 +80,7 @@ public class RegionProviderAutoConfiguration {
 		}
 	}
 
-	private AwsProfileRegionProvider createProfileRegionProvider(Profile profile) {
+	private static AwsProfileRegionProvider createProfileRegionProvider(Profile profile) {
 		Supplier<ProfileFile> profileFileFn = () -> {
 			if (profile.getPath() != null) {
 				return ProfileFile.builder().type(ProfileFile.Type.CONFIGURATION).content(Paths.get(profile.getPath()))

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoaderIntegrationTests.java
@@ -174,6 +174,21 @@ class ParameterStoreConfigDataLoaderIntegrationTests {
 		}
 	}
 
+	@Test
+	void parameterStoreClientUsesGlobalRegion() {
+		SpringApplication application = new SpringApplication(App.class);
+		application.setWebApplicationType(WebApplicationType.NONE);
+
+		try (ConfigurableApplicationContext context = application.run(
+				"--spring.config.import=aws-parameterstore:/config/spring/",
+				"--spring.cloud.aws.endpoint=" + localstack.getEndpointOverride(SSM).toString(),
+				"--spring.cloud.aws.credentials.access-key=noop", "--spring.cloud.aws.credentials.secret-key=noop",
+				"--spring.cloud.aws.region.static=" + REGION,
+				"--logging.level.io.awspring.cloud.parameterstore=debug")) {
+			assertThat(context.getEnvironment().getProperty("message")).isEqualTo("value from tests");
+		}
+	}
+
 	private ConfigurableApplicationContext runApplication(SpringApplication application, String springConfigImport,
 			String endpointProperty) {
 		return application.run("--spring.config.import=" + springConfigImport,

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
@@ -174,6 +174,20 @@ class SecretsManagerConfigDataLoaderIntegrationTests {
 		}
 	}
 
+	@Test
+	void secretsManagerClientUsesGlobalRegion() {
+		SpringApplication application = new SpringApplication(SecretsManagerConfigDataLoaderIntegrationTests.App.class);
+		application.setWebApplicationType(WebApplicationType.NONE);
+
+		try (ConfigurableApplicationContext context = application.run(
+				"--spring.config.import=aws-secretsmanager:/config/spring;/config/second",
+				"--spring.cloud.aws.endpoint=" + localstack.getEndpointOverride(SECRETSMANAGER).toString(),
+				"--spring.cloud.aws.credentials.access-key=noop", "--spring.cloud.aws.credentials.secret-key=noop",
+				"--spring.cloud.aws.region.static=" + REGION)) {
+			assertThat(context.getEnvironment().getProperty("message")).isEqualTo("value from tests");
+		}
+	}
+
 	private ConfigurableApplicationContext runApplication(SpringApplication application, String springConfigImport) {
 		return runApplication(application, springConfigImport, "spring.cloud.aws.secretsmanager.endpoint");
 	}


### PR DESCRIPTION
Before this change, `spring.cloud.aws.region` property was not taken into account by Parameter Store and Secrets Manager integrations.

The only way to set the region was through `spring.cloud.aws.parameterstore.region` and `spring.cloud.aws.secretsmanager.region`.