### PR TITLE
Change property name resolved for plaintext secrets in Secrets Manager integration

### DIFF
--- a/docs/src/main/asciidoc/secrets-manager.adoc
+++ b/docs/src/main/asciidoc/secrets-manager.adoc
@@ -114,8 +114,6 @@ Secret value can be retrieved by referencing secret name:
 spring.datasource.url=${jdbc-url}
 ----
 
-Secrets Manager integration cannot resolve plaintext secrets that end with `/`, for example if we had `/secrets/my-certificate/` exception would be thrown and application fails to start.
-
 === Using SecretsManagerClient
 
 The starter automatically configures and registers a `SecretsManagerClient` bean in the Spring application context. The `SecretsManagerClient` bean can be used to create or retrieve secrets imperatively.

--- a/docs/src/main/asciidoc/secrets-manager.adoc
+++ b/docs/src/main/asciidoc/secrets-manager.adoc
@@ -114,6 +114,8 @@ Secret value can be retrieved by referencing secret name:
 spring.datasource.url=${jdbc-url}
 ----
 
+Secrets Manager integration cannot resolve plaintext secrets that end with `/`, for example if we had `/secrets/my-certificate/` exception would be thrown and application fails to start.
+
 === Using SecretsManagerClient
 
 The starter automatically configures and registers a `SecretsManagerClient` bean in the Spring application context. The `SecretsManagerClient` bean can be used to create or retrieve secrets imperatively.

