### PR TITLE
Adds aws starter for RegionProviderAutoConfiguration

### DIFF
--- a/spring-cloud-aws-starters/spring-cloud-aws-starter-metrics/pom.xml
+++ b/spring-cloud-aws-starters/spring-cloud-aws-starter-metrics/pom.xml
@@ -36,6 +36,10 @@
 			<artifactId>spring-cloud-aws-autoconfigure</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.awspring.cloud</groupId>
+			<artifactId>spring-cloud-aws-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-cloudwatch2</artifactId>
 		</dependency>

--- a/spring-cloud-aws-starters/spring-cloud-aws-starter-metrics/pom.xml
+++ b/spring-cloud-aws-starters/spring-cloud-aws-starter-metrics/pom.xml
@@ -33,11 +33,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>io.awspring.cloud</groupId>
-			<artifactId>spring-cloud-aws-autoconfigure</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.awspring.cloud</groupId>
-			<artifactId>spring-cloud-aws-core</artifactId>
+			<artifactId>spring-cloud-aws-starter</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>


### PR DESCRIPTION
If a project is using only metrics starter then Creation of CloudWatchAsyncClient Bean couldn't be completed as it needs AwsRegionProvider Bean.

Though there is a `RegionProviderAutoConfiguration` it can't be triggered as there is a condition on 

`@ConditionalOnClass({ StaticRegionProvider.class, AwsRegionProvider.class, ProfileFile.class })`

Here **`StaticRegionProvider.class`** is present in aws-core Hence adding  it to fix the issue

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
