### PR TITLE
Fixing Spring cloud dependencies parent version from 4.0.0-M5 to 3.1.5

### DIFF
--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
-		<version>4.0.0-M5</version>
+		<version>3.1.5</version>
 		<relativePath/>
 	</parent>
 	<scm>
@@ -29,7 +29,7 @@
 		<awssdk-v1.version>1.12.326</awssdk-v1.version>
 		<amazon.dax.version>2.0.1</amazon.dax.version>
 		<maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-		<spring-cloud-commons.version>4.0.0-M5</spring-cloud-commons.version>
+		<spring-cloud-commons.version>3.1.5</spring-cloud-commons.version>
 		<testcontainers.version>1.17.5</testcontainers.version>
 	</properties>
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
I updated the `spring-cloud-aws-dependencies` version to 3.0.0-M3 in my project and it was failing.
```
org.springframework.cloud:spring-cloud-dependencies-parent:pom:4.0.0-M5 was not found in https://repo.maven.apache.org/maven2
```
the 4.0.0-M5 version is not available and I see the latest version available is 3.1.5 so thought of fixing it.  

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
I am assuming the pipeline with tell me if the fix is proper or not. 


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
