### PR TITLE
Add spring-cloud-aws-starter-metrics to dependencies

### DIFF
--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -149,6 +149,12 @@
 
 			<dependency>
 				<groupId>io.awspring.cloud</groupId>
+				<artifactId>spring-cloud-aws-starter-metrics</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>io.awspring.cloud</groupId>
 				<artifactId>spring-cloud-aws-starter-parameter-store</artifactId>
 				<version>${project.version}</version>
 			</dependency>


### PR DESCRIPTION
Currently, not able to import the dependency when declare
io.awspring.cloud:spring-cloud-aws-dependencies in dependencyManagement.
