### PR TITLE
Add Queue to SQS Container Task Executor (#580)

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractPipelineMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractPipelineMessageListenerContainer.java
@@ -222,7 +222,8 @@ public abstract class AbstractPipelineMessageListenerContainer<T> extends Abstra
 		int poolSize = getContainerOptions().getMaxInFlightMessagesPerQueue() * this.messageSources.size();
 		executor.setMaxPoolSize(poolSize);
 		executor.setCorePoolSize(getContainerOptions().getMaxMessagesPerPoll());
-		executor.setQueueCapacity(0);
+		// Necessary due to a small racing condition between releasing the permit and releasing the thread.
+		executor.setQueueCapacity(poolSize);
 		executor.setAllowCoreThreadTimeOut(true);
 		executor.setThreadFactory(createThreadFactory());
 		executor.afterPropertiesSet();


### PR DESCRIPTION
There's a small racing condition between the time it takes for a permit to be released and the time the executor releases the thread which could lead to a small number of tasks being rejected.

Adding a queue fixes the issue.

Fixes #580