### PR TITLE
Docs update for S3 and ParameterStore starter coordinates.

### DIFF
--- a/docs/src/main/asciidoc/parameter-store.adoc
+++ b/docs/src/main/asciidoc/parameter-store.adoc
@@ -9,7 +9,7 @@ Maven coordinates, using <<index.adoc#bill-of-materials, Spring Cloud AWS BOM>>:
 ----
 <dependency>
     <groupId>io.awspring.cloud</groupId>
-    <artifactId>spring-cloud-starter-aws-parameter-store</artifactId>
+    <artifactId>spring-cloud-aws-starter-parameter-store</artifactId>
 </dependency>
 ----
 

--- a/docs/src/main/asciidoc/s3.adoc
+++ b/docs/src/main/asciidoc/s3.adoc
@@ -10,7 +10,7 @@ Maven coordinates, using <<index.adoc#bill-of-materials, Spring Cloud AWS BOM>>:
 ----
 <dependency>
     <groupId>io.awspring.cloud</groupId>
-    <artifactId>spring-cloud-starter-aws-s3</artifactId>
+    <artifactId>spring-cloud-aws-starter-s3</artifactId>
 </dependency>
 ----
 
@@ -85,7 +85,7 @@ To disable `CrossRegionS3Client` creation and use instead a regular region-speci
 ----
 <dependency>
     <groupId>io.awspring.cloud</groupId>
-    <artifactId>spring-cloud-starter-aws-s3</artifactId>
+    <artifactId>spring-cloud-aws-starter-s3</artifactId>
     <exclusions>
         <exclusion>
             <groupId>io.awspring.cloud</groupId>


### PR DESCRIPTION
This PR fixes the issue https://github.com/awspring/spring-cloud-aws/issues/524

Updated the docs to correct the S3 and ParameterStore starters maven coordinates to the following:

```
<dependency>
    <groupId>io.awspring.cloud</groupId>
    <artifactId>spring-cloud-aws-starter-s3</artifactId>
</dependency>
<dependency>
    <groupId>io.awspring.cloud</groupId>
    <artifactId>spring-cloud-aws-starter-parameter-store</artifactId>
</dependency>
```