### PR TITLE
Add Ability to get metadata via S3Resource

### DIFF
--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Resource.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Resource.java
@@ -40,7 +40,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
  * @author Agim Emruli
  * @author Alain Sahli
  * @author Maciej Walkowiak
- * @author yoshida
+ * @author Yuki Yoshida
  * @since 3.0
  */
 public class S3Resource extends AbstractResource implements WritableResource {

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Resource.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Resource.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.WritableResource;
 import org.springframework.lang.Nullable;
@@ -39,6 +40,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
  * @author Agim Emruli
  * @author Alain Sahli
  * @author Maciej Walkowiak
+ * @author yoshida
  * @since 3.0
  */
 public class S3Resource extends AbstractResource implements WritableResource {
@@ -146,6 +148,13 @@ public class S3Resource extends AbstractResource implements WritableResource {
 				+ "getInputStream() to retrieve the contents of the object!");
 	}
 
+	public Map<String, String> metadata() {
+		if (headMetadata == null) {
+			fetchMetadata();
+		}
+		return headMetadata.metadata;
+	}
+
 	private void fetchMetadata() {
 		HeadObjectResponse response = s3Client.headObject(request -> request.bucket(location.getBucket())
 				.key(location.getObject()).versionId(location.getVersion()));
@@ -165,10 +174,13 @@ public class S3Resource extends AbstractResource implements WritableResource {
 
 		private final String contentType;
 
+		private final Map<String, String> metadata;
+
 		HeadMetadata(HeadObjectResponse headObjectResponse) {
 			this.contentLength = headObjectResponse.contentLength();
 			this.lastModified = headObjectResponse.lastModified();
 			this.contentType = headObjectResponse.contentType();
+			this.metadata = headObjectResponse.metadata();
 		}
 
 	}

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ResourceIntegrationTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ResourceIntegrationTests.java
@@ -31,11 +31,14 @@ import java.lang.annotation.Target;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.localstack.LocalStackContainer;
@@ -220,6 +223,23 @@ class S3ResourceIntegrationTests {
 		GetObjectResponse result = client
 				.getObject(request -> request.bucket("first-bucket").key("new-file.txt").build()).response();
 		assertThat(result.contentType()).isEqualTo("text/plain");
+	}
+
+	@Test
+	void retrievesMetadata() {
+		Map<String, String> metadata = new HashMap<>();
+		metadata.put("key", "keyValue");
+		metadata.put("camelCaseKey", "camelCaseKeyValue");
+
+		client.putObject(r -> r.bucket("first-bucket").key("metadata.txt").metadata(metadata),
+				RequestBody.fromString("hello"));
+
+		S3Resource resource = s3Resource("s3://first-bucket/metadata.txt",
+				new InMemoryBufferingS3OutputStreamProvider(client, new PropertiesS3ObjectContentTypeResolver()));
+
+		assertThat(resource.metadata()).containsEntry("key", "keyValue")
+				// retrieved as lower case
+				.containsEntry("camelcasekey", "camelCaseKeyValue").doesNotContainKey("camelCaseKey");
 	}
 
 	@NotNull

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
@@ -25,8 +25,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -186,22 +184,6 @@ class S3TemplateIntegrationTests {
 			String result = StreamUtils.copyToString(is, StandardCharsets.UTF_8);
 			assertThat(result).isEqualTo("hello");
 		}
-	}
-
-	@Test
-	void retrieveMetadata() throws IOException {
-		Map<String, String> metadata = new HashMap<>();
-		metadata.put("key", "keyValue");
-		metadata.put("camelCaseKey", "camelCaseKeyValue");
-
-		client.putObject(r -> r.bucket("test-bucket").key("metadata.txt").metadata(metadata), RequestBody.fromString("hello"));
-		S3Resource resource = s3Template.download("test-bucket", "metadata.txt");
-
-		assertThat(resource.metadata())
-			.containsEntry("key", "keyValue")
-			// retrieved as lower case
-			.containsEntry("camelcasekey", "camelCaseKeyValue")
-			.doesNotContainKey("camelCaseKey");
 	}
 
 	private void bucketDoesNotExist(ListBucketsResponse r, String bucketName) {

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
@@ -50,7 +50,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
  * Integration tests for {@link S3Template}.
  *
  * @author Maciej Walkowiak
- * @author yoshida
+ * @author Yuki Yoshida
  */
 @Testcontainers
 class S3TemplateIntegrationTests {

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
@@ -25,6 +25,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +50,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
  * Integration tests for {@link S3Template}.
  *
  * @author Maciej Walkowiak
+ * @author yoshida
  */
 @Testcontainers
 class S3TemplateIntegrationTests {
@@ -183,6 +186,22 @@ class S3TemplateIntegrationTests {
 			String result = StreamUtils.copyToString(is, StandardCharsets.UTF_8);
 			assertThat(result).isEqualTo("hello");
 		}
+	}
+
+	@Test
+	void retrieveMetadata() throws IOException {
+		Map<String, String> metadata = new HashMap<>();
+		metadata.put("key", "keyValue");
+		metadata.put("camelCaseKey", "camelCaseKeyValue");
+
+		client.putObject(r -> r.bucket("test-bucket").key("metadata.txt").metadata(metadata), RequestBody.fromString("hello"));
+		S3Resource resource = s3Template.download("test-bucket", "metadata.txt");
+
+		assertThat(resource.metadata())
+			.containsEntry("key", "keyValue")
+			// retrieved as lower case
+			.containsEntry("camelcasekey", "camelCaseKeyValue")
+			.doesNotContainKey("camelCaseKey");
 	}
 
 	private void bucketDoesNotExist(ListBucketsResponse r, String bucketName) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Add Ability to get metadata via S3Resource

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We can retrieve metadata from `S3Resource` without using `S3Client` directly.

## :green_heart: How did you test it?
Add below integration test.

`io.awspring.cloud.s3.S3TemplateIntegrationTests#retrieveMetadata`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

#447 Should or Should not treat metadata key as case-insensitive.