### PR TITLE
Simplify Region and Credentials providers autoconfigurations.

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProviderAutoConfiguration.java
@@ -76,6 +76,9 @@ public class CredentialsProviderAutoConfiguration {
 		if (providers.isEmpty()) {
 			return DefaultCredentialsProvider.create();
 		}
+		else if (providers.size() == 1) {
+			return providers.get(0);
+		}
 		else {
 			return AwsCredentialsProviderChain.builder().credentialsProviders(providers).build();
 		}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/RegionProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/RegionProviderAutoConfiguration.java
@@ -75,6 +75,9 @@ public class RegionProviderAutoConfiguration {
 		if (providers.isEmpty()) {
 			return DefaultAwsRegionProviderChain.builder().build();
 		}
+		else if (providers.size() == 1) {
+			return providers.get(0);
+		}
 		else {
 			return new AwsRegionProviderChain(providers.toArray(new AwsRegionProvider[0]));
 		}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/core/CredentialsProviderAutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/core/CredentialsProviderAutoConfigurationTests.java
@@ -18,7 +18,6 @@ package io.awspring.cloud.autoconfigure.core;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -26,7 +25,6 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.test.util.ReflectionTestUtils;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -59,15 +57,10 @@ class CredentialsProviderAutoConfigurationTests {
 		this.contextRunner.withPropertyValues("spring.cloud.aws.credentials.accessKey:foo",
 				"spring.cloud.aws.credentials.secretKey:bar").run((context) -> {
 					AwsCredentialsProvider awsCredentialsProvider = context.getBean("credentialsProvider",
-							AwsCredentialsProvider.class);
+							StaticCredentialsProvider.class);
 					assertThat(awsCredentialsProvider).isNotNull();
 					assertThat(awsCredentialsProvider.resolveCredentials().accessKeyId()).isEqualTo("foo");
 					assertThat(awsCredentialsProvider.resolveCredentials().secretAccessKey()).isEqualTo("bar");
-
-					@SuppressWarnings("unchecked")
-					List<AwsCredentialsProvider> credentialsProviders = (List<AwsCredentialsProvider>) ReflectionTestUtils
-							.getField(awsCredentialsProvider, "credentialsProviders");
-					assertThat(credentialsProviders).hasSize(1).hasOnlyElementsOfType(StaticCredentialsProvider.class);
 				});
 	}
 
@@ -75,13 +68,8 @@ class CredentialsProviderAutoConfigurationTests {
 	void credentialsProvider_instanceProfileConfigured_configuresInstanceProfileCredentialsProvider() {
 		this.contextRunner.withPropertyValues("spring.cloud.aws.credentials.instance-profile:true").run((context) -> {
 			AwsCredentialsProvider awsCredentialsProvider = context.getBean("credentialsProvider",
-					AwsCredentialsProvider.class);
+					InstanceProfileCredentialsProvider.class);
 			assertThat(awsCredentialsProvider).isNotNull();
-
-			@SuppressWarnings("unchecked")
-			List<AwsCredentialsProvider> credentialsProviders = (List<AwsCredentialsProvider>) ReflectionTestUtils
-					.getField(awsCredentialsProvider, "credentialsProviders");
-			assertThat(credentialsProviders).hasSize(1).hasOnlyElementsOfType(InstanceProfileCredentialsProvider.class);
 		});
 	}
 
@@ -93,17 +81,11 @@ class CredentialsProviderAutoConfigurationTests {
 								.getAbsolutePath())
 				.run((context) -> {
 					AwsCredentialsProvider awsCredentialsProvider = context.getBean("credentialsProvider",
-							AwsCredentialsProvider.class);
+							ProfileCredentialsProvider.class);
 					assertThat(awsCredentialsProvider).isNotNull();
-
-					@SuppressWarnings("unchecked")
-					List<AwsCredentialsProvider> credentialsProviders = (List<AwsCredentialsProvider>) ReflectionTestUtils
-							.getField(awsCredentialsProvider, "credentialsProviders");
-					assertThat(credentialsProviders).hasSize(1).hasOnlyElementsOfType(ProfileCredentialsProvider.class);
-
-					ProfileCredentialsProvider provider = (ProfileCredentialsProvider) credentialsProviders.get(0);
-					assertThat(provider.resolveCredentials().accessKeyId()).isEqualTo("testAccessKey");
-					assertThat(provider.resolveCredentials().secretAccessKey()).isEqualTo("testSecretKey");
+					assertThat(awsCredentialsProvider.resolveCredentials().accessKeyId()).isEqualTo("testAccessKey");
+					assertThat(awsCredentialsProvider.resolveCredentials().secretAccessKey())
+							.isEqualTo("testSecretKey");
 				});
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/core/RegionProviderAutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/core/RegionProviderAutoConfigurationTests.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.awspring.cloud.core.region.StaticRegionProvider;
 import java.io.IOException;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -27,7 +26,6 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.test.util.ReflectionTestUtils;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.AwsProfileRegionProvider;
