### PR TITLE
Reduce amount of logs in Parameter Store tests.

### DIFF
--- a/spring-cloud-starter-aws-parameter-store-config/src/test/resources/logback.xml
+++ b/spring-cloud-starter-aws-parameter-store-config/src/test/resources/logback.xml
@@ -1,0 +1,34 @@
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<logger name="org.testcontainers" level="INFO"/>
+	<logger name="com.github.dockerjava" level="WARN"/>
+	<logger name="io.awspring" level="INFO"/>
+	<logger name="com.amazonaws.util.EC2MetadataUtils" level="ERROR"/>
+	<logger name="com.amazonaws.internal.InstanceMetadataServiceResourceFetcher" level="ERROR"/>
+
+	<root level="INFO">
+		<appender-ref ref="STDOUT"/>
+	</root>
+</configuration>


### PR DESCRIPTION
Docker and Testcontainers produce huge amount of logs causing sometimes JVM crash.