--- a/docs/src/main/asciidoc/secrets-manager.adoc
+++ b/docs/src/main/asciidoc/secrets-manager.adoc
@@ -97,21 +97,21 @@ For example, we will JDBC saved as plain text secret type with name `/secrets/my
 
 [source]
 ----
-$ aws secretsmanager create-secret --name /secrets/jdbc-url --secret-string jdbc:url
+$ aws secretsmanager create-secret --name /secrets/prod/jdbc-url --secret-string jdbc:url
 ----
 
 `spring.config.import` entry is added to `application.properties`:
 
 [source, properties]
 ----
-spring.config.import=aws-secretsmanager:/secrets/jdbc-url
+spring.config.import=aws-secretsmanager:/secrets/prod/jdbc-url
 ----
 
 Secret value can be retrieved by referencing secret name:
 
 [source,properties]
 ----
-spring.datasource.url=${/secrets/jdbc-url}
+spring.datasource.url=${jdbc-url}
 ----
 
 === Using SecretsManagerClient

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
@@ -62,8 +62,8 @@ class SecretsManagerConfigDataLoaderIntegrationTests {
 	static void beforeAll() {
 		createSecret(localstack, "/config/spring",
 				"{\"message\":\"value from tests\", \"another-parameter\": \"another parameter value\"}", REGION);
-		createSecret(localstack, "/certs/prod/fn_certificate", "=== my cert should be here", REGION);
-		createSecret(localstack, "/certs/dev/fn_certificate/", "=== my cert should be here", REGION);
+		createSecret(localstack, "/certs/prod/fn_certificate", "=== my prod cert should be here", REGION);
+		createSecret(localstack, "/certs/dev/fn_certificate/", "=== my dev cert should be here", REGION);
 		createSecret(localstack, "fn_certificate", "=== my cert should be here", REGION);
 		createSecret(localstack, "/config/second", "{\"secondMessage\":\"second value from tests\"}", REGION);
 	}
@@ -89,22 +89,20 @@ class SecretsManagerConfigDataLoaderIntegrationTests {
 
 		try (ConfigurableApplicationContext context = runApplication(application,
 				"aws-secretsmanager:/certs/prod/fn_certificate")) {
-			assertThat(context.getEnvironment().getProperty("fn_certificate")).isEqualTo("=== my cert should be here");
+			assertThat(context.getEnvironment().getProperty("fn_certificate"))
+					.isEqualTo("=== my prod cert should be here");
 		}
 	}
 
 	@Test
-	void resolvesPropertyFromSecretsManager_PlainTextSecret_CannotResolve(CapturedOutput output) {
+	void resolvesPropertyFromSecretsManager_PlainTextSecret_endingWithSlash() {
 		SpringApplication application = new SpringApplication(App.class);
 		application.setWebApplicationType(WebApplicationType.NONE);
 
 		try (ConfigurableApplicationContext context = runApplication(application,
 				"aws-secretsmanager:/certs/dev/fn_certificate/")) {
-			fail("SecretName ending with `/` should fail on start");
-		}
-		catch (RuntimeException e) {
-			assertThat(e.getCause().getMessage()).contains(
-					"Plain Text Secret which name ends with / cannot be resolved. Please change SecretName so it does not end with `/`   SecretName is:");
+			assertThat(context.getEnvironment().getProperty("fn_certificate"))
+					.isEqualTo("=== my dev cert should be here");
 		}
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
@@ -63,6 +63,7 @@ class SecretsManagerConfigDataLoaderIntegrationTests {
 		createSecret(localstack, "/config/spring",
 				"{\"message\":\"value from tests\", \"another-parameter\": \"another parameter value\"}", REGION);
 		createSecret(localstack, "/certs/prod/fn_certificate", "=== my cert should be here", REGION);
+		createSecret(localstack, "/certs/dev/fn_certificate/", "=== my cert should be here", REGION);
 		createSecret(localstack, "fn_certificate", "=== my cert should be here", REGION);
 		createSecret(localstack, "/config/second", "{\"secondMessage\":\"second value from tests\"}", REGION);
 	}
@@ -89,6 +90,21 @@ class SecretsManagerConfigDataLoaderIntegrationTests {
 		try (ConfigurableApplicationContext context = runApplication(application,
 				"aws-secretsmanager:/certs/prod/fn_certificate")) {
 			assertThat(context.getEnvironment().getProperty("fn_certificate")).isEqualTo("=== my cert should be here");
+		}
+	}
+
+	@Test
+	void resolvesPropertyFromSecretsManager_PlainTextSecret_CannotResolve(CapturedOutput output) {
+		SpringApplication application = new SpringApplication(App.class);
+		application.setWebApplicationType(WebApplicationType.NONE);
+
+		try (ConfigurableApplicationContext context = runApplication(application,
+				"aws-secretsmanager:/certs/dev/fn_certificate/")) {
+			fail("SecretName ending with `/` should fail on start");
+		}
+		catch (RuntimeException e) {
+			assertThat(e.getCause().getMessage()).contains(
+					"Plain Text Secret which name ends with / cannot be resolved. Please change SecretName so it does not end with `/`   SecretName is:");
 		}
 	}
 

--- a/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
+++ b/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
@@ -89,6 +89,12 @@ public class SecretsManagerPropertySource extends EnumerablePropertySource<Secre
 		}
 		catch (JsonParseException e) {
 			// If the secret is not a JSON string, then it is a simple "plain text" string
+			if (secretValueResponse.name().endsWith("/")) {
+				String msg = "Plain Text Secret which name ends with / cannot be resolved. Please change SecretName so it does not end with `/`   SecretName is:"
+						+ secretValueResponse.name();
+				LOG.error(msg);
+				throw new RuntimeException(msg);
+			}
 			String secretName = secretValueResponse.name().lastIndexOf("/") != 0
 					? secretValueResponse.name().substring(secretValueResponse.name().lastIndexOf("/") + 1)
 					: secretValueResponse.name();

--- a/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
+++ b/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
@@ -90,9 +90,9 @@ public class SecretsManagerPropertySource extends EnumerablePropertySource<Secre
 		catch (JsonParseException e) {
 			// If the secret is not a JSON string, then it is a simple "plain text" string
 			if (secretValueResponse.name().endsWith("/")) {
-				String msg = "Plain Text Secret which name ends with / cannot be resolved. Please change SecretName so it does not end with `/`   SecretName is:"
-						+ secretValueResponse.name();
-				throw new RuntimeException(msg);
+				throw new RuntimeException(
+						"Plain Text Secret which name ends with / cannot be resolved. Please change SecretName so it does not end with `/`   SecretName is:"
+								+ secretValueResponse.name());
 			}
 			String secretName = secretValueResponse.name().lastIndexOf("/") != 0
 					? secretValueResponse.name().substring(secretValueResponse.name().lastIndexOf("/") + 1)

--- a/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
+++ b/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
@@ -89,8 +89,11 @@ public class SecretsManagerPropertySource extends EnumerablePropertySource<Secre
 		}
 		catch (JsonParseException e) {
 			// If the secret is not a JSON string, then it is a simple "plain text" string
-			LOG.debug("Populating property retrieved from AWS Secrets Manager: " + secretValueResponse.name());
-			properties.put(secretValueResponse.name(), secretValueResponse.secretString());
+			String secretName = secretValueResponse.name().lastIndexOf("/") != 0
+					? secretValueResponse.name().substring(secretValueResponse.name().lastIndexOf("/") + 1)
+					: secretValueResponse.name();
+			LOG.debug("Populating property retrieved from AWS Secrets Manager: " + secretName);
+			properties.put(secretName, secretValueResponse.secretString());
 		}
 		catch (JsonProcessingException e) {
 			throw new RuntimeException(e);

--- a/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
+++ b/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
@@ -89,14 +89,8 @@ public class SecretsManagerPropertySource extends EnumerablePropertySource<Secre
 		}
 		catch (JsonParseException e) {
 			// If the secret is not a JSON string, then it is a simple "plain text" string
-			if (secretValueResponse.name().endsWith("/")) {
-				throw new RuntimeException(
-						"Plain Text Secret which name ends with / cannot be resolved. Please change SecretName so it does not end with `/`   SecretName is:"
-								+ secretValueResponse.name());
-			}
-			String secretName = secretValueResponse.name().lastIndexOf("/") != 0
-					? secretValueResponse.name().substring(secretValueResponse.name().lastIndexOf("/") + 1)
-					: secretValueResponse.name();
+			String[] parts = secretValueResponse.name().split("/");
+			String secretName = parts[parts.length - 1];
 			LOG.debug("Populating property retrieved from AWS Secrets Manager: " + secretName);
 			properties.put(secretName, secretValueResponse.secretString());
 		}

--- a/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
+++ b/spring-cloud-aws-secrets-manager/src/main/java/io/awspring/cloud/secretsmanager/SecretsManagerPropertySource.java
@@ -92,7 +92,6 @@ public class SecretsManagerPropertySource extends EnumerablePropertySource<Secre
 			if (secretValueResponse.name().endsWith("/")) {
 				String msg = "Plain Text Secret which name ends with / cannot be resolved. Please change SecretName so it does not end with `/`   SecretName is:"
 						+ secretValueResponse.name();
-				LOG.error(msg);
 				throw new RuntimeException(msg);
 			}
 			String secretName = secretValueResponse.name().lastIndexOf("/") != 0


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Since secret names that are used in secrets manager usually follow patter `/something/enviroment/secretname` we should resolve plaintext secret to `secretname`.
In case of `/certs/prod/fn_certificate `   `fn_certificate` should be secret name that will be used with `@Value("${fn_certificate}`.
This allows more fine grained namings for example:
`/certs/dev/fn_certificate`
`/certs/prod/fn_certificate`
and so on.

## :bulb: Motivation and Context
To allow users to fine grain secrets names depending on evniroment.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
