### PR TITLE
Use status code instead of message to detect region change

### DIFF
--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-codegen/src/main/java/io/awspring/cloud/s3/codegen/CrossRegionS3ClientTemplate.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-codegen/src/main/java/io/awspring/cloud/s3/codegen/CrossRegionS3ClientTemplate.java
@@ -41,6 +41,7 @@ public class CrossRegionS3ClientTemplate implements S3Client {
 	private static final Logger LOGGER = LoggerFactory.getLogger("io.awspring.cloud.s3.CrossRegionS3Client");
 
 	private static final int DEFAULT_BUCKET_CACHE_SIZE = 20;
+	private static final int HTTP_CODE_PERMANENT_REDIRECT = 301;
 
 	private final Map<Region, S3Client> clientCache = new ConcurrentHashMap<>(Region.regions().size());
 
@@ -96,9 +97,9 @@ public class CrossRegionS3ClientTemplate implements S3Client {
 				LOGGER.debug("Exception when requesting S3 for bucket: {}: [{}] {}", bucket,
 						e.awsErrorDetails().errorCode(), e.awsErrorDetails().errorMessage());
 			}
-			// "PermanentRedirect" means that the bucket is in different region than the
+			// A 301 error code ("PermanentRedirect") means that the bucket is in different region than the
 			// defaultS3Client is configured for
-			if ("PermanentRedirect".equals(e.awsErrorDetails().errorCode())) {
+			if (e.awsErrorDetails().sdkHttpResponse().statusCode() == HTTP_CODE_PERMANENT_REDIRECT) {
 				return fn.apply(bucketCache.get(bucket));
 			}
 			else {

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/test/java/io/awspring/cloud/s3/crossregion/CrossRegionS3ClientTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/test/java/io/awspring/cloud/s3/crossregion/CrossRegionS3ClientTests.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
@@ -124,8 +125,12 @@ class CrossRegionS3ClientTests {
 	}
 
 	private void createBucket(String s, Region region) {
-		when(defaultClient.listObjects(ListObjectsRequest.builder().bucket(s).build())).thenThrow(S3Exception.builder()
-				.awsErrorDetails(AwsErrorDetails.builder().errorCode("PermanentRedirect").build()).build());
+		when(defaultClient.listObjects(ListObjectsRequest.builder().bucket(s).build()))
+				.thenThrow(
+						S3Exception.builder()
+								.awsErrorDetails(AwsErrorDetails.builder()
+										.sdkHttpResponse(SdkHttpResponse.builder().statusCode(301).build()).build())
+								.build());
 		when(defaultClient.getBucketLocation(GetBucketLocationRequest.builder().bucket(s).build()))
 				.thenReturn(GetBucketLocationResponse.builder().locationConstraint(region.id()).build());
 	}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Instead of checking whether the S3Exception message matches "PermanentRedirect", just check whether the code is 301 (by definition, permanent redirect).


## :bulb: Motivation and Context
The AWS SDK has a null message when the HeadObject operation uses the wrong region, meaning that the existing CrossRegionS3Client implementation doesn't detect it. By using the code instead, the client works on more use cases.

https://github.com/aws/aws-sdk-java-v2/issues/3287

## :green_heart: How did you test it?
Run locally in a project which gets the file size prior to actually reading the file, and has failed up until this point.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
