### PR TITLE
Remove ReceiveMessageRequestId from Standard SQS (#529)

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/FifoSqsComponentFactory.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/FifoSqsComponentFactory.java
@@ -26,8 +26,8 @@ import io.awspring.cloud.sqs.listener.sink.MessageSink;
 import io.awspring.cloud.sqs.listener.sink.OrderedMessageSink;
 import io.awspring.cloud.sqs.listener.sink.adapter.MessageGroupingSinkAdapter;
 import io.awspring.cloud.sqs.listener.sink.adapter.MessageVisibilityExtendingSinkAdapter;
+import io.awspring.cloud.sqs.listener.source.FifoSqsMessageSource;
 import io.awspring.cloud.sqs.listener.source.MessageSource;
-import io.awspring.cloud.sqs.listener.source.SqsMessageSource;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.function.Function;
@@ -62,7 +62,7 @@ public class FifoSqsComponentFactory<T> implements ContainerComponentFactory<T> 
 
 	@Override
 	public MessageSource<T> createMessageSource(ContainerOptions options) {
-		return new SqsMessageSource<>();
+		return new FifoSqsMessageSource<>();
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/StandardSqsComponentFactory.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/StandardSqsComponentFactory.java
@@ -24,7 +24,7 @@ import io.awspring.cloud.sqs.listener.sink.BatchMessageSink;
 import io.awspring.cloud.sqs.listener.sink.FanOutMessageSink;
 import io.awspring.cloud.sqs.listener.sink.MessageSink;
 import io.awspring.cloud.sqs.listener.source.MessageSource;
-import io.awspring.cloud.sqs.listener.source.SqsMessageSource;
+import io.awspring.cloud.sqs.listener.source.StandardSqsMessageSource;
 import java.time.Duration;
 import java.util.Collection;
 import org.springframework.util.Assert;
@@ -50,7 +50,7 @@ public class StandardSqsComponentFactory<T> implements ContainerComponentFactory
 
 	@Override
 	public MessageSource<T> createMessageSource(ContainerOptions options) {
-		return new SqsMessageSource<>();
+		return new StandardSqsMessageSource<>();
 	}
 
 	// @formatter:off

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/FifoSqsMessageSource.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/FifoSqsMessageSource.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.source;
+
+import java.util.UUID;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+
+/**
+ * {@link AbstractSqsMessageSource} implementation for FIFO queues.
+ * @author Tomaz Fernandes
+ * @since 3.0
+ */
+public class FifoSqsMessageSource<T> extends AbstractSqsMessageSource<T> {
+
+	@Override
+	protected void customizeRequest(ReceiveMessageRequest.Builder builder) {
+		builder.receiveRequestAttemptId(UUID.randomUUID().toString());
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/StandardSqsMessageSource.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/StandardSqsMessageSource.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.source;
+
+/**
+ * {@link AbstractSqsMessageSource} implementation for standard queues.
+ * @author Tomaz Fernandes
+ * @since 3.0
+ */
+public class StandardSqsMessageSource<T> extends AbstractSqsMessageSource<T> {
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
@@ -42,8 +42,8 @@ import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementMod
 import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import io.awspring.cloud.sqs.listener.sink.MessageSink;
+import io.awspring.cloud.sqs.listener.source.AbstractSqsMessageSource;
 import io.awspring.cloud.sqs.listener.source.MessageSource;
-import io.awspring.cloud.sqs.listener.source.SqsMessageSource;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -476,7 +476,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 			return Collections.singletonList(new StandardSqsComponentFactory<Object>() {
 				@Override
 				public MessageSource<Object> createMessageSource(ContainerOptions options) {
-					return new SqsMessageSource<Object>() {
+					return new AbstractSqsMessageSource<Object>() {
 						@Override
 						protected AcknowledgementExecutor<Object> createAcknowledgementExecutorInstance() {
 							return new SqsAcknowledgementExecutor<Object>() {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsLoadIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsLoadIntegrationTests.java
@@ -30,8 +30,8 @@ import io.awspring.cloud.sqs.listener.MessageListenerContainerRegistry;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
 import io.awspring.cloud.sqs.listener.StandardSqsComponentFactory;
 import io.awspring.cloud.sqs.listener.acknowledgement.SqsAcknowledgementExecutor;
+import io.awspring.cloud.sqs.listener.source.AbstractSqsMessageSource;
 import io.awspring.cloud.sqs.listener.source.MessageSource;
-import io.awspring.cloud.sqs.listener.source.SqsMessageSource;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
@@ -414,7 +414,7 @@ class SqsLoadIntegrationTests extends BaseSqsIntegrationTest {
 			return new StandardSqsComponentFactory<String>() {
 				@Override
 				public MessageSource<String> createMessageSource(ContainerOptions options) {
-					return new SqsMessageSource<String>() {
+					return new AbstractSqsMessageSource<String>() {
 						@Override
 						protected SqsAcknowledgementExecutor<String> createAcknowledgementExecutorInstance() {
 							return new SqsAcknowledgementExecutor<String>() {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSourceTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSourceTests.java
@@ -39,7 +39,7 @@ import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
  * @author Tomaz Fernandes
  * @since 3.0
  */
-class SqsMessageSourceTests {
+class AbstractSqsMessageSourceTests {
 
 	@Test
 	void shouldReturnBatchOfTenMessages() {
@@ -50,7 +50,7 @@ class SqsMessageSourceTests {
 		ReceiveMessageResponse response = ReceiveMessageResponse.builder().messages(batch).build();
 		given(client.receiveMessage(any(ReceiveMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(response));
-		SqsMessageSource<Object> source = new SqsMessageSource<>();
+		AbstractSqsMessageSource<Object> source = new StandardSqsMessageSource<>();
 		source.setSqsAsyncClient(client);
 		CompletableFuture<Collection<Message>> messages = source.doPollForMessages(10);
 		assertThat(messages).isCompletedWithValue(batch);
@@ -65,7 +65,7 @@ class SqsMessageSourceTests {
 		ReceiveMessageResponse response = ReceiveMessageResponse.builder().messages(batch).build();
 		given(client.receiveMessage(any(ReceiveMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(response));
-		SqsMessageSource<Object> source = new SqsMessageSource<>();
+		AbstractSqsMessageSource<Object> source = new StandardSqsMessageSource<>();
 		source.setSqsAsyncClient(client);
 		CompletableFuture<Collection<Message>> messages = source.doPollForMessages(100);
 		assertThat(messages.join()).containsExactlyElementsOf(getHundredMessages(batch));
@@ -81,7 +81,7 @@ class SqsMessageSourceTests {
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
 		given(client.receiveMessage(any(ReceiveMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(response));
-		SqsMessageSource<Object> source = new SqsMessageSource<>();
+		AbstractSqsMessageSource<Object> source = new StandardSqsMessageSource<>();
 		source.setSqsAsyncClient(client);
 		source.doPollForMessages(101);
 		then(client).should(times(11)).receiveMessage(captor.capture());

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/FifoSqsMessageSourceTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/FifoSqsMessageSourceTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 3.0
+ */
+class FifoSqsMessageSourceTests {
+
+	@Test
+	void shouldAddReceiveRequestIdParameter() {
+		List<Message> batch = IntStream.range(0, 10).mapToObj(
+				index -> Message.builder().body(String.valueOf(index)).messageId(UUID.randomUUID().toString()).build())
+				.collect(Collectors.toList());
+		SqsAsyncClient client = mock(SqsAsyncClient.class);
+		ReceiveMessageResponse response = ReceiveMessageResponse.builder().messages(batch).build();
+		given(client.receiveMessage(any(ReceiveMessageRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(response));
+		FifoSqsMessageSource<Object> source = new FifoSqsMessageSource<>();
+		source.setSqsAsyncClient(client);
+		source.doPollForMessages(10);
+		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
+		verify(client).receiveMessage(captor.capture());
+		assertThat(captor.getValue()).extracting(ReceiveMessageRequest::receiveRequestAttemptId).isNotNull();
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/StandardSqsMessageSourceTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/StandardSqsMessageSourceTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 3.0
+ */
+class StandardSqsMessageSourceTests {
+
+	@Test
+	void shouldNotAddReceiveRequestIdParameter() {
+		List<Message> batch = IntStream.range(0, 10).mapToObj(
+				index -> Message.builder().body(String.valueOf(index)).messageId(UUID.randomUUID().toString()).build())
+				.collect(Collectors.toList());
+		SqsAsyncClient client = mock(SqsAsyncClient.class);
+		ReceiveMessageResponse response = ReceiveMessageResponse.builder().messages(batch).build();
+		given(client.receiveMessage(any(ReceiveMessageRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(response));
+		StandardSqsMessageSource<Object> source = new StandardSqsMessageSource<>();
+		source.setSqsAsyncClient(client);
+		source.doPollForMessages(10);
+		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
+		verify(client).receiveMessage(captor.capture());
+		assertThat(captor.getValue()).extracting(ReceiveMessageRequest::receiveRequestAttemptId).isNull();
+	}
+
+}


### PR DESCRIPTION
This parameter was causing errors when using elastic mq with standard queues.

Since it's not a required parameter, we can take it off and leave it only for the FIFO queues.

Fixes (#529)
