### PR TITLE
feat: open user specific fork on gitpod

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,8 @@
 
 To avoid setting up your local development environment, you can use [Gitpod](https://www.gitpod.io/) and develop directly in browser based Visual Studio Code, or [JetBrains Client via JetBrains Gateway](https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway).
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/awspring/spring-cloud-aws)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
+**Note**: The above button does not work on Privacy oriented browsers, please [click here](https://gitpod.io/#https://github.com/awspring/spring-cloud-aws/)  to open the project on gitpod.
 
 Thanks!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🍃 Spring Cloud AWS
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/awspring/spring-cloud-aws)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 Simplifies using AWS managed services in a Spring and Spring Boot applications.
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
The `Open with Gitpod` Button opens the fork of the user when clicked.


## :bulb: Motivation and Context
When contributing most users will be working on their own forks, and loading the upstream repo and then switching is an extra step.
This way the user can directly start working on the fork if they already have one.
Note: This feature does not automatically create the fork for the user
Refs: #358 

## :green_heart: How did you test it?
Create a fork, click on the `Open with Gitpod` Button

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
