### PR TITLE
Replace singletonList(null) in BatchAckProcessor (#584)

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
@@ -262,7 +262,7 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 					.collect(Collectors.toList());
 			if (!futures.isEmpty()) {
 				purgeEmptyBuffers();
-				return Collections.singletonList(null);
+				return futures;
 			}
 			return Collections.emptyList();
 		}


### PR DESCRIPTION
Replace singletonList(null) in BatchAckProcessor (#584)

The list is just a marker on which we check for empty, but there's no reason we can't return the Future list instead.

Fixes #584