### PR TITLE
Simplify generator path calculation

### DIFF
--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-codegen/pom.xml
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-codegen/pom.xml
@@ -29,6 +29,11 @@
 	</dependencies>
 
 	<build>
+		<resources>
+			<resource> <!-- Include raw java files so that the generator can use them as a template -->
+				<directory>src/main/java</directory>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-codegen/src/main/java/io/awspring/cloud/s3/codegen/AbstractCrossRegionS3ClientGenerator.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-codegen/src/main/java/io/awspring/cloud/s3/codegen/AbstractCrossRegionS3ClientGenerator.java
@@ -60,7 +60,7 @@ public final class AbstractCrossRegionS3ClientGenerator {
 
 		// load template class
 		CompilationUnit compilationUnit = StaticJavaParser
-				.parseResource("io/awspring/cloud/s3/codegen/AbstractCrossRegionS3ClientTemplate.java");
+				.parseResource(AbstractCrossRegionS3ClientTemplate.class.getName().replace(".", "/") + ".java");
 		compilationUnit.setPackageDeclaration("io.awspring.cloud.s3.crossregion");
 		ClassOrInterfaceDeclaration classOrInterfaceDeclaration = compilationUnit
 				.getClassByName("AbstractCrossRegionS3ClientTemplate")

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-codegen/src/main/java/io/awspring/cloud/s3/codegen/AbstractCrossRegionS3ClientGenerator.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-codegen/src/main/java/io/awspring/cloud/s3/codegen/AbstractCrossRegionS3ClientGenerator.java
@@ -55,13 +55,12 @@ public final class AbstractCrossRegionS3ClientGenerator {
 
 	public static void main(String[] args) throws IOException {
 		if (args.length != 1) {
-			throw new IllegalArgumentException("Need 1 parameter: the JavaParser source checkout root directory.");
+			throw new IllegalArgumentException("Needs 1 parameter: the output directory");
 		}
 
 		// load template class
-		final Path source = Paths.get(args[0], "..", "spring-cloud-aws-s3-codegen", "src", "main", "java", "io",
-				"awspring", "cloud", "s3", "codegen", "AbstractCrossRegionS3ClientTemplate.java");
-		CompilationUnit compilationUnit = StaticJavaParser.parse(source);
+		CompilationUnit compilationUnit = StaticJavaParser
+				.parseResource("io/awspring/cloud/s3/codegen/AbstractCrossRegionS3ClientTemplate.java");
 		compilationUnit.setPackageDeclaration("io.awspring.cloud.s3.crossregion");
 		ClassOrInterfaceDeclaration classOrInterfaceDeclaration = compilationUnit
 				.getClassByName("AbstractCrossRegionS3ClientTemplate")
@@ -76,8 +75,12 @@ public final class AbstractCrossRegionS3ClientGenerator {
 		addOverriddenMethods(classOrInterfaceDeclaration);
 
 		// generate target file
-		final Path generatedJavaCcRoot = Paths.get(args[0], "..", "spring-cloud-aws-s3-cross-region-client", "src",
-				"main", "java", "io", "awspring", "cloud", "s3", "crossregion", "AbstractCrossRegionS3Client.java");
+		String[] classPackage = classOrInterfaceDeclaration.getFullyQualifiedName()
+				.orElseThrow(() -> new IllegalStateException("Couldn't get FQN from " + classOrInterfaceDeclaration))
+				.split("\\.");
+		classPackage[classPackage.length - 1] += ".java";
+		final Path generatedJavaCcRoot = Paths.get(args[0], classPackage);
+		Files.createDirectories(generatedJavaCcRoot.getParent());
 		Files.write(generatedJavaCcRoot, Collections.singletonList(compilationUnit.toString()));
 	}
 

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/pom.xml
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/pom.xml
@@ -51,7 +51,7 @@
 					<includePluginDependencies>true</includePluginDependencies>
 					<mainClass>io.awspring.cloud.s3.codegen.AbstractCrossRegionS3ClientGenerator</mainClass>
 					<arguments>
-						<argument>${project.basedir}</argument>
+						<argument>${project.build.sourceDirectory}</argument>
 					</arguments>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
A piece of https://github.com/fjmacagno/spring-cloud-aws/pull/1 which i thought might still be useful. Instead of having the generator take the path that the template is at, include the template as a resource so that it will always be accessible, whether the generator is run with access to the source tree or not. It also swaps the argument to be the output directory, so that the generator doesn't need to be project-aware.


## :bulb: Motivation and Context
Originally this made putting the generated class into the target dir possible, but now motivation is just that i already did the work and the code is potentially cleaner for it.


## :green_heart: How did you test it?
Running `mvn clean` and `make build`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