@@ -57,15 +55,8 @@ class RegionProviderAutoConfigurationTests {
 	@Test
 	void staticRegionConfigured_staticRegionProviderWithConfiguredRegionConfigured() {
 		this.contextRunner.withPropertyValues("spring.cloud.aws.region.static:eu-west-1").run((context) -> {
-			AwsRegionProvider awsRegionProvider = context.getBean(AwsRegionProvider.class);
-
-			@SuppressWarnings("unchecked")
-			List<AwsRegionProvider> regionProviders = (List<AwsRegionProvider>) ReflectionTestUtils
-					.getField(awsRegionProvider, "providers");
-			assertThat(regionProviders).hasSize(1).hasOnlyElementsOfType(StaticRegionProvider.class);
-
-			StaticRegionProvider regionProvider = (StaticRegionProvider) regionProviders.get(0);
-			assertThat(regionProvider.getRegion()).isEqualTo(Region.EU_WEST_1);
+			AwsRegionProvider awsRegionProvider = context.getBean("regionProvider", StaticRegionProvider.class);
+			assertThat(awsRegionProvider.getRegion()).isEqualTo(Region.EU_WEST_1);
 		});
 	}
 
@@ -86,29 +77,19 @@ class RegionProviderAutoConfigurationTests {
 						+ new ClassPathResource(getClass().getSimpleName() + "-profile", getClass()).getFile()
 								.getAbsolutePath())
 				.run((context) -> {
-					AwsRegionProvider awsRegionProvider = context.getBean("regionProvider", AwsRegionProvider.class);
+					AwsRegionProvider awsRegionProvider = context.getBean("regionProvider",
+							AwsProfileRegionProvider.class);
 					assertThat(awsRegionProvider).isNotNull();
-
-					@SuppressWarnings("unchecked")
-					List<AwsRegionProvider> regionProviders = (List<AwsRegionProvider>) ReflectionTestUtils
-							.getField(awsRegionProvider, "providers");
-					assertThat(regionProviders).hasSize(1).hasOnlyElementsOfType(AwsProfileRegionProvider.class);
-
-					AwsProfileRegionProvider regionProvider = (AwsProfileRegionProvider) regionProviders.get(0);
-					assertThat(regionProvider.getRegion()).isEqualTo(Region.EU_WEST_1);
+					assertThat(awsRegionProvider.getRegion()).isEqualTo(Region.EU_WEST_1);
 				});
 	}
 
 	@Test
 	void regionProvider_instanceProfileConfigured_configuresInstanceProfileCredentialsProvider() {
 		this.contextRunner.withPropertyValues("spring.cloud.aws.region.instance-profile:true").run((context) -> {
-			AwsRegionProvider awsCredentialsProvider = context.getBean("regionProvider", AwsRegionProvider.class);
+			AwsRegionProvider awsCredentialsProvider = context.getBean("regionProvider",
+					InstanceProfileRegionProvider.class);
 			assertThat(awsCredentialsProvider).isNotNull();
-
-			@SuppressWarnings("unchecked")
-			List<AwsRegionProvider> credentialsProviders = (List<AwsRegionProvider>) ReflectionTestUtils
-					.getField(awsCredentialsProvider, "providers");
-			assertThat(credentialsProviders).hasSize(1).hasOnlyElementsOfType(InstanceProfileRegionProvider.class);
 		});
 	}
 


### PR DESCRIPTION
When only single region/credentials provider is configured, instead of wrapping it into provider chain with single element, return this provider directly. Simplifies testing as a side effect.