### PR TITLE
Add SqsTemplate

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -7,7 +7,7 @@
 |spring.cloud.aws.credentials.instance-profile | `+++false+++` | Configures an instance profile credentials provider with no further configuration.
 |spring.cloud.aws.credentials.profile |  | The AWS profile.
 |spring.cloud.aws.credentials.secret-key |  | The secret key to be used with a static provider.
-|spring.cloud.aws.defaults-mode |  | Sets the {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
+|spring.cloud.aws.defaults-mode |  | Sets the {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK. <a href= "https://aws.amazon.com/blogs/developer/introducing-smart-configuration-defaults-in-the-aws-sdk-for-java-v2/">Introducing Smart Configuration Defaults in the AWS SDK for Java v2</a>
 |spring.cloud.aws.dualstack-enabled |  | Configure whether the SDK should use the AWS dualstack endpoint.
 |spring.cloud.aws.dynamodb.dax.cluster-update-interval-millis |  | Interval between polling of cluster members for membership changes.
 |spring.cloud.aws.dynamodb.dax.connect-timeout-millis |  | Connection timeout.
@@ -28,25 +28,31 @@
 |spring.cloud.aws.fips-enabled |  | Configure whether the SDK should use the AWS fips endpoints.
 |spring.cloud.aws.parameterstore.endpoint |  | Overrides the default endpoint.
 |spring.cloud.aws.parameterstore.region |  | Overrides the default region.
+|spring.cloud.aws.parameterstore.reload.max-wait-for-restart | `+++2s+++` | If {@link ReloadStrategy#RESTART_CONTEXT} is configured, maximum waiting time for server restart.
+|spring.cloud.aws.parameterstore.reload.period | `+++1m+++` | Refresh period for {@link PollingAwsPropertySourceChangeDetector}.
+|spring.cloud.aws.parameterstore.reload.strategy |  | Reload strategy to run when properties change.
 |spring.cloud.aws.region.instance-profile | `+++false+++` | Configures an instance profile region provider with no further configuration.
 |spring.cloud.aws.region.profile |  | The AWS profile.
 |spring.cloud.aws.region.static |  | 
 |spring.cloud.aws.s3.accelerate-mode-enabled |  | Option to enable using the accelerate endpoint when accessing S3. Accelerate endpoints allow faster transfer of objects by using Amazon CloudFront's globally distributed edge locations.
 |spring.cloud.aws.s3.checksum-validation-enabled |  | Option to disable doing a validation of the checksum of an object stored in S3.
 |spring.cloud.aws.s3.chunked-encoding-enabled |  | Option to enable using chunked encoding when signing the request payload for {@link software.amazon.awssdk.services.s3.model.PutObjectRequest} and {@link software.amazon.awssdk.services.s3.model.UploadPartRequest}.
+|spring.cloud.aws.s3.crt.initial-read-buffer-size-in-bytes |  | Configure the starting buffer size the client will use to buffer the parts downloaded from S3. Maintain a larger window to keep up a high download throughput; parts cannot download in parallel unless the window is large enough to hold multiple parts. Maintain a smaller window to limit the amount of data buffered in memory.
+|spring.cloud.aws.s3.crt.max-concurrency |  | Specifies the maximum number of S3 connections that should be established during transfer.
+|spring.cloud.aws.s3.crt.minimum-part-size-in-bytes |  | Sets the minimum part size for transfer parts. Decreasing the minimum part size causes multipart transfer to be split into a larger number of smaller parts. Setting this value too low has a negative effect on transfer speeds, causing extra latency and network communication for each part.
+|spring.cloud.aws.s3.crt.target-throughput-in-gbps |  | The target throughput for transfer requests. Higher value means more S3 connections will be opened. Whether the transfer manager can achieve the configured target throughput depends on various factors such as the network bandwidth of the environment and the configured `max-concurrency`.
 |spring.cloud.aws.s3.enabled | `+++true+++` | Enables S3 integration.
 |spring.cloud.aws.s3.endpoint |  | Overrides the default endpoint.
 |spring.cloud.aws.s3.path-style-access-enabled |  | Option to enable using path style access for accessing S3 objects instead of DNS style access. DNS style access is preferred as it will result in better load balancing when accessing S3.
 |spring.cloud.aws.s3.region |  | Overrides the default region.
-|spring.cloud.aws.s3.transfer-manager.max-concurrency |  | 
-|spring.cloud.aws.s3.transfer-manager.minimum-part-size-in-bytes |  | 
-|spring.cloud.aws.s3.transfer-manager.target-throughput-in-gbps |  | 
-|spring.cloud.aws.s3.transfer-manager.upload-directory.follow-symbolic-links |  | 
-|spring.cloud.aws.s3.transfer-manager.upload-directory.max-depth |  | 
-|spring.cloud.aws.s3.transfer-manager.upload-directory.recursive |  | 
+|spring.cloud.aws.s3.transfer-manager.follow-symbolic-links |  | Specifies whether to follow symbolic links when traversing the file tree in `S3TransferManager#uploadDirectory` operation.
+|spring.cloud.aws.s3.transfer-manager.max-depth |  | Specifies the maximum number of levels of directories to visit in `S3TransferManager#uploadDirectory` operation.
 |spring.cloud.aws.s3.use-arn-region-enabled |  | If an S3 resource ARN is passed in as the target of an S3 operation that has a different region to the one the client was configured with, this flag must be set to 'true' to permit the client to make a cross-region call to the region specified in the ARN otherwise an exception will be thrown.
 |spring.cloud.aws.secretsmanager.endpoint |  | Overrides the default endpoint.
 |spring.cloud.aws.secretsmanager.region |  | Overrides the default region.
+|spring.cloud.aws.secretsmanager.reload.max-wait-for-restart | `+++2s+++` | If {@link ReloadStrategy#RESTART_CONTEXT} is configured, maximum waiting time for server restart.
+|spring.cloud.aws.secretsmanager.reload.period | `+++1m+++` | Refresh period for {@link PollingAwsPropertySourceChangeDetector}.
+|spring.cloud.aws.secretsmanager.reload.strategy |  | Reload strategy to run when properties change.
 |spring.cloud.aws.ses.enabled | `+++true+++` | Enables Simple Email Service integration.
 |spring.cloud.aws.ses.endpoint |  | Overrides the default endpoint.
 |spring.cloud.aws.ses.region |  | Overrides the default region.

--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -7,7 +7,7 @@
 |spring.cloud.aws.credentials.instance-profile | `+++false+++` | Configures an instance profile credentials provider with no further configuration.
 |spring.cloud.aws.credentials.profile |  | The AWS profile.
 |spring.cloud.aws.credentials.secret-key |  | The secret key to be used with a static provider.
-|spring.cloud.aws.defaults-mode |  | Sets the {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK. <a href= "https://aws.amazon.com/blogs/developer/introducing-smart-configuration-defaults-in-the-aws-sdk-for-java-v2/">Introducing Smart Configuration Defaults in the AWS SDK for Java v2</a>
+|spring.cloud.aws.defaults-mode |  | Sets the {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
 |spring.cloud.aws.dualstack-enabled |  | Configure whether the SDK should use the AWS dualstack endpoint.
 |spring.cloud.aws.dynamodb.dax.cluster-update-interval-millis |  | Interval between polling of cluster members for membership changes.
 |spring.cloud.aws.dynamodb.dax.connect-timeout-millis |  | Connection timeout.
@@ -28,31 +28,25 @@
 |spring.cloud.aws.fips-enabled |  | Configure whether the SDK should use the AWS fips endpoints.
 |spring.cloud.aws.parameterstore.endpoint |  | Overrides the default endpoint.
 |spring.cloud.aws.parameterstore.region |  | Overrides the default region.
-|spring.cloud.aws.parameterstore.reload.max-wait-for-restart | `+++2s+++` | If {@link ReloadStrategy#RESTART_CONTEXT} is configured, maximum waiting time for server restart.
-|spring.cloud.aws.parameterstore.reload.period | `+++1m+++` | Refresh period for {@link PollingAwsPropertySourceChangeDetector}.
-|spring.cloud.aws.parameterstore.reload.strategy |  | Reload strategy to run when properties change.
 |spring.cloud.aws.region.instance-profile | `+++false+++` | Configures an instance profile region provider with no further configuration.
 |spring.cloud.aws.region.profile |  | The AWS profile.
 |spring.cloud.aws.region.static |  | 
 |spring.cloud.aws.s3.accelerate-mode-enabled |  | Option to enable using the accelerate endpoint when accessing S3. Accelerate endpoints allow faster transfer of objects by using Amazon CloudFront's globally distributed edge locations.
 |spring.cloud.aws.s3.checksum-validation-enabled |  | Option to disable doing a validation of the checksum of an object stored in S3.
 |spring.cloud.aws.s3.chunked-encoding-enabled |  | Option to enable using chunked encoding when signing the request payload for {@link software.amazon.awssdk.services.s3.model.PutObjectRequest} and {@link software.amazon.awssdk.services.s3.model.UploadPartRequest}.
-|spring.cloud.aws.s3.crt.initial-read-buffer-size-in-bytes |  | Configure the starting buffer size the client will use to buffer the parts downloaded from S3. Maintain a larger window to keep up a high download throughput; parts cannot download in parallel unless the window is large enough to hold multiple parts. Maintain a smaller window to limit the amount of data buffered in memory.
-|spring.cloud.aws.s3.crt.max-concurrency |  | Specifies the maximum number of S3 connections that should be established during transfer.
-|spring.cloud.aws.s3.crt.minimum-part-size-in-bytes |  | Sets the minimum part size for transfer parts. Decreasing the minimum part size causes multipart transfer to be split into a larger number of smaller parts. Setting this value too low has a negative effect on transfer speeds, causing extra latency and network communication for each part.
-|spring.cloud.aws.s3.crt.target-throughput-in-gbps |  | The target throughput for transfer requests. Higher value means more S3 connections will be opened. Whether the transfer manager can achieve the configured target throughput depends on various factors such as the network bandwidth of the environment and the configured `max-concurrency`.
 |spring.cloud.aws.s3.enabled | `+++true+++` | Enables S3 integration.
 |spring.cloud.aws.s3.endpoint |  | Overrides the default endpoint.
 |spring.cloud.aws.s3.path-style-access-enabled |  | Option to enable using path style access for accessing S3 objects instead of DNS style access. DNS style access is preferred as it will result in better load balancing when accessing S3.
 |spring.cloud.aws.s3.region |  | Overrides the default region.
-|spring.cloud.aws.s3.transfer-manager.follow-symbolic-links |  | Specifies whether to follow symbolic links when traversing the file tree in `S3TransferManager#uploadDirectory` operation.
-|spring.cloud.aws.s3.transfer-manager.max-depth |  | Specifies the maximum number of levels of directories to visit in `S3TransferManager#uploadDirectory` operation.
+|spring.cloud.aws.s3.transfer-manager.max-concurrency |  | 
+|spring.cloud.aws.s3.transfer-manager.minimum-part-size-in-bytes |  | 
+|spring.cloud.aws.s3.transfer-manager.target-throughput-in-gbps |  | 
+|spring.cloud.aws.s3.transfer-manager.upload-directory.follow-symbolic-links |  | 
+|spring.cloud.aws.s3.transfer-manager.upload-directory.max-depth |  | 
+|spring.cloud.aws.s3.transfer-manager.upload-directory.recursive |  | 
 |spring.cloud.aws.s3.use-arn-region-enabled |  | If an S3 resource ARN is passed in as the target of an S3 operation that has a different region to the one the client was configured with, this flag must be set to 'true' to permit the client to make a cross-region call to the region specified in the ARN otherwise an exception will be thrown.
 |spring.cloud.aws.secretsmanager.endpoint |  | Overrides the default endpoint.
 |spring.cloud.aws.secretsmanager.region |  | Overrides the default region.
-|spring.cloud.aws.secretsmanager.reload.max-wait-for-restart | `+++2s+++` | If {@link ReloadStrategy#RESTART_CONTEXT} is configured, maximum waiting time for server restart.
-|spring.cloud.aws.secretsmanager.reload.period | `+++1m+++` | Refresh period for {@link PollingAwsPropertySourceChangeDetector}.
-|spring.cloud.aws.secretsmanager.reload.strategy |  | Reload strategy to run when properties change.
 |spring.cloud.aws.ses.enabled | `+++true+++` | Enables Simple Email Service integration.
 |spring.cloud.aws.ses.endpoint |  | Overrides the default endpoint.
 |spring.cloud.aws.ses.region |  | Overrides the default region.

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -81,61 +81,351 @@ public class SQSConfiguration {
 ----
 
 === Sending Messages
-Spring Cloud AWS SQS autoconfigures a `SqsAsyncClient` bean that can be used for sending messages.
-Note that the payload has to be converted to a JSON String to be sent.
-A `SqsTemplate` should be included in a future milestone simplifying this process.
 
-Currently, a lightweight producer abstraction can be created to facilitate sending messages, such as:
+`Spring Cloud AWS` provides the `SqsTemplate` to send messages to `SQS`.
 
-[source,java]
-----
-@Component
-public class SqsSampleProducer {
+[[sqs-template-send]]
+==== SqsTemplate
+When using `Spring Boot` and autoconfiguration, a `SqsTemplate<Object>` instance is autowired by default in case no other template bean is found in the context.
+This template instance is backed by the autoconfigured `SqsAsyncClient`, with any configurations provided.
+`SqsTemplate` instances are immutable and thread-safe.
 
-    private final SqsAsyncClient sqsAsyncClient;
+NOTE: The endpoint to which the message will be sent can be either the queue name or URL.
 
-    private final ObjectMapper objectMapper;
+==== Creating a SqsTemplate Instance
 
-    public SqsSampleProducer(SqsAsyncClient sqsAsyncClient, ObjectMapper objectMapper) {
-        this.sqsAsyncClient = sqsAsyncClient;
-        this.objectMapper = objectMapper;
-    }
+`SqsTemplate` implements two `Operations` interfaces: `SqsOperations` contains blocking methods, and `SqsAsyncOperations` contains async methods that return `CompletableFuture` instances.
+In case only sync or async operations are to be used, the corresponding interface can be utilized to eliminate unnecessary methods.
 
-    public CompletableFuture<Void> sendToUrl(String queueUrl, Object payload) {
-        return this.sqsAsyncClient.sendMessage(request -> request.messageBody(getMessageBodyAsJson(payload)).queueUrl(queueUrl))
-                .thenRun(() -> {});
-    }
+The following methods can be used to create new `SqsTemplate` instances with default options:
 
-    public CompletableFuture<Void> send(String queueName, Object payload) {
-        return this.sqsAsyncClient.getQueueUrl(request -> request.queueName(queueName))
-                .thenApply(GetQueueUrlResponse::queueUrl)
-                .thenCompose(queueUrl -> sendToUrl(queueUrl, payload));
-    }
+```java
+SqsTemplate<SampleRecord> template = SqsTemplate.newTemplate(sqsAsyncClient);
 
-    private String getMessageBodyAsJson(Object payload) {
-        try {
-            return objectMapper.writeValueAsString(payload);
-        }
-        catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("Error converting payload: " + payload, e);
-        }
-    }
+SqsOperations<SampleRecord> blockingTemplate = SqsTemplate.newSyncTemplate(sqsAsyncClient);
+
+SqsAsyncOperations<SampleRecord> asyncTemplate = SqsTemplate.newAsyncTemplate(sqsAsyncClient);
+```
+
+NOTE: The returned object is always the `SqsTemplate`, and the separate methods are only for convenience of the interface return type.
+
+In case more complex configuration is required, a builder is also provided, and a set of options:
+
+```java
+SqsTemplate<SampleRecord> template = SqsTemplate.<SampleRecord>builder()
+    .sqsAsyncClient(this.asyncClient)
+        .configure(options -> options
+                .acknowledgementMode(TemplateAcknowledgementMode.MANUAL)
+                .defaultEndpointName("my-queue"))
+        .build();
+```
+
+The builder also offers the `buildSyncTemplate()` method to return the template as `SqsOperations`, and `buildAsyncTemplate()` to return it as `SqsAsyncOperations`.
+
+NOTE: The generic class is used for compile time safety only.
+An `Object` generic type can be provided to create a template that can be used with different classes.
+
+
+==== Template Options
+
+The following options can be configured through the `options` object.
+The defaults are applied in case no other value is provided as a parameter in the operation method.
+
+===== TemplateOptions Descriptions
+[cols="12,5,5,16", options="header"]
+|===
+| Name
+| Type
+| Default
+| Description
+
+|`acknowledgementMode`
+|TemplateAcknowledgementMode
+|TemplateAcknowledgementMode
+#ACKNOWLEDGE_ON_RECEIVE
+|Whether messages should be acknowledged by the template after being received.
+Messages can be acknowledged later by using the `Acknowledgement#acknowledge` methods. See <<sqs-template-acknowledgement>> for more information.
+
+|`sendBatchFailureHandlingStrategy`
+|SendBatchFailureStrategy
+|SendBatchFailureStrategy
+#THROW
+|Whether a `SendBatchOperationFailedException` containing a `SendResult.Batch` instance should be thrown if at least one message from a sent batch fails to be delivered.
+With SendBatchFailureStrategy#DO_NOT_THROW, the `SendResult.Batch` object is returned.
+
+|`defaultPollTimeout`
+|Duration
+|10 seconds
+|The default maximum time to wait for messages when performing a receive request to SQS.
+See <<template-receive>> for more information.
+
+|`defaultMaxNumberOfMessages`
+|Integer
+|10
+|The default maximum of messages to be returned by a receive request to SQS.
+See <<template-receive>> for more information.
+
+|`defaultEndpointName`
+|String
+|blank
+|The default endpoint name to be used by the template.
+See <<template-receive>> for more information.
+
+|`defaultPayloadClass`
+|Class
+|null
+|The default class to which payloads should be converted to.
+Note that messages sent with the `SqsTemplate` by default contains a header with the type information, so no configuration is needed.
+See <<template-message-conversion>> for more information.
+
+|`additionalHeaderForReceive`
+|String, Object
+|empty
+|Set a single header to be added to all messages received by this template.
+
+|`additionalHeadersForReceive`
+|Map<String, Object>
+|empty
+|Set headers to be added to all messages received by this template.
+
+|`queueNotFoundStrategy`
+|QueueNotFoundStrategy
+|QueueNotFoundStrategy
+#CREATE
+|Set the strategy to use in case a queue is not found.
+With `QueueNotFoundStrategy#FAIL`, an exception is thrown in case a queue is not found.
+
+|`queueAttributeNames`
+|Collection<AttributeNames>
+|empty
+|Set the queue attribute names that will be retrieved.
+Such attributes are available as `MessageHeaders` in received messages.
+
+|`messageAttributeNames`
+|Collection<String>
+|All
+|Set the message attribute names that will be retrieved with messages on receive operations.
+Such attributes are available as `MessageHeaders` in received messages.
+
+|`messageSystemAttributeNames`
+|Collection
+<MessageSystemAttributeName>
+|All
+|Set the message system attribute names that will be retrieved with messages on receive operations.
+Such attributes are available as `MessageHeaders` in received messages.
+|===
+
+==== Sending Messages
+
+There are a number of available methods to send messages to `Standard` and `Fifo` queues using the `SqsTemplate`.
+The following methods are available through the `SqsOperations` interface, with the respective `async` counterparts available in the `SqsAsyncOperations`.
+
+```java
+// Send a message to the configured default endpoint.
+SendResult<T> send(T payload);
+
+// Send a message to the provided endpoint (or default) with the given payload.
+SendResult<T> send(@Nullable String endpointName, T payload);
+
+// Send the given Message to the provided (or default) endpoint.
+SendResult<T> send(@Nullable String endpointName, Message<T> message);
+
+// Send a batch of Messages to the provided (or default) endpoint
+SendResult.Batch<T> sendMany(@Nullable String endpointName, Collection<Message<T>> messages);
+
+// Send a message with the provided options.
+SendResult<T> send(Consumer<SqsSendOptions.Standard<T>> to);
+
+// Send a message to a FIFO queue and add relevant headers.
+SendResult<T> sendFifo(Consumer<SqsSendOptions.Fifo<T>> to);
+
+// Send a batch of Messages to a FIFO queue and add relevant headers.
+SendResult.Batch<T> sendManyFifo(String endpoint, Collection<Message<T>> messages);
+
+```
+
+An example using the `options` variant follows:
+
+```java
+SendResult<String> result = template.send(to -> to.queue("myQueue")
+    .payload("myPayload")
+    .header("myHeaderName", "myHeaderValue")
+    .headers(Map.of("myOtherHeaderName", "myOtherHeaderValue"))
+    .delaySeconds(10)
+);
+```
+
+The `Fifo` variant includes the options of specifying a `messageDeduplicationId` and a `messageGroupId`.
+If either values are not provided, a random `UUID` is generated.
+The generated values can be retrieved in the headers of the `Message` contained in the `SendResult` object.
+
+===== SendResult
+
+The `SendResult` record contains useful information on the send operation.
+
+```java
+public record SendResult<T>(UUID messageId, String endpoint, Message<T> message, Map<String, Object> additionalInformation) {
+
+	public record Batch<T>(Collection<SendResult<T>> successful, Collection<SendResult.Failed<T>> failed) {}
+
+	public record Failed<T> (String errorMessage, String endpoint, Message<T> message, Map<String, Object> additionalInformation) {}
 
 }
-----
+```
 
-Modifications can be made to enable adding other attributes such as `MessageGroupId`, `MessageAttributes` and `MessageDeduplicationId`.
+When the send operation is successful, the `SendResult` object is created with:
 
-It can then be autowired and used such as:
+* the `messageId` returned from `SQS` for the message
+* the `endpoint` the message was sent to
+* the `Message` instance that was sent, with any additional headers that might have been added by the framework
+* an `additionalInformation` map with the `sequenceNumber` generated for the message in `Fifo` queues.
 
-`sampleProducer.send(queueName, new MyPojo("My value", "My Other Value")).join();`
+When the send operation fails for single message operations, a `MessagingOperationFailedException` containing the message is thrown.
 
-IMPORTANT: The `join()` method blocks the thread and throws any error from the operation. If a `CompletableFuture` chain is being used, simply return the value instead.
+For `Batch` send operations, a `SendResult.Batch` object is returned.
+This object contains a `Collection` of `successful` and `failed` results.
 
+In case there are messages that failed to be sent within a batch, corresponding `SendResult.Failed` objects are generated.
+The `SendBatch.Failed` object contains:
+
+* the `errorMessage` returned by SQS
+* the `endpoint` the message was to be sent to
+* the `Message` instance that was tried to be sent, with any additional headers that might have been added by the framework
+* an `additionalInformation` map with the `code` and `senderFault` parameters returned by SQS.
+
+By default, if there's at least one failed message in a send batch operation, a `SendBatchOperationFailedException` will be thrown.
+Such exception contains a `SendResult.Batch<?>` property containing both successful and failed messages.
+
+This behavior can be configured using the `sendBatchFailureHandlingStrategy` option when creating the template.
+If `SendBatchFailureStrategy#DO_NOT_THROW` is configured, no exception is thrown and a `SendResult.Batch` object containing both successful and failed messages is returned.
+
+For convenience, the `additionalInformation` parameters can be found as constants in the `SqsTemplateParameters` class.
+
+[[template-message-conversion]]
+==== Template Message Conversion
+
+Message conversion by default is handled by a `SqsMessagingMessageConverter` instance, which contains:
+
+* `SqsHeaderMapper` for mapping headers to and from `messageAttributes`
+* `CompositeMessageConverter` with a `StringMessageConverter` and a `MappingJackson2MessageConverter` for converting payloads to and from JSON.
+
+A custom `MessagingMessageConverter` implementation can be provided in the `SqsTemplate.builder()`:
+
+```java
+SqsOperations<Object> template = SqsTemplate
+    .builder()
+    .sqsAsyncClient(sqsAsyncClient)
+    .messageConverter(converter)
+    .buildSyncTemplate();
+```
+
+The default `SqsMessagingMessageConverter` instance can also be configured in the builder:
+
+```java
+SqsOperations<Object> template = SqsTemplate
+    .builder()
+    .sqsAsyncClient(sqsAsyncClient)
+    .configureDefaultConverter(converter -> {
+            converter.setObjectMapper(objectMapper);
+            converter.setHeaderMapper(headerMapper);
+            converter.setPayloadTypeHeader("my-custom-type-header");
+        }
+    )
+    .buildSyncTemplate();
+```
+
+===== Specifying a Payload Class for Receive Operations
+
+By default, the `SqsTemplate` adds a header with name `JavaType` containing the fully qualified name of the payload class to all messages sent.
+Such header is used in receive operations by the `SqsTemplate`, `SqsMessageListenerContainer` and `@SqsListener` to identify to which class the payload should be deserialized to.
+
+This behavior can be configured in the `SqsMessagingMessageConverter` using the `setPayloadTypeHeaderValueFunction` method.
+The function receives a `Message` object and returns a `String` with the value to be used in the header, the payload's class `FQCN` by default.
+If `null` is returned by the function, no header with type information is added.
+
+The `typeHeaderName` can be configured using the `setPayloadTypeHeader` method.
+
+In case type mapping information is not available, the payload class can be specified either in the <<template-options>> or in the `receive()` method variants:
+
+```java
+Optional<Message<Object>> receivedMessage = template
+			.receive(from -> from.queue(queue)
+                .payloadClass(SampleRecord.class));
+```
+
+NOTE: The payload class must be a subclass of the class specified in the `SqsTemplate` generics.
+For a more versatile template, `Object` can be used as the generic type.
 
 === Receiving Messages
 
 The framework offers the following options to receive messages from a queue.
+
+[[template-receive]]
+==== SqsTemplate
+
+The `SqsTemplate` offers convenient methods to receive messages from `Standard` and `Fifo` SQS queues.
+These methods are separated into two interfaces that are implemented by `SqsTemplate`: `SqsOperations` and `SqsAsyncOperations`.
+If only `sync` or `async` operations are to be used, using the specific interface can narrow down the methods.
+
+See <<sqs-template-send>> for more information on the interfaces, <<creating-a-sqstemplate-instance>> and <<template-options>>.
+
+The following methods are available through the `SqsOperations` interface, with the respective `async` counterparts available in the `SqsAsyncOperations`.
+
+```java
+// Receive a message from the configured default endpoint and options.
+Optional<Message<T>> receive();
+
+// Receive a message with the provided parameters or their defaults if null.
+Optional<Message<T>> receive(@Nullable String endpointName, @Nullable Class<T> payloadClass,
+			@Nullable Duration pollTimeout, @Nullable Map<String, Object> additionalHeaders);
+
+// Receive a batch of messages from the configured default endpoint and options.
+Collection<Message<T>> receiveMany();
+
+// Receive a batch of messages with the provided parameters or their defaults if null.
+Collection<Message<T>> receiveMany(@Nullable String endpointName, @Nullable Class<T> payloadClass,
+        @Nullable Duration pollTimeout, @Nullable Integer maxNumberOfMessages,
+        @Nullable Map<String, Object> additionalHeaders);
+
+// Receive a message with the provided options.
+Optional<Message<T>> receive(Consumer<SqsReceiveOptions.Standard<T>> from);
+
+// Receive a message from a Fifo queue with the provided options.
+Optional<Message<T>> receiveFifo(Consumer<SqsReceiveOptions.Fifo<T>> from);
+
+// Receive a batch of messages with the provided options.
+Collection<Message<T>> receiveMany(Consumer<SqsReceiveOptions.Standard<T>> from);
+
+// Receive a batch of messages from a Fifo queue with the provided options.
+Collection<Message<T>> receiveManyFifo(Consumer<SqsReceiveOptions.Fifo<T>> from);
+```
+
+The following is an example for receiving a message with options:
+
+```java
+Optional<Message<SampleRecord>> receivedMessage = template
+        .receive(from -> from.queue("my-queue")
+                .visibilityTimeout(Duration.ofSeconds(10))
+                .pollTimeout(Duration.ofSeconds(5))
+                .payloadClass(SampleRecord.class)
+                .additionalHeaders(Map.of("my-custom-header-name", "my-custom-header-value")));
+```
+
+The `Fifo` variant adds a `receiveRequestAttemptId` option.
+If none is provided, a random `UUID` is generated.
+
+[[sqs-template-acknowledgement]]
+===== SqsTemplate Acknowledgement
+
+The `SqsTemplate` by default acknowledges all received messages, which can be changed by setting `TemplateAcknowledgementMode.MANUAL` in the template options:
+
+```java
+SqsTemplate.builder().configure(options -> options.acknowledgementMode(TemplateAcknowledgementMode.MANUAL));
+```
+
+If an error occurs during acknowledgement, a `SqsAcknowledgementException` is thrown, containing both the messages that were successfully acknowledged and those which failed.
+
+To acknowledge messages received with `MANUAL` acknowledgement, the `Acknowledgement#acknowledge` and `Acknowledgement#acknowledgeAsync` methods can be used.
 
 ==== Message Listeners
 
@@ -488,6 +778,7 @@ The Spring Boot Starter for SQS provides the following auto-configuration proper
 
 
 ===== SqsContainerOptions Descriptions
+
 [cols="13,9,9,16", options="header"]
 |===
 | Property
@@ -1048,10 +1339,10 @@ IMPORTANT: If an immediate acknowledging triggers an error, message processing i
 ==== Manual Acknowledgement
 
 Acknowledgements can be handled manually by setting `AcknowledgementMode.MANUAL` in the `SqsContainerOptions`.
-
-Manual acknowledgement can be used in conjunction with acknowledgement batching - the message will be queued for acknowledgement but won't be executed until one of the above criteria is met.
-
+Manual acknowledgement can be used in conjunction with acknowledgement batching - the message will be queued for acknowledgement but won't be executed until one of the acknowledgement thresholds is reached.
 It can also be used in conjunction with immediate acknowledgement.
+
+The `Acknowledgement#acknowledge` and `Acknowledgement#acknowledgeAsync` methods are also available to acknowledge messages received in `MANUAL` acknowledgement mode.
 
 The following arguments can be used in listener methods to manually acknowledge:
 

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -86,7 +86,7 @@ public class SQSConfiguration {
 
 [[sqs-template-send]]
 ==== SqsTemplate
-When using `Spring Boot` and autoconfiguration, a `SqsTemplate<Object>` instance is autowired by default in case no other template bean is found in the context.
+When using `Spring Boot` and autoconfiguration, a `SqsTemplate` instance is autowired by default in case no other template bean is found in the context.
 This template instance is backed by the autoconfigured `SqsAsyncClient`, with any configurations provided.
 `SqsTemplate` instances are immutable and thread-safe.
 
@@ -100,11 +100,11 @@ In case only sync or async operations are to be used, the corresponding interfac
 The following methods can be used to create new `SqsTemplate` instances with default options:
 
 ```java
-SqsTemplate<SampleRecord> template = SqsTemplate.newTemplate(sqsAsyncClient);
+SqsTemplate template = SqsTemplate.newTemplate(sqsAsyncClient);
 
-SqsOperations<SampleRecord> blockingTemplate = SqsTemplate.newSyncTemplate(sqsAsyncClient);
+SqsOperations blockingTemplate = SqsTemplate.newSyncTemplate(sqsAsyncClient);
 
-SqsAsyncOperations<SampleRecord> asyncTemplate = SqsTemplate.newAsyncTemplate(sqsAsyncClient);
+SqsAsyncOperations asyncTemplate = SqsTemplate.newAsyncTemplate(sqsAsyncClient);
 ```
 
 NOTE: The returned object is always the `SqsTemplate`, and the separate methods are only for convenience of the interface return type.
@@ -112,7 +112,7 @@ NOTE: The returned object is always the `SqsTemplate`, and the separate methods 
 In case more complex configuration is required, a builder is also provided, and a set of options:
 
 ```java
-SqsTemplate<SampleRecord> template = SqsTemplate.<SampleRecord>builder()
+SqsTemplate template = SqsTemplate.builder()
     .sqsAsyncClient(this.asyncClient)
         .configure(options -> options
                 .acknowledgementMode(TemplateAcknowledgementMode.MANUAL)
@@ -121,9 +121,6 @@ SqsTemplate<SampleRecord> template = SqsTemplate.<SampleRecord>builder()
 ```
 
 The builder also offers the `buildSyncTemplate()` method to return the template as `SqsOperations`, and `buildAsyncTemplate()` to return it as `SqsAsyncOperations`.
-
-NOTE: The generic class is used for compile time safety only.
-An `Object` generic type can be provided to create a template that can be used with different classes.
 
 
 ==== Template Options
@@ -217,31 +214,24 @@ Such attributes are available as `MessageHeaders` in received messages.
 
 ==== Sending Messages
 
-There are a number of available methods to send messages to `Standard` and `Fifo` queues using the `SqsTemplate`.
+There are a number of available methods to send messages to SQS queues using the `SqsTemplate`.
 The following methods are available through the `SqsOperations` interface, with the respective `async` counterparts available in the `SqsAsyncOperations`.
 
 ```java
 // Send a message to the configured default endpoint.
 SendResult<T> send(T payload);
 
-// Send a message to the provided endpoint (or default) with the given payload.
-SendResult<T> send(@Nullable String endpointName, T payload);
+// Send a message to the provided queue with the given payload.
+SendResult<T> send(String queue, T payload);
 
-// Send the given Message to the provided (or default) endpoint.
-SendResult<T> send(@Nullable String endpointName, Message<T> message);
-
-// Send a batch of Messages to the provided (or default) endpoint
-SendResult.Batch<T> sendMany(@Nullable String endpointName, Collection<Message<T>> messages);
+// Send the given Message to the provided queue.
+SendResult<T> send(String queue, Message<T> message);
 
 // Send a message with the provided options.
-SendResult<T> send(Consumer<SqsSendOptions.Standard<T>> to);
+SendResult<T> send(Consumer<SqsSendOptions> to);
 
-// Send a message to a FIFO queue and add relevant headers.
-SendResult<T> sendFifo(Consumer<SqsSendOptions.Fifo<T>> to);
-
-// Send a batch of Messages to a FIFO queue and add relevant headers.
-SendResult.Batch<T> sendManyFifo(String endpoint, Collection<Message<T>> messages);
-
+// Send a batch of Messages to the provided queue
+SendResult.Batch<T> sendMany(String queue, Collection<Message<T>> messages);
 ```
 
 An example using the `options` variant follows:
@@ -255,9 +245,10 @@ SendResult<String> result = template.send(to -> to.queue("myQueue")
 );
 ```
 
-The `Fifo` variant includes the options of specifying a `messageDeduplicationId` and a `messageGroupId`.
-If either values are not provided, a random `UUID` is generated.
+NOTE: To send messages to a Fifo queue, the options include `messageDeduplicationId` and `messageGroupId` properties.
+If either values are not provided, a random UUID is generated.
 The generated values can be retrieved in the headers of the `Message` contained in the `SendResult` object.
+
 
 ===== SendResult
 
@@ -312,7 +303,7 @@ Message conversion by default is handled by a `SqsMessagingMessageConverter` ins
 A custom `MessagingMessageConverter` implementation can be provided in the `SqsTemplate.builder()`:
 
 ```java
-SqsOperations<Object> template = SqsTemplate
+SqsOperations template = SqsTemplate
     .builder()
     .sqsAsyncClient(sqsAsyncClient)
     .messageConverter(converter)
@@ -322,7 +313,7 @@ SqsOperations<Object> template = SqsTemplate
 The default `SqsMessagingMessageConverter` instance can also be configured in the builder:
 
 ```java
-SqsOperations<Object> template = SqsTemplate
+SqsOperations template = SqsTemplate
     .builder()
     .sqsAsyncClient(sqsAsyncClient)
     .configureDefaultConverter(converter -> {
@@ -348,13 +339,9 @@ The `typeHeaderName` can be configured using the `setPayloadTypeHeader` method.
 In case type mapping information is not available, the payload class can be specified either in the <<template-options>> or in the `receive()` method variants:
 
 ```java
-Optional<Message<Object>> receivedMessage = template
-			.receive(from -> from.queue(queue)
-                .payloadClass(SampleRecord.class));
+Optional<Message<SampleRecord>> receivedMessage = template
+			.receive(queue, SampleRecord.class);
 ```
-
-NOTE: The payload class must be a subclass of the class specified in the `SqsTemplate` generics.
-For a more versatile template, `Object` can be used as the generic type.
 
 === Receiving Messages
 
@@ -373,31 +360,28 @@ The following methods are available through the `SqsOperations` interface, with 
 
 ```java
 // Receive a message from the configured default endpoint and options.
-Optional<Message<T>> receive();
+Optional<Message<?>> receive();
 
-// Receive a message with the provided parameters or their defaults if null.
-Optional<Message<T>> receive(@Nullable String endpointName, @Nullable Class<T> payloadClass,
-			@Nullable Duration pollTimeout, @Nullable Map<String, Object> additionalHeaders);
-
-// Receive a batch of messages from the configured default endpoint and options.
-Collection<Message<T>> receiveMany();
-
-// Receive a batch of messages with the provided parameters or their defaults if null.
-Collection<Message<T>> receiveMany(@Nullable String endpointName, @Nullable Class<T> payloadClass,
-        @Nullable Duration pollTimeout, @Nullable Integer maxNumberOfMessages,
-        @Nullable Map<String, Object> additionalHeaders);
+// Receive a message from the provided queue and convert the payload to the provided class.
+<T> Optional<Message<T>> receive(String queue, Class<T> payloadClass);
 
 // Receive a message with the provided options.
-Optional<Message<T>> receive(Consumer<SqsReceiveOptions.Standard<T>> from);
+Optional<Message<?>> receive(Consumer<SqsReceiveOptions> from);
 
-// Receive a message from a Fifo queue with the provided options.
-Optional<Message<T>> receiveFifo(Consumer<SqsReceiveOptions.Fifo<T>> from);
+// Receive a message with the provided options and convert the payload to the provided class.
+<T> Optional<Message<T>> receive(Consumer<SqsReceiveOptions> from, Class<T> payloadClass);
+
+// Receive a batch of messages from the configured default endpoint and options.
+Collection<Message<?>> receiveMany();
+
+// Receive a batch of messages from the provided queue and convert the payloads to the provided class.
+<T> Collection<Message<T>> receiveMany(String queue, Class<T> payloadClass);
 
 // Receive a batch of messages with the provided options.
-Collection<Message<T>> receiveMany(Consumer<SqsReceiveOptions.Standard<T>> from);
+Collection<Message<?>> receiveMany(Consumer<SqsReceiveOptions> from);
 
-// Receive a batch of messages from a Fifo queue with the provided options.
-Collection<Message<T>> receiveManyFifo(Consumer<SqsReceiveOptions.Fifo<T>> from);
+// Receive a batch of messages with the provided options and convert the payloads to the provided class.
+<T> Collection<Message<T>> receiveMany(Consumer<SqsReceiveOptions> from, Class<T> payloadClass);
 ```
 
 The following is an example for receiving a message with options:
@@ -407,12 +391,13 @@ Optional<Message<SampleRecord>> receivedMessage = template
         .receive(from -> from.queue("my-queue")
                 .visibilityTimeout(Duration.ofSeconds(10))
                 .pollTimeout(Duration.ofSeconds(5))
-                .payloadClass(SampleRecord.class)
-                .additionalHeaders(Map.of("my-custom-header-name", "my-custom-header-value")));
+                .additionalHeaders(Map.of("my-custom-header-name", "my-custom-header-value")),
+		SampleRecord.class);
 ```
 
-The `Fifo` variant adds a `receiveRequestAttemptId` option.
-If none is provided, a random `UUID` is generated.
+NOTE: To receive messages from a Fifo queue, the options include a `receiveRequestAttemptId` parameter.
+If no such parameter is provided, a random one is generated.
+
 
 [[sqs-template-acknowledgement]]
 ===== SqsTemplate Acknowledgement

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -74,9 +74,8 @@ public class SqsAutoConfiguration {
 
 	@ConditionalOnMissingBean
 	@Bean
-	public SqsTemplate<Object> sqsTemplate(SqsAsyncClient sqsAsyncClient,
-			ObjectProvider<ObjectMapper> objectMapperProvider) {
-		SqsTemplateBuilder<Object> builder = SqsTemplate.builder().sqsAsyncClient(sqsAsyncClient);
+	public SqsTemplate sqsTemplate(SqsAsyncClient sqsAsyncClient, ObjectProvider<ObjectMapper> objectMapperProvider) {
+		SqsTemplateBuilder builder = SqsTemplate.builder().sqsAsyncClient(sqsAsyncClient);
 		objectMapperProvider
 				.ifAvailable(om -> builder.configureDefaultConverter(converter -> converter.setObjectMapper(om)));
 		return builder.build();

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -28,6 +28,7 @@ import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
 import io.awspring.cloud.sqs.listener.errorhandler.ErrorHandler;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -68,6 +69,12 @@ public class SqsAutoConfiguration {
 			ObjectProvider<AwsClientCustomizer<SqsAsyncClientBuilder>> configurer) {
 		return awsClientBuilderConfigurer
 				.configure(SqsAsyncClient.builder(), this.sqsProperties, configurer.getIfAvailable()).build();
+	}
+
+	@ConditionalOnMissingBean
+	@Bean
+	public SqsTemplate<Object> sqsTemplate(SqsAsyncClient sqsAsyncClient) {
+		return SqsTemplate.newTemplate(sqsAsyncClient);
 	}
 
 	@ConditionalOnMissingBean

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -78,7 +78,7 @@ public class SqsAutoConfiguration {
 		SqsTemplate.Builder<Object> builder = SqsTemplate.builder()
 			.sqsAsyncClient(sqsAsyncClient);
 		objectMapperProvider.ifAvailable(om -> builder
-			.defaultMessageConverter(converter -> converter.setObjectMapper(om)));
+			.setupDefaultConverter(converter -> converter.setObjectMapper(om)));
 		return builder.build();
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -74,18 +74,18 @@ public class SqsAutoConfiguration {
 	@ConditionalOnMissingBean
 	@Bean
 	public SqsTemplate<Object> sqsTemplate(SqsAsyncClient sqsAsyncClient,
-										   ObjectProvider<ObjectMapper> objectMapperProvider) {
-		SqsTemplate.Builder<Object> builder = SqsTemplate.builder()
-			.sqsAsyncClient(sqsAsyncClient);
-		objectMapperProvider.ifAvailable(om -> builder
-			.setupDefaultConverter(converter -> converter.setObjectMapper(om)));
+			ObjectProvider<ObjectMapper> objectMapperProvider) {
+		SqsTemplate.Builder<Object> builder = SqsTemplate.builder().sqsAsyncClient(sqsAsyncClient);
+		objectMapperProvider
+				.ifAvailable(om -> builder.setupDefaultConverter(converter -> converter.setObjectMapper(om)));
 		return builder.build();
 	}
 
 	@ConditionalOnMissingBean
 	@Bean
 	public SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFactory(
-			ObjectProvider<SqsAsyncClient> sqsAsyncClient, ObjectProvider<AsyncErrorHandler<Object>> asyncErrorHandler,
+			ObjectProvider<SqsAsyncClient> sqsAsyncClient,
+			ObjectProvider<AsyncErrorHandler<Object>> asyncErrorHandler,
 			ObjectProvider<ErrorHandler<Object>> errorHandler,
 			ObjectProvider<AsyncMessageInterceptor<Object>> asyncInterceptors,
 			ObjectProvider<MessageInterceptor<Object>> interceptors) {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -77,7 +77,7 @@ public class SqsAutoConfiguration {
 			ObjectProvider<ObjectMapper> objectMapperProvider) {
 		SqsTemplate.Builder<Object> builder = SqsTemplate.builder().sqsAsyncClient(sqsAsyncClient);
 		objectMapperProvider
-				.ifAvailable(om -> builder.setupDefaultConverter(converter -> converter.setObjectMapper(om)));
+				.ifAvailable(om -> builder.configureDefaultConverter(converter -> converter.setObjectMapper(om)));
 		return builder.build();
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -73,8 +73,13 @@ public class SqsAutoConfiguration {
 
 	@ConditionalOnMissingBean
 	@Bean
-	public SqsTemplate<Object> sqsTemplate(SqsAsyncClient sqsAsyncClient) {
-		return SqsTemplate.newTemplate(sqsAsyncClient);
+	public SqsTemplate<Object> sqsTemplate(SqsAsyncClient sqsAsyncClient,
+										   ObjectProvider<ObjectMapper> objectMapperProvider) {
+		SqsTemplate.Builder<Object> builder = SqsTemplate.builder()
+			.sqsAsyncClient(sqsAsyncClient);
+		objectMapperProvider.ifAvailable(om -> builder
+			.defaultMessageConverter(converter -> converter.setObjectMapper(om)));
+		return builder.build();
 	}
 
 	@ConditionalOnMissingBean

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -29,6 +29,7 @@ import io.awspring.cloud.sqs.listener.errorhandler.ErrorHandler;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
+import io.awspring.cloud.sqs.operations.SqsTemplateBuilder;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -75,7 +76,7 @@ public class SqsAutoConfiguration {
 	@Bean
 	public SqsTemplate<Object> sqsTemplate(SqsAsyncClient sqsAsyncClient,
 			ObjectProvider<ObjectMapper> objectMapperProvider) {
-		SqsTemplate.Builder<Object> builder = SqsTemplate.builder().sqsAsyncClient(sqsAsyncClient);
+		SqsTemplateBuilder<Object> builder = SqsTemplate.builder().sqsAsyncClient(sqsAsyncClient);
 		objectMapperProvider
 				.ifAvailable(om -> builder.configureDefaultConverter(converter -> converter.setObjectMapper(om)));
 		return builder.build();

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -23,7 +23,7 @@ import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
 import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration;
 import io.awspring.cloud.sqs.config.SqsListenerConfigurer;
 import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
-import io.awspring.cloud.sqs.listener.ContainerOptions;
+import io.awspring.cloud.sqs.listener.SqsContainerOptions;
 import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
 import io.awspring.cloud.sqs.listener.errorhandler.ErrorHandler;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
@@ -48,6 +48,7 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClientBuilder;
  * {@link EnableAutoConfiguration Auto-configuration} for SQS integration.
  *
  * @author Tomaz Fernandes
+ * @author Maciej Walkowiak
  * @since 3.0
  */
 @AutoConfiguration
@@ -84,8 +85,7 @@ public class SqsAutoConfiguration {
 	@ConditionalOnMissingBean
 	@Bean
 	public SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFactory(
-			ObjectProvider<SqsAsyncClient> sqsAsyncClient,
-			ObjectProvider<AsyncErrorHandler<Object>> asyncErrorHandler,
+			ObjectProvider<SqsAsyncClient> sqsAsyncClient, ObjectProvider<AsyncErrorHandler<Object>> asyncErrorHandler,
 			ObjectProvider<ErrorHandler<Object>> errorHandler,
 			ObjectProvider<AsyncMessageInterceptor<Object>> asyncInterceptors,
 			ObjectProvider<MessageInterceptor<Object>> interceptors) {
@@ -100,7 +100,7 @@ public class SqsAutoConfiguration {
 		return factory;
 	}
 
-	private void configureContainerOptions(ContainerOptions.Builder options) {
+	private void configureContainerOptions(SqsContainerOptions.Builder options) {
 		PropertyMapper mapper = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		mapper.from(this.sqsProperties.getListener().getMaxInflightMessagesPerQueue())
 				.to(options::maxInflightMessagesPerQueue);

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationIntegrationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationIntegrationTest.java
@@ -67,7 +67,7 @@ class SqsAutoConfigurationIntegrationTest {
 	@Test
 	void sendsAndReceivesMessage() {
 		this.contextRunner.run(context -> {
-			SqsTemplate<Object> sqsTemplate = context.getBean(SqsTemplate.class);
+			SqsTemplate sqsTemplate = context.getBean(SqsTemplate.class);
 			sqsTemplate.send(to -> to.queue(QUEUE_NAME).payload(PAYLOAD));
 			CountDownLatch latch = context.getBean(CountDownLatch.class);
 			assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationIntegrationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationIntegrationTest.java
@@ -22,10 +22,9 @@ import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
 import io.awspring.cloud.sqs.annotation.SqsListener;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
-import io.awspring.cloud.sqs.operations.SqsTemplate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -37,7 +36,6 @@ import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
-import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 /**
  * Integration tests for {@link SqsAutoConfiguration}.

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
@@ -32,11 +32,10 @@ import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
 import io.awspring.cloud.sqs.listener.ContainerOptions;
 import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
-
-import io.awspring.cloud.sqs.operations.SqsTemplate;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -92,8 +91,7 @@ class SqsAutoConfigurationTest {
 
 	@Test
 	void configuresSqsTemplate() {
-		this.contextRunner.run(context ->
-			assertThat(context).hasSingleBean(SqsTemplate.class));
+		this.contextRunner.run(context -> assertThat(context).hasSingleBean(SqsTemplate.class));
 	}
 
 	@Test

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
@@ -35,6 +35,8 @@ import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
+
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -57,6 +59,7 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClientBuilder;
 class SqsAutoConfigurationTest {
 
 	private static final String CUSTOM_OBJECT_MAPPER_BEAN_NAME = "customObjectMapper";
+
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withPropertyValues("spring.cloud.aws.region.static:eu-west-1")
 			.withConfiguration(AutoConfigurations.of(RegionProviderAutoConfiguration.class,
@@ -85,6 +88,12 @@ class SqsAutoConfigurationTest {
 			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(SqsAsyncClient.class));
 			assertThat(client.getEndpoint()).isEqualTo(URI.create("https://sqs.eu-west-1.amazonaws.com"));
 		});
+	}
+
+	@Test
+	void configuresSqsTemplate() {
+		this.contextRunner.run(context ->
+			assertThat(context).hasSingleBean(SqsTemplate.class));
 	}
 
 	@Test
@@ -160,13 +169,13 @@ class SqsAutoConfigurationTest {
 
 		@Bean
 		AsyncErrorHandler<Object> asyncErrorHandler() {
-			return new AsyncErrorHandler<Object>() {
+			return new AsyncErrorHandler<>() {
 			};
 		}
 
 		@Bean
 		AsyncMessageInterceptor<?> asyncMessageInterceptor() {
-			return new AsyncMessageInterceptor<Object>() {
+			return new AsyncMessageInterceptor<>() {
 			};
 		}
 
@@ -187,7 +196,7 @@ class SqsAutoConfigurationTest {
 
 		@Bean
 		AwsClientCustomizer<SqsAsyncClientBuilder> sqsClientBuilderAwsClientConfigurer() {
-			return new AwsClientCustomizer<SqsAsyncClientBuilder>() {
+			return new AwsClientCustomizer<>() {
 				@Override
 				@Nullable
 				public ClientOverrideConfiguration overrideConfiguration() {

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/FifoUtils.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/FifoUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs;
+
+import java.util.Collection;
+
+/**
+ * Methods related to FIFO queues.
+ * @author Tomaz Fernandes
+ * @since 3.0
+ */
+public class FifoUtils {
+
+	/**
+	 * Prevent instantiation.
+	 */
+	private FifoUtils() {
+	}
+
+	/**
+	 * Return whether the provided queue is Fifo.
+	 * @param queue the queue.
+	 * @return true if fifo.
+	 */
+	public static boolean isFifo(String queue) {
+		return queue.endsWith(".fifo");
+	}
+
+	/**
+	 * Return whether all provided queues are Fifo.
+	 * @param queues the queues.
+	 * @return true if all queues are Fifo.
+	 */
+	public static boolean areAllFifo(Collection<String> queues) {
+		return queues.stream().allMatch(FifoUtils::isFifo);
+	}
+
+	/**
+	 * Return whether all provided queues are not Fifo.
+	 * @param queues the queues.
+	 * @return true if all queues are not Fifo.
+	 */
+	public static boolean areNotFifo(Collection<String> queues) {
+		return queues.stream().noneMatch(FifoUtils::isFifo);
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/MessageHeaderUtils.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/MessageHeaderUtils.java
@@ -15,13 +15,12 @@
  */
 package io.awspring.cloud.sqs;
 
+import io.awspring.cloud.sqs.support.converter.MessagingMessageHeaders;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
-import io.awspring.cloud.sqs.support.converter.MessagingMessageHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.GenericMessage;
@@ -94,8 +93,8 @@ public class MessageHeaderUtils {
 	}
 
 	/**
-	 * Add a header to a {@link Message} while preserving the id and timestamp.
-	 * Note that since messages are immutable, a new instance will be returned.
+	 * Add a header to a {@link Message} while preserving the id and timestamp. Note that since messages are immutable,
+	 * a new instance will be returned.
 	 * @param message the message to add headers to.
 	 * @param headerName the header name.
 	 * @param headerValue the header value.
@@ -107,8 +106,8 @@ public class MessageHeaderUtils {
 	}
 
 	/**
-	 * Add headers to a {@link Message} while preserving the id and timestamp.
-	 * Note that since messages are immutable, a new instance will be returned.
+	 * Add headers to a {@link Message} while preserving the id and timestamp. Note that since messages are immutable, a
+	 * new instance will be returned.
 	 * @param message the message to add headers to.
 	 * @param newHeaders the headers to add.
 	 * @return the new message.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/MessageHeaderUtils.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/MessageHeaderUtils.java
@@ -101,8 +101,8 @@ public class MessageHeaderUtils {
 	 * @return the new message.
 	 * @param <T> the payload type.
 	 */
-	public static <T> Message<T> addHeaderToMessage(Message<T> message, String headerName, Object headerValue) {
-		return addHeadersToMessage(message, Map.of(headerName, headerValue));
+	public static <T> Message<T> addHeaderIfAbsent(Message<T> message, String headerName, Object headerValue) {
+		return addHeadersIfAbsent(message, Map.of(headerName, headerValue));
 	}
 
 	/**
@@ -113,15 +113,15 @@ public class MessageHeaderUtils {
 	 * @return the new message.
 	 * @param <T> the payload type.
 	 */
-	public static <T> Message<T> addHeadersToMessage(Message<T> message, Map<String, Object> newHeaders) {
-		return new GenericMessage<>(message.getPayload(), addHeaders(message.getHeaders(), newHeaders));
+	public static <T> Message<T> addHeadersIfAbsent(Message<T> message, Map<String, Object> newHeaders) {
+		return new GenericMessage<>(message.getPayload(), addHeadersIfAbsent(message.getHeaders(), newHeaders));
 	}
 
-	public static MessageHeaders addHeader(MessageHeaders headers, String headerName, Object headerValue) {
-		return addHeaders(headers, Map.of(headerName, headerValue));
+	public static MessageHeaders addHeaderIfAbsent(MessageHeaders headers, String headerName, Object headerValue) {
+		return addHeadersIfAbsent(headers, Map.of(headerName, headerValue));
 	}
 
-	public static MessageHeaders addHeaders(MessageHeaders headers, Map<String, Object> newHeaders) {
+	public static MessageHeaders addHeadersIfAbsent(MessageHeaders headers, Map<String, Object> newHeaders) {
 		MessageHeaderAccessor accessor = new MessageHeaderAccessor();
 		accessor.copyHeaders(headers);
 		accessor.copyHeadersIfAbsent(newHeaders);

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/MessagingHeaders.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/MessagingHeaders.java
@@ -13,24 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.awspring.cloud.sqs.operations;
+package io.awspring.cloud.sqs;
 
 /**
- * The strategy to use when handling a send batch operation that has at least one failed message.
- *
+ * {@link org.springframework.messaging.MessageHeaders} associated with messaging operations.
  * @author Tomaz Fernandes
  * @since 3.0
  */
-public enum SendBatchFailureStrategy {
+public class MessagingHeaders {
 
 	/**
-	 * Throw a {@link SendBatchOperationFailedException} with a {@link SendResult.Batch} object.
+	 * Header for a {@link io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementCallback} for this message.
 	 */
-	THROW_EXCEPTION,
-
-	/**
-	 * Do not throw an exception and return the {@link SendResult.Batch} object directly.
-	 */
-	RETURN_RESULT
+	public static final String ACKNOWLEDGMENT_CALLBACK_HEADER = "AcknowledgementCallback";
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/QueueAttributesResolver.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/QueueAttributesResolver.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.awspring.cloud.sqs.listener;
+package io.awspring.cloud.sqs;
 
-import io.awspring.cloud.sqs.CompletableFutures;
-import io.awspring.cloud.sqs.QueueAttributesResolvingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -25,6 +23,10 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+
+import io.awspring.cloud.sqs.listener.ContainerOptions;
+import io.awspring.cloud.sqs.listener.QueueAttributes;
+import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.lang.Nullable;

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/QueueAttributesResolver.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/QueueAttributesResolver.java
@@ -15,9 +15,9 @@
  */
 package io.awspring.cloud.sqs;
 
-import io.awspring.cloud.sqs.listener.ContainerOptions;
 import io.awspring.cloud.sqs.listener.QueueAttributes;
 import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
+import io.awspring.cloud.sqs.listener.SqsContainerOptions;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -46,10 +46,11 @@ import software.amazon.awssdk.services.sqs.model.QueueDoesNotExistException;
  * {@link QueueAttributeName} collection.
  *
  * @author Tomaz Fernandes
+ * @author Agim Emruli
  * @author Adrian Stoelken
  * @since 3.0
- * @see ContainerOptions#getQueueAttributeNames()
- * @see ContainerOptions#getQueueNotFoundStrategy()
+ * @see SqsContainerOptions#getQueueAttributeNames()
+ * @see SqsContainerOptions#getQueueNotFoundStrategy()
  */
 public class QueueAttributesResolver {
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/QueueAttributesResolver.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/QueueAttributesResolver.java
@@ -15,6 +15,9 @@
  */
 package io.awspring.cloud.sqs;
 
+import io.awspring.cloud.sqs.listener.ContainerOptions;
+import io.awspring.cloud.sqs.listener.QueueAttributes;
+import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -23,10 +26,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-
-import io.awspring.cloud.sqs.listener.ContainerOptions;
-import io.awspring.cloud.sqs.listener.QueueAttributes;
-import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.lang.Nullable;

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/QueueAttributesResolvingException.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/QueueAttributesResolvingException.java
@@ -16,7 +16,7 @@
 package io.awspring.cloud.sqs;
 
 /**
- * Exception thrown when a {@link io.awspring.cloud.sqs.listener.QueueAttributesResolver} fails.
+ * Exception thrown when a {@link QueueAttributesResolver} fails.
  *
  * @author Tomaz Fernandes
  * @since 3.0

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/SqsAcknowledgementException.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/SqsAcknowledgementException.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.awspring.cloud.sqs.listener.acknowledgement;
+package io.awspring.cloud.sqs;
 
-import io.awspring.cloud.sqs.SqsException;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import org.springframework.lang.Nullable;
@@ -29,36 +28,36 @@ import org.springframework.messaging.Message;
  */
 public class SqsAcknowledgementException extends SqsException {
 
-	private final String queueUrl;
+	private final String queue;
 
 	private final Collection<Message<?>> failedAcknowledgementMessages;
 
 	private final Collection<Message<?>> successfullyAcknowledgedMessages;
 
 	/**
-	 * Contruct an instance with the given parameters.
+	 * Construct an instance with the given parameters.
 	 * @param errorMessage the error message.
 	 * @param failedAcknowledgementMessages the messages that failed to be acknowledged.
-	 * @param queueUrl the url for the queue from which the messages were polled from.
+	 * @param queue the queue from which the messages were received from.
 	 * @param <T> the messages payload type.
 	 */
 	public <T> SqsAcknowledgementException(String errorMessage, Collection<Message<T>> successfullyAcknowledgedMessages,
-			Collection<Message<T>> failedAcknowledgementMessages, String queueUrl) {
-		this(errorMessage, successfullyAcknowledgedMessages, failedAcknowledgementMessages, queueUrl, null);
+			Collection<Message<T>> failedAcknowledgementMessages, String queue) {
+		this(errorMessage, successfullyAcknowledgedMessages, failedAcknowledgementMessages, queue, null);
 	}
 
 	/**
-	 * Contruct an instance with the given parameters.
+	 * Construct an instance with the given parameters.
 	 * @param errorMessage the error message.
 	 * @param failedAcknowledgementMessages the messages that failed to be acknowledged.
-	 * @param queueUrl the url for the queue from which the messages were polled from.
+	 * @param queue the queue from which the messages were received from.
 	 * @param cause the exception cause.
 	 * @param <T> the messages payload type.
 	 */
 	public <T> SqsAcknowledgementException(String errorMessage, Collection<Message<T>> successfullyAcknowledgedMessages,
-			Collection<Message<T>> failedAcknowledgementMessages, String queueUrl, @Nullable Throwable cause) {
+			Collection<Message<T>> failedAcknowledgementMessages, String queue, @Nullable Throwable cause) {
 		super(errorMessage, cause);
-		this.queueUrl = queueUrl;
+		this.queue = queue;
 		this.failedAcknowledgementMessages = failedAcknowledgementMessages.stream().map(msg -> (Message<?>) msg)
 				.collect(Collectors.toList());
 		this.successfullyAcknowledgedMessages = successfullyAcknowledgedMessages.stream().map(msg -> (Message<?>) msg)
@@ -74,7 +73,7 @@ public class SqsAcknowledgementException extends SqsException {
 	}
 
 	/**
-	 * Return the messages that failed to be acknowledged.
+	 * Return the messages that were successfully acknowledged.
 	 * @return the messages.
 	 */
 	public Collection<Message<?>> getSuccessfullyAcknowledgedMessages() {
@@ -82,11 +81,11 @@ public class SqsAcknowledgementException extends SqsException {
 	}
 
 	/**
-	 * Return the url for the queue from which the messages were polled from.
+	 * Return the queue from which the messages were received from.
 	 * @return the queue url.
 	 */
-	public String getQueueUrl() {
-		return this.queueUrl;
+	public String getQueue() {
+		return this.queue;
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/SqsAcknowledgementException.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/SqsAcknowledgementException.java
@@ -41,8 +41,8 @@ public class SqsAcknowledgementException extends SqsException {
 	 * @param queue the queue from which the messages were received from.
 	 * @param <T> the messages payload type.
 	 */
-	public <T> SqsAcknowledgementException(String errorMessage, Collection<Message<T>> successfullyAcknowledgedMessages,
-			Collection<Message<T>> failedAcknowledgementMessages, String queue) {
+	public SqsAcknowledgementException(String errorMessage, Collection<Message<?>> successfullyAcknowledgedMessages,
+			Collection<Message<?>> failedAcknowledgementMessages, String queue) {
 		this(errorMessage, successfullyAcknowledgedMessages, failedAcknowledgementMessages, queue, null);
 	}
 
@@ -54,8 +54,8 @@ public class SqsAcknowledgementException extends SqsException {
 	 * @param cause the exception cause.
 	 * @param <T> the messages payload type.
 	 */
-	public <T> SqsAcknowledgementException(String errorMessage, Collection<Message<T>> successfullyAcknowledgedMessages,
-			Collection<Message<T>> failedAcknowledgementMessages, String queue, @Nullable Throwable cause) {
+	public SqsAcknowledgementException(String errorMessage, Collection<Message<?>> successfullyAcknowledgedMessages,
+			Collection<Message<?>> failedAcknowledgementMessages, String queue, @Nullable Throwable cause) {
 		super(errorMessage, cause);
 		this.queue = queue;
 		this.failedAcknowledgementMessages = failedAcknowledgementMessages.stream().map(msg -> (Message<?>) msg)

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/SqsException.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/SqsException.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.sqs;
 
 import org.springframework.core.NestedRuntimeException;
+import org.springframework.lang.Nullable;
 
 /**
  * Top-level exception for Sqs {@link RuntimeException} instances.
@@ -30,7 +31,7 @@ public class SqsException extends NestedRuntimeException {
 	 * @param msg the message.
 	 * @param cause the cause.
 	 */
-	public SqsException(String msg, Throwable cause) {
+	public SqsException(String msg, @Nullable Throwable cause) {
 		super(msg, cause);
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
@@ -63,7 +63,7 @@ public class SqsListenerAnnotationBeanPostProcessor extends AbstractListenerAnno
 
 	@Override
 	protected Collection<HandlerMethodArgumentResolver> createAdditionalArgumentResolvers() {
-		return Arrays.asList(new VisibilityHandlerMethodArgumentResolver(SqsHeaders.SQS_VISIBILITY_HEADER),
+		return Arrays.asList(new VisibilityHandlerMethodArgumentResolver(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER),
 				new SqsMessageMethodArgumentResolver(), new QueueAttributesMethodArgumentResolver());
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/FifoSqsComponentFactory.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/FifoSqsComponentFactory.java
@@ -96,7 +96,7 @@ public class FifoSqsComponentFactory<T> implements ContainerComponentFactory<T, 
 	}
 
 	private Function<Message<T>, String> getMessageGroupingFunction() {
-		return message -> MessageHeaderUtils.getHeaderAsString(message, SqsHeaders.MessageSystemAttribute.SQS_MESSAGE_GROUP_ID_HEADER);
+		return message -> MessageHeaderUtils.getHeaderAsString(message, SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER);
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/FifoSqsComponentFactory.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/FifoSqsComponentFactory.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.sqs.listener;
 
 import io.awspring.cloud.sqs.ConfigUtils;
+import io.awspring.cloud.sqs.FifoUtils;
 import io.awspring.cloud.sqs.MessageHeaderUtils;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementOrdering;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementProcessor;
@@ -58,7 +59,7 @@ public class FifoSqsComponentFactory<T> implements ContainerComponentFactory<T, 
 
 	@Override
 	public boolean supports(Collection<String> queueNames, SqsContainerOptions options) {
-		return queueNames.stream().allMatch(name -> name.endsWith(".fifo"));
+		return FifoUtils.areAllFifo(queueNames);
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsHeaders.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsHeaders.java
@@ -107,7 +107,8 @@ public class SqsHeaders {
 		/**
 		 * Deduplication header in a SQS message.
 		 */
-		public static final String SQS_MESSAGE_DEDUPLICATION_ID_HEADER = SQS_MSA_HEADER_PREFIX + "MessageDeduplicationId";
+		public static final String SQS_MESSAGE_DEDUPLICATION_ID_HEADER = SQS_MSA_HEADER_PREFIX
+				+ "MessageDeduplicationId";
 
 		/**
 		 * ApproximateFirstReceiveTimestamp header in a SQS message.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsHeaders.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsHeaders.java
@@ -35,11 +35,6 @@ public class SqsHeaders {
 	public static final String SQS_HEADER_PREFIX = "Sqs_";
 
 	/**
-	 * MessageAttributes prefix to be used by all headers mapped from SQS Message Attributes.
-	 */
-	public static final String SQS_MA_HEADER_PREFIX = SQS_HEADER_PREFIX + "Ma_";
-
-	/**
 	 * Header for the queue name.
 	 */
 	public static final String SQS_QUEUE_NAME_HEADER = SQS_HEADER_PREFIX + "QueueName";
@@ -62,12 +57,17 @@ public class SqsHeaders {
 	/**
 	 * Header for the {@link Visibility} object for this message.
 	 */
-	public static final String SQS_VISIBILITY_HEADER = SQS_HEADER_PREFIX + "Visibility";
+	public static final String SQS_VISIBILITY_TIMEOUT_HEADER = SQS_HEADER_PREFIX + "VisibilityTimeout";
 
 	/**
 	 * Header for the received at attribute.
 	 */
 	public static final String SQS_RECEIVED_AT_HEADER = SQS_HEADER_PREFIX + "ReceivedAt";
+
+	/**
+	 * Header for the delay attribute.
+	 */
+	public static final String SQS_DELAY_HEADER = SQS_HEADER_PREFIX + "Delay";
 
 	/**
 	 * Header for a {@link io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementCallback} for this message.
@@ -80,13 +80,18 @@ public class SqsHeaders {
 	public static final String SQS_QUEUE_ATTRIBUTES_HEADER = SQS_HEADER_PREFIX + "QueueAttributes";
 
 	/**
+	 * Header for the ReceiveRequestAttemptId for this message.
+	 */
+	public static final String SQS_RECEIVE_REQUEST_ATTEMPT_ID_HEADER = SQS_HEADER_PREFIX + "ReceiveRequestAttemptId";
+
+	/**
 	 * Header containing the FQCN of the {@link Class} that the message's payload should be deserialized to.
 	 */
 	public static final String SQS_DEFAULT_TYPE_HEADER = "JavaType";
 
-	public static class MessageSystemAttribute {
+	public static class MessageSystemAttributes {
 
-		private MessageSystemAttribute() {
+		private MessageSystemAttributes() {
 		}
 
 		/**
@@ -102,7 +107,7 @@ public class SqsHeaders {
 		/**
 		 * Deduplication header in a SQS message.
 		 */
-		public static final String SQS_DEDUPLICATION_ID_HEADER = SQS_MSA_HEADER_PREFIX + "MessageDeduplicationId";
+		public static final String SQS_MESSAGE_DEDUPLICATION_ID_HEADER = SQS_MSA_HEADER_PREFIX + "MessageDeduplicationId";
 
 		/**
 		 * ApproximateFirstReceiveTimestamp header in a SQS message.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsHeaders.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsHeaders.java
@@ -70,11 +70,6 @@ public class SqsHeaders {
 	public static final String SQS_DELAY_HEADER = SQS_HEADER_PREFIX + "Delay";
 
 	/**
-	 * Header for a {@link io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementCallback} for this message.
-	 */
-	public static final String SQS_ACKNOWLEDGMENT_CALLBACK_HEADER = SQS_HEADER_PREFIX + "Acknowledgement";
-
-	/**
 	 * Header for the {@link QueueAttributes} for this message.
 	 */
 	public static final String SQS_QUEUE_ATTRIBUTES_HEADER = SQS_HEADER_PREFIX + "QueueAttributes";

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/StandardSqsComponentFactory.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/StandardSqsComponentFactory.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.sqs.listener;
 
 import io.awspring.cloud.sqs.ConfigUtils;
+import io.awspring.cloud.sqs.FifoUtils;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementOrdering;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementProcessor;
 import io.awspring.cloud.sqs.listener.acknowledgement.BatchingAcknowledgementProcessor;
@@ -45,7 +46,7 @@ public class StandardSqsComponentFactory<T> implements ContainerComponentFactory
 
 	@Override
 	public boolean supports(Collection<String> queueNames, SqsContainerOptions options) {
-		return queueNames.stream().noneMatch(name -> name.endsWith(".fifo"));
+		return FifoUtils.areNotFifo(queueNames);
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/Acknowledgement.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/Acknowledgement.java
@@ -16,9 +16,10 @@
 package io.awspring.cloud.sqs.listener.acknowledgement;
 
 import io.awspring.cloud.sqs.MessageHeaderUtils;
-import io.awspring.cloud.sqs.listener.SqsHeaders;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+
+import io.awspring.cloud.sqs.MessagingHeaders;
 import org.springframework.messaging.Message;
 
 /**
@@ -49,22 +50,21 @@ public interface Acknowledgement {
 	}
 
 	/**
-	 * Acknowledge the provided messages.
-	 * @param messages the messages.
-	 */
-	static <T> void acknowledge(Collection<Message<T>> messages) {
-		acknowledgeAsync(messages).join();
-	}
-
-	/**
 	 * Acknowledge the provided message asynchronously.
 	 * @param message the message.
 	 */
 	@SuppressWarnings("unchecked")
 	static CompletableFuture<Void> acknowledgeAsync(Message<?> message) {
-		return MessageHeaderUtils
-				.getHeader(message, SqsHeaders.SQS_ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class)
+		return MessageHeaderUtils.getHeader(message, MessagingHeaders.ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class)
 				.onAcknowledge(message);
+	}
+
+	/**
+	 * Acknowledge the provided messages.
+	 * @param messages the messages.
+	 */
+	static <T> void acknowledge(Collection<Message<T>> messages) {
+		acknowledgeAsync(messages).join();
 	}
 
 	/**
@@ -74,7 +74,7 @@ public interface Acknowledgement {
 	@SuppressWarnings("unchecked")
 	static <T> CompletableFuture<Void> acknowledgeAsync(Collection<Message<T>> messages) {
 		return !messages.isEmpty() ? MessageHeaderUtils.getHeader(messages.iterator().next(),
-				SqsHeaders.SQS_ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class).onAcknowledge(messages)
+			MessagingHeaders.ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class).onAcknowledge(messages)
 				: CompletableFuture.completedFuture(null);
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/Acknowledgement.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/Acknowledgement.java
@@ -53,7 +53,7 @@ public interface Acknowledgement {
 	 * Acknowledge the provided messages.
 	 * @param messages the messages.
 	 */
-	static void acknowledge(Collection<Message<?>> messages) {
+	static <T> void acknowledge(Collection<Message<T>> messages) {
 		acknowledgeAsync(messages).join();
 	}
 
@@ -72,7 +72,7 @@ public interface Acknowledgement {
 	 * @param messages the messages.
 	 */
 	@SuppressWarnings("unchecked")
-	static CompletableFuture<Void> acknowledgeAsync(Collection<Message<?>> messages) {
+	static <T> CompletableFuture<Void> acknowledgeAsync(Collection<Message<T>> messages) {
 		return !messages.isEmpty()
 			? MessageHeaderUtils.getHeader(messages.iterator().next(), SqsHeaders.SQS_ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class)
 			.onAcknowledge(messages)

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/Acknowledgement.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/Acknowledgement.java
@@ -19,6 +19,7 @@ import io.awspring.cloud.sqs.MessageHeaderUtils;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
 import org.springframework.messaging.Message;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -40,14 +41,42 @@ public interface Acknowledgement {
 	 */
 	CompletableFuture<Void> acknowledgeAsync();
 
+	/**
+	 * Acknowledge the provided message.
+	 * @param message the message.
+	 */
 	static void acknowledge(Message<?> message) {
 		acknowledgeAsync(message).join();
 	}
 
+	/**
+	 * Acknowledge the provided messages.
+	 * @param messages the messages.
+	 */
+	static void acknowledge(Collection<Message<?>> messages) {
+		acknowledgeAsync(messages).join();
+	}
+
+	/**
+	 * Acknowledge the provided message asynchronously.
+	 * @param message the message.
+	 */
 	@SuppressWarnings("unchecked")
 	static CompletableFuture<Void> acknowledgeAsync(Message<?> message) {
 		return MessageHeaderUtils.getHeader(message, SqsHeaders.SQS_ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class)
 			.onAcknowledge(message);
+	}
+
+	/**
+	 * Acknowledge the provided messages asynchronously.
+	 * @param messages the messages.
+	 */
+	@SuppressWarnings("unchecked")
+	static CompletableFuture<Void> acknowledgeAsync(Collection<Message<?>> messages) {
+		return !messages.isEmpty()
+			? MessageHeaderUtils.getHeader(messages.iterator().next(), SqsHeaders.SQS_ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class)
+			.onAcknowledge(messages)
+			: CompletableFuture.completedFuture(null);
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/Acknowledgement.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/Acknowledgement.java
@@ -16,10 +16,9 @@
 package io.awspring.cloud.sqs.listener.acknowledgement;
 
 import io.awspring.cloud.sqs.MessageHeaderUtils;
+import io.awspring.cloud.sqs.MessagingHeaders;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
-
-import io.awspring.cloud.sqs.MessagingHeaders;
 import org.springframework.messaging.Message;
 
 /**
@@ -55,7 +54,8 @@ public interface Acknowledgement {
 	 */
 	@SuppressWarnings("unchecked")
 	static CompletableFuture<Void> acknowledgeAsync(Message<?> message) {
-		return MessageHeaderUtils.getHeader(message, MessagingHeaders.ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class)
+		return MessageHeaderUtils
+				.getHeader(message, MessagingHeaders.ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class)
 				.onAcknowledge(message);
 	}
 
@@ -74,7 +74,7 @@ public interface Acknowledgement {
 	@SuppressWarnings("unchecked")
 	static <T> CompletableFuture<Void> acknowledgeAsync(Collection<Message<T>> messages) {
 		return !messages.isEmpty() ? MessageHeaderUtils.getHeader(messages.iterator().next(),
-			MessagingHeaders.ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class).onAcknowledge(messages)
+				MessagingHeaders.ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class).onAcknowledge(messages)
 				: CompletableFuture.completedFuture(null);
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/Acknowledgement.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/Acknowledgement.java
@@ -17,10 +17,9 @@ package io.awspring.cloud.sqs.listener.acknowledgement;
 
 import io.awspring.cloud.sqs.MessageHeaderUtils;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
-import org.springframework.messaging.Message;
-
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import org.springframework.messaging.Message;
 
 /**
  * Interface representing a message acknowledgement. For this interface to be used as a listener method parameter,
@@ -63,8 +62,9 @@ public interface Acknowledgement {
 	 */
 	@SuppressWarnings("unchecked")
 	static CompletableFuture<Void> acknowledgeAsync(Message<?> message) {
-		return MessageHeaderUtils.getHeader(message, SqsHeaders.SQS_ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class)
-			.onAcknowledge(message);
+		return MessageHeaderUtils
+				.getHeader(message, SqsHeaders.SQS_ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class)
+				.onAcknowledge(message);
 	}
 
 	/**
@@ -73,10 +73,9 @@ public interface Acknowledgement {
 	 */
 	@SuppressWarnings("unchecked")
 	static <T> CompletableFuture<Void> acknowledgeAsync(Collection<Message<T>> messages) {
-		return !messages.isEmpty()
-			? MessageHeaderUtils.getHeader(messages.iterator().next(), SqsHeaders.SQS_ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class)
-			.onAcknowledge(messages)
-			: CompletableFuture.completedFuture(null);
+		return !messages.isEmpty() ? MessageHeaderUtils.getHeader(messages.iterator().next(),
+				SqsHeaders.SQS_ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class).onAcknowledge(messages)
+				: CompletableFuture.completedFuture(null);
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/Acknowledgement.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/Acknowledgement.java
@@ -15,6 +15,10 @@
  */
 package io.awspring.cloud.sqs.listener.acknowledgement;
 
+import io.awspring.cloud.sqs.MessageHeaderUtils;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import org.springframework.messaging.Message;
+
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -35,5 +39,15 @@ public interface Acknowledgement {
 	 * Asynchronously acknowledge the message.
 	 */
 	CompletableFuture<Void> acknowledgeAsync();
+
+	static void acknowledge(Message<?> message) {
+		acknowledgeAsync(message).join();
+	}
+
+	@SuppressWarnings("unchecked")
+	static CompletableFuture<Void> acknowledgeAsync(Message<?> message) {
+		return MessageHeaderUtils.getHeader(message, SqsHeaders.SQS_ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class)
+			.onAcknowledge(message);
+	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementException.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementException.java
@@ -18,13 +18,11 @@ package io.awspring.cloud.sqs.listener.acknowledgement;
 import io.awspring.cloud.sqs.SqsException;
 import java.util.Collection;
 import java.util.stream.Collectors;
-
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 
 /**
- * {@link RuntimeException} that wraps an error thrown during acknowledgement execution.
- *
+ * Exception representing an error during acknowledgement execution.
  *
  * @author Tomaz Fernandes
  * @since 3.0
@@ -45,7 +43,7 @@ public class SqsAcknowledgementException extends SqsException {
 	 * @param <T> the messages payload type.
 	 */
 	public <T> SqsAcknowledgementException(String errorMessage, Collection<Message<T>> successfullyAcknowledgedMessages,
-										   Collection<Message<T>> failedAcknowledgementMessages, String queueUrl) {
+			Collection<Message<T>> failedAcknowledgementMessages, String queueUrl) {
 		this(errorMessage, successfullyAcknowledgedMessages, failedAcknowledgementMessages, queueUrl, null);
 	}
 
@@ -58,13 +56,13 @@ public class SqsAcknowledgementException extends SqsException {
 	 * @param <T> the messages payload type.
 	 */
 	public <T> SqsAcknowledgementException(String errorMessage, Collection<Message<T>> successfullyAcknowledgedMessages,
-										   Collection<Message<T>> failedAcknowledgementMessages, String queueUrl, @Nullable Throwable cause) {
+			Collection<Message<T>> failedAcknowledgementMessages, String queueUrl, @Nullable Throwable cause) {
 		super(errorMessage, cause);
 		this.queueUrl = queueUrl;
 		this.failedAcknowledgementMessages = failedAcknowledgementMessages.stream().map(msg -> (Message<?>) msg)
 				.collect(Collectors.toList());
 		this.successfullyAcknowledgedMessages = successfullyAcknowledgedMessages.stream().map(msg -> (Message<?>) msg)
-			.collect(Collectors.toList());
+				.collect(Collectors.toList());
 	}
 
 	/**

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementException.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementException.java
@@ -18,6 +18,8 @@ package io.awspring.cloud.sqs.listener.acknowledgement;
 import io.awspring.cloud.sqs.SqsException;
 import java.util.Collection;
 import java.util.stream.Collectors;
+
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 
 /**
@@ -29,24 +31,40 @@ import org.springframework.messaging.Message;
  */
 public class SqsAcknowledgementException extends SqsException {
 
+	private final String queueUrl;
+
 	private final Collection<Message<?>> failedAcknowledgementMessages;
 
-	private final String queueUrl;
+	private final Collection<Message<?>> successfullyAcknowledgedMessages;
 
 	/**
 	 * Contruct an instance with the given parameters.
 	 * @param errorMessage the error message.
 	 * @param failedAcknowledgementMessages the messages that failed to be acknowledged.
 	 * @param queueUrl the url for the queue from which the messages were polled from.
-	 * @param e the exception cause.
 	 * @param <T> the messages payload type.
 	 */
-	public <T> SqsAcknowledgementException(String errorMessage, Collection<Message<T>> failedAcknowledgementMessages,
-			String queueUrl, Throwable e) {
-		super(errorMessage, e);
+	public <T> SqsAcknowledgementException(String errorMessage, Collection<Message<T>> successfullyAcknowledgedMessages,
+										   Collection<Message<T>> failedAcknowledgementMessages, String queueUrl) {
+		this(errorMessage, successfullyAcknowledgedMessages, failedAcknowledgementMessages, queueUrl, null);
+	}
+
+	/**
+	 * Contruct an instance with the given parameters.
+	 * @param errorMessage the error message.
+	 * @param failedAcknowledgementMessages the messages that failed to be acknowledged.
+	 * @param queueUrl the url for the queue from which the messages were polled from.
+	 * @param cause the exception cause.
+	 * @param <T> the messages payload type.
+	 */
+	public <T> SqsAcknowledgementException(String errorMessage, Collection<Message<T>> successfullyAcknowledgedMessages,
+										   Collection<Message<T>> failedAcknowledgementMessages, String queueUrl, @Nullable Throwable cause) {
+		super(errorMessage, cause);
 		this.queueUrl = queueUrl;
 		this.failedAcknowledgementMessages = failedAcknowledgementMessages.stream().map(msg -> (Message<?>) msg)
 				.collect(Collectors.toList());
+		this.successfullyAcknowledgedMessages = successfullyAcknowledgedMessages.stream().map(msg -> (Message<?>) msg)
+			.collect(Collectors.toList());
 	}
 
 	/**
@@ -55,6 +73,14 @@ public class SqsAcknowledgementException extends SqsException {
 	 */
 	public Collection<Message<?>> getFailedAcknowledgementMessages() {
 		return this.failedAcknowledgementMessages;
+	}
+
+	/**
+	 * Return the messages that failed to be acknowledged.
+	 * @return the messages.
+	 */
+	public Collection<Message<?>> getSuccessfullyAcknowledgedMessages() {
+		return this.successfullyAcknowledgedMessages;
 	}
 
 	/**

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementExecutor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementExecutor.java
@@ -83,8 +83,8 @@ public class SqsAcknowledgementExecutor<T>
 	private SqsAcknowledgementException createAcknowledgementException(Collection<Message<T>> messagesToAck,
 			Throwable e) {
 		return new SqsAcknowledgementException(
-				"Error acknowledging messages " + MessageHeaderUtils.getId(messagesToAck), Collections.emptyList(), messagesToAck, this.queueUrl,
-				e);
+				"Error acknowledging messages " + MessageHeaderUtils.getId(messagesToAck), Collections.emptyList(),
+				messagesToAck, this.queueUrl, e);
 	}
 
 	// @formatter:off

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementExecutor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementExecutor.java
@@ -85,7 +85,7 @@ public class SqsAcknowledgementExecutor<T>
 			Throwable e) {
 		return new SqsAcknowledgementException(
 				"Error acknowledging messages " + MessageHeaderUtils.getId(messagesToAck), Collections.emptyList(),
-				messagesToAck, this.queueUrl, e);
+				messagesToAck.stream().map(msg -> (Message<?>) msg).collect(Collectors.toList()), this.queueUrl, e);
 	}
 
 	// @formatter:off

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementExecutor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementExecutor.java
@@ -22,6 +22,7 @@ import io.awspring.cloud.sqs.listener.QueueAttributesAware;
 import io.awspring.cloud.sqs.listener.SqsAsyncClientAware;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -82,7 +83,7 @@ public class SqsAcknowledgementExecutor<T>
 	private SqsAcknowledgementException createAcknowledgementException(Collection<Message<T>> messagesToAck,
 			Throwable e) {
 		return new SqsAcknowledgementException(
-				"Error acknowledging messages " + MessageHeaderUtils.getId(messagesToAck), messagesToAck, this.queueUrl,
+				"Error acknowledging messages " + MessageHeaderUtils.getId(messagesToAck), Collections.emptyList(), messagesToAck, this.queueUrl,
 				e);
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementExecutor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementExecutor.java
@@ -17,6 +17,7 @@ package io.awspring.cloud.sqs.listener.acknowledgement;
 
 import io.awspring.cloud.sqs.CompletableFutures;
 import io.awspring.cloud.sqs.MessageHeaderUtils;
+import io.awspring.cloud.sqs.SqsAcknowledgementException;
 import io.awspring.cloud.sqs.listener.QueueAttributes;
 import io.awspring.cloud.sqs.listener.QueueAttributesAware;
 import io.awspring.cloud.sqs.listener.SqsAsyncClientAware;

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/handler/AcknowledgementMode.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/handler/AcknowledgementMode.java
@@ -40,7 +40,6 @@ public enum AcknowledgementMode {
 	/**
 	 * Messages will not be acknowledged automatically by the container.
 	 * @see io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement
-	 * @see io.awspring.cloud.sqs.listener.acknowledgement.AsyncAcknowledgement
 	 */
 	MANUAL
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSource.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSource.java
@@ -19,7 +19,7 @@ import io.awspring.cloud.sqs.ConfigUtils;
 import io.awspring.cloud.sqs.listener.ContainerOptions;
 import io.awspring.cloud.sqs.listener.QueueAttributes;
 import io.awspring.cloud.sqs.listener.QueueAttributesAware;
-import io.awspring.cloud.sqs.listener.QueueAttributesResolver;
+import io.awspring.cloud.sqs.QueueAttributesResolver;
 import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
 import io.awspring.cloud.sqs.listener.SqsAsyncClientAware;
 import io.awspring.cloud.sqs.listener.SqsContainerOptions;

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSource.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSource.java
@@ -16,10 +16,10 @@
 package io.awspring.cloud.sqs.listener.source;
 
 import io.awspring.cloud.sqs.ConfigUtils;
+import io.awspring.cloud.sqs.QueueAttributesResolver;
 import io.awspring.cloud.sqs.listener.ContainerOptions;
 import io.awspring.cloud.sqs.listener.QueueAttributes;
 import io.awspring.cloud.sqs.listener.QueueAttributesAware;
-import io.awspring.cloud.sqs.QueueAttributesResolver;
 import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
 import io.awspring.cloud.sqs.listener.SqsAsyncClientAware;
 import io.awspring.cloud.sqs.listener.SqsContainerOptions;

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AbstractMessagingTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AbstractMessagingTemplate.java
@@ -442,11 +442,13 @@ public abstract class AbstractMessagingTemplate<S> implements MessagingOperation
 			return self();
 		}
 
-		@Override
-		public O defaultEndpointName(String defaultEndpointName) {
-			Assert.hasText(defaultEndpointName, "defaultEndpointName must have text");
+		/**
+		 * Subclasses should have a method with a more specific name and delegate to this.
+		 * @param defaultEndpointName the default endpoint name.
+		 */
+		protected void defaultEndpointName(String defaultEndpointName) {
+			Assert.notNull(defaultEndpointName, "defaultEndpointName must not be null");
 			this.defaultEndpointName = defaultEndpointName;
-			return self();
 		}
 
 		@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AbstractMessagingTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AbstractMessagingTemplate.java
@@ -1,17 +1,24 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.operations;
-
 
 import io.awspring.cloud.sqs.MessageHeaderUtils;
 import io.awspring.cloud.sqs.support.converter.ContextAwareMessagingMessageConverter;
 import io.awspring.cloud.sqs.support.converter.MessageConversionContext;
 import io.awspring.cloud.sqs.support.converter.MessagingMessageConverter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.lang.Nullable;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.util.Assert;
-
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
@@ -21,14 +28,19 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.Assert;
 
 /**
  * Base class for {@link MessagingOperations}
  * @param <T> the payload type
  * @param <S> the source message type for conversion
  */
-public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperations<T>,
-	AsyncMessagingOperations<T> {
+public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperations<T>, AsyncMessagingOperations<T> {
 
 	private static final Logger logger = LoggerFactory.getLogger(AbstractMessagingTemplate.class);
 
@@ -36,8 +48,7 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 
 	private static final Duration DEFAULT_POLL_TIMEOUT = Duration.ofSeconds(10);
 
-	private static final SendBatchFailureStrategy DEFAULT_SEND_BATCH_OPERATION_FAILURE_STRATEGY =
-		SendBatchFailureStrategy.THROW_EXCEPTION;
+	private static final SendBatchFailureStrategy DEFAULT_SEND_BATCH_OPERATION_FAILURE_STRATEGY = SendBatchFailureStrategy.THROW_EXCEPTION;
 
 	private static final int DEFAULT_MAX_NUMBER_OF_MESSAGES = 10;
 
@@ -60,7 +71,8 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 
 	private final MessagingMessageConverter<S> messageConverter;
 
-	protected AbstractMessagingTemplate(MessagingMessageConverter<S> messageConverter, AbstractMessagingTemplateOptions<T, ?> options) {
+	protected AbstractMessagingTemplate(MessagingMessageConverter<S> messageConverter,
+			AbstractMessagingTemplateOptions<T, ?> options) {
 		Assert.notNull(messageConverter, "messageConverter must not be null");
 		Assert.notNull(options, "options must not be null");
 		this.messageConverter = messageConverter;
@@ -79,7 +91,8 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 	}
 
 	@Override
-	public Optional<Message<T>> receive(@Nullable String endpoint, @Nullable Class<T> payloadClass, @Nullable Duration pollTimeout, @Nullable Map<String, Object> additionalHeaders) {
+	public Optional<Message<T>> receive(@Nullable String endpoint, @Nullable Class<T> payloadClass,
+			@Nullable Duration pollTimeout, @Nullable Map<String, Object> additionalHeaders) {
 		return unwrapCompletionException(receiveAsync(endpoint, payloadClass, pollTimeout, additionalHeaders));
 	}
 
@@ -90,9 +103,10 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 
 	@Override
 	public Collection<Message<T>> receiveMany(@Nullable String endpoint, @Nullable Class<T> payloadClass,
-											  @Nullable Duration pollTimeout, @Nullable Integer maxNumberOfMessages,
-											  @Nullable Map<String, Object> additionalHeaders) {
-		return unwrapCompletionException(receiveManyAsync(endpoint, payloadClass, pollTimeout, maxNumberOfMessages, additionalHeaders));
+			@Nullable Duration pollTimeout, @Nullable Integer maxNumberOfMessages,
+			@Nullable Map<String, Object> additionalHeaders) {
+		return unwrapCompletionException(
+				receiveManyAsync(endpoint, payloadClass, pollTimeout, maxNumberOfMessages, additionalHeaders));
 	}
 
 	@Override
@@ -101,10 +115,11 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 	}
 
 	@Override
-	public CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String endpoint, @Nullable Class<T> payloadClass,
-																@Nullable Duration pollTimeout, @Nullable Map<String, Object> additionalHeaders) {
+	public CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String endpoint,
+			@Nullable Class<T> payloadClass, @Nullable Duration pollTimeout,
+			@Nullable Map<String, Object> additionalHeaders) {
 		return receiveManyAsync(endpoint, payloadClass, pollTimeout, 1, additionalHeaders)
-			.thenApply(msgs -> msgs.isEmpty() ? Optional.empty() : Optional.of(msgs.iterator().next()));
+				.thenApply(msgs -> msgs.isEmpty() ? Optional.empty() : Optional.of(msgs.iterator().next()));
 	}
 
 	@Override
@@ -113,21 +128,20 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 	}
 
 	@Override
-	public CompletableFuture<Collection<Message<T>>> receiveManyAsync(@Nullable String endpoint, @Nullable Class<T> payloadClass, @Nullable Duration pollTimeout,
-																	  @Nullable Integer maxNumberOfMessages, @Nullable Map<String, Object> additionalHeaders) {
+	public CompletableFuture<Collection<Message<T>>> receiveManyAsync(@Nullable String endpoint,
+			@Nullable Class<T> payloadClass, @Nullable Duration pollTimeout, @Nullable Integer maxNumberOfMessages,
+			@Nullable Map<String, Object> additionalHeaders) {
 		String endpointToUse = getEndpointName(endpoint);
 		logger.trace("Receiving messages from endpoint {}", endpointToUse);
 		Map<String, Object> headers = getAdditionalHeadersToReceive(additionalHeaders);
-		return doReceiveAsync(endpointToUse,
-			getOrDefault(pollTimeout, this.defaultPollTimeout, "pollTimeout"),
-			getOrDefault(maxNumberOfMessages, this.defaultMaxNumberOfMessages, "defaultMaxNumberOfMessages"),
-			headers)
-			.thenApply(messages -> convertReceivedMessages(endpointToUse, payloadClass, messages, headers))
-			.thenCompose(messages -> handleAcknowledgement(endpointToUse, messages))
-			.exceptionallyCompose(t -> CompletableFuture
-				.failedFuture(new MessagingOperationFailedException("Message receive operation failed for endpoint %s"
-					.formatted(endpointToUse), endpointToUse, t instanceof CompletionException ? t.getCause() : t)))
-			.whenComplete((v, t) -> logReceiveMessageResult(endpointToUse, v, t));
+		return doReceiveAsync(endpointToUse, getOrDefault(pollTimeout, this.defaultPollTimeout, "pollTimeout"),
+				getOrDefault(maxNumberOfMessages, this.defaultMaxNumberOfMessages, "defaultMaxNumberOfMessages"),
+				headers).thenApply(messages -> convertReceivedMessages(endpointToUse, payloadClass, messages, headers))
+						.thenCompose(messages -> handleAcknowledgement(endpointToUse, messages))
+						.exceptionallyCompose(t -> CompletableFuture.failedFuture(new MessagingOperationFailedException(
+								"Message receive operation failed for endpoint %s".formatted(endpointToUse),
+								endpointToUse, t instanceof CompletionException ? t.getCause() : t)))
+						.whenComplete((v, t) -> logReceiveMessageResult(endpointToUse, v, t));
 	}
 
 	private Map<String, Object> getAdditionalHeadersToReceive(@Nullable Map<String, Object> additionalHeaders) {
@@ -139,29 +153,30 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 	}
 
 	private Collection<Message<T>> convertReceivedMessages(String endpoint, @Nullable Class<T> payloadClass,
-														   Collection<S> messages, Map<String, Object> additionalHeaders) {
-		return messages.stream().map(message -> convertReceivedMessage(getEndpointName(endpoint), message,
-				payloadClass != null ? payloadClass : this.defaultPayloadClass))
-			.map(message -> addAdditionalHeaders(message, additionalHeaders))
-			.collect(Collectors.toList());
+			Collection<S> messages, Map<String, Object> additionalHeaders) {
+		return messages.stream()
+				.map(message -> convertReceivedMessage(getEndpointName(endpoint), message,
+						payloadClass != null ? payloadClass : this.defaultPayloadClass))
+				.map(message -> addAdditionalHeaders(message, additionalHeaders)).collect(Collectors.toList());
 	}
 
 	protected Message<T> addAdditionalHeaders(Message<T> message, Map<String, Object> additionalHeaders) {
 		Map<String, Object> headersToAdd = handleAdditionalHeaders(additionalHeaders);
-		return headersToAdd.isEmpty()
-			? message
-			: MessageHeaderUtils.addHeadersToMessage(message, headersToAdd);
+		return headersToAdd.isEmpty() ? message : MessageHeaderUtils.addHeadersToMessage(message, headersToAdd);
 	}
 
 	protected abstract Map<String, Object> handleAdditionalHeaders(Map<String, Object> additionalHeaders);
 
-	private CompletableFuture<Collection<Message<T>>> handleAcknowledgement(@Nullable String endpoint, Collection<Message<T>> messages) {
-		return TemplateAcknowledgementMode.ACKNOWLEDGE_ON_RECEIVE.equals(this.acknowledgementMode) && !messages.isEmpty()
-			? doAcknowledgeMessages(getEndpointName(endpoint), messages).thenApply(theVoid -> messages)
-			: CompletableFuture.completedFuture(messages);
+	private CompletableFuture<Collection<Message<T>>> handleAcknowledgement(@Nullable String endpoint,
+			Collection<Message<T>> messages) {
+		return TemplateAcknowledgementMode.ACKNOWLEDGE_ON_RECEIVE.equals(this.acknowledgementMode)
+				&& !messages.isEmpty()
+						? doAcknowledgeMessages(getEndpointName(endpoint), messages).thenApply(theVoid -> messages)
+						: CompletableFuture.completedFuture(messages);
 	}
 
-	protected abstract CompletableFuture<Void> doAcknowledgeMessages(String endpointName, Collection<Message<T>> messages);
+	protected abstract CompletableFuture<Void> doAcknowledgeMessages(String endpointName,
+			Collection<Message<T>> messages);
 
 	private String getEndpointName(@Nullable String endpoint) {
 		String endpointName = getOrDefault(endpoint, this.defaultEndpointName, "endpointName");
@@ -170,14 +185,16 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 	}
 
 	private <V> V getOrDefault(@Nullable V value, V defaultValue, String valueName) {
-		return Objects.requireNonNull(value != null ? value : defaultValue, valueName + " not set and no default value provided");
+		return Objects.requireNonNull(value != null ? value : defaultValue,
+				valueName + " not set and no default value provided");
 	}
 
 	@SuppressWarnings("unchecked")
 	private Message<T> convertReceivedMessage(String endpoint, S message, @Nullable Class<T> payloadClass) {
 		return this.messageConverter instanceof ContextAwareMessagingMessageConverter<S> contextConverter
-			? (Message<T>) contextConverter.toMessagingMessage(message, getReceiveMessageConversionContext(endpoint, payloadClass))
-			: (Message<T>) this.messageConverter.toMessagingMessage(message);
+				? (Message<T>) contextConverter.toMessagingMessage(message,
+						getReceiveMessageConversionContext(endpoint, payloadClass))
+				: (Message<T>) this.messageConverter.toMessagingMessage(message);
 	}
 
 	private void logReceiveMessageResult(String endpoint, @Nullable Collection<Message<T>> v, @Nullable Throwable t) {
@@ -189,7 +206,8 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 		}
 	}
 
-	protected abstract CompletableFuture<Collection<S>> doReceiveAsync(String endpointName, Duration pollTimeout, Integer maxNumberOfMessages, Map<String, Object> additionalHEaders);
+	protected abstract CompletableFuture<Collection<S>> doReceiveAsync(String endpointName, Duration pollTimeout,
+			Integer maxNumberOfMessages, Map<String, Object> additionalHEaders);
 
 	@Override
 	public SendResult<T> send(T payload) {
@@ -219,7 +237,8 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 	@SuppressWarnings("unchecked")
 	@Override
 	public CompletableFuture<SendResult<T>> sendAsync(@Nullable String endpointName, T payload) {
-		return sendAsync(endpointName, payload instanceof Message ? (Message<T>) payload : MessageBuilder.withPayload(payload).build());
+		return sendAsync(endpointName,
+				payload instanceof Message ? (Message<T>) payload : MessageBuilder.withPayload(payload).build());
 	}
 
 	@Override
@@ -227,34 +246,39 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 		String endpointToUse = getEndpointName(endpointName);
 		logger.trace("Sending message {} to endpoint {}", MessageHeaderUtils.getId(message), endpointName);
 		return doSendAsync(endpointToUse, convertMessageToSend(message), message)
-			.exceptionallyCompose(t -> CompletableFuture.failedFuture(new MessagingOperationFailedException(
-				"Message send operation failed for message %s to endpoint %s"
-					.formatted(MessageHeaderUtils.getId(message), endpointToUse), endpointToUse, message, t)))
-			.whenComplete((v, t) -> logSendMessageResult(endpointToUse, message, t));
+				.exceptionallyCompose(
+						t -> CompletableFuture
+								.failedFuture(new MessagingOperationFailedException(
+										"Message send operation failed for message %s to endpoint %s"
+												.formatted(MessageHeaderUtils.getId(message), endpointToUse),
+										endpointToUse, message, t)))
+				.whenComplete((v, t) -> logSendMessageResult(endpointToUse, message, t));
 	}
 
 	@Override
 	public CompletableFuture<SendResult.Batch<T>> sendManyAsync(@Nullable String endpointName,
-																Collection<Message<T>> messages) {
+			Collection<Message<T>> messages) {
 		logger.trace("Sending messages {} to endpoint {}", MessageHeaderUtils.getId(messages), endpointName);
 		String endpointToUse = getEndpointName(endpointName);
 		return doSendBatchAsync(endpointToUse, convertMessagesToSend(messages), messages)
-			.exceptionallyCompose(t -> wrapSendException(messages, endpointToUse, t))
-			.thenCompose(result -> handleFailedMessages(endpointToUse, result))
-			.whenComplete((v, t) -> logSendMessageBatchResult(endpointToUse, messages, t));
+				.exceptionallyCompose(t -> wrapSendException(messages, endpointToUse, t))
+				.thenCompose(result -> handleFailedMessages(endpointToUse, result))
+				.whenComplete((v, t) -> logSendMessageBatchResult(endpointToUse, messages, t));
 	}
 
-	private CompletableFuture<SendResult.Batch<T>> handleFailedMessages(String endpointToUse, SendResult.Batch<T> result) {
+	private CompletableFuture<SendResult.Batch<T>> handleFailedMessages(String endpointToUse,
+			SendResult.Batch<T> result) {
 		return !result.failed().isEmpty()
-			&& SendBatchFailureStrategy.THROW_EXCEPTION.equals(this.sendBatchFailureStrategy)
-				? handleFailedSendBatch(endpointToUse, result)
-				: CompletableFuture.completedFuture(result);
+				&& SendBatchFailureStrategy.THROW_EXCEPTION.equals(this.sendBatchFailureStrategy)
+						? handleFailedSendBatch(endpointToUse, result)
+						: CompletableFuture.completedFuture(result);
 	}
 
-	private CompletableFuture<SendResult.Batch<T>> wrapSendException(Collection<Message<T>> messages, String endpointToUse, Throwable t) {
-		return CompletableFuture.failedFuture(new MessagingOperationFailedException(
-			"Message send operation failed for messages %s to endpoint %s"
-				.formatted(MessageHeaderUtils.getId(messages), endpointToUse), endpointToUse, messages, t));
+	private CompletableFuture<SendResult.Batch<T>> wrapSendException(Collection<Message<T>> messages,
+			String endpointToUse, Throwable t) {
+		return CompletableFuture.failedFuture(
+				new MessagingOperationFailedException("Message send operation failed for messages %s to endpoint %s"
+						.formatted(MessageHeaderUtils.getId(messages), endpointToUse), endpointToUse, messages, t));
 	}
 
 	private CompletableFuture<SendResult.Batch<T>> handleFailedSendBatch(String endpoint, SendResult.Batch<T> result) {
@@ -267,17 +291,19 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 
 	private S convertMessageToSend(Message<T> message) {
 		return this.messageConverter instanceof ContextAwareMessagingMessageConverter<S> contextConverter
-			? contextConverter.fromMessagingMessage(message, getSendMessageConversionContext(message))
-			: messageConverter.fromMessagingMessage(message);
+				? contextConverter.fromMessagingMessage(message, getSendMessageConversionContext(message))
+				: messageConverter.fromMessagingMessage(message);
 	}
 
-	protected abstract CompletableFuture<SendResult<T>> doSendAsync(String endpointName, S message, Message<T> originalMessage);
+	protected abstract CompletableFuture<SendResult<T>> doSendAsync(String endpointName, S message,
+			Message<T> originalMessage);
 
-	protected abstract CompletableFuture<SendResult.Batch<T>> doSendBatchAsync(String endpointName, Collection<S> messages,
-																			   Collection<Message<T>> originalMessages);
+	protected abstract CompletableFuture<SendResult.Batch<T>> doSendBatchAsync(String endpointName,
+			Collection<S> messages, Collection<Message<T>> originalMessages);
 
 	@Nullable
-	protected MessageConversionContext getReceiveMessageConversionContext(String endpointName, @Nullable Class<T> payloadClass) {
+	protected MessageConversionContext getReceiveMessageConversionContext(String endpointName,
+			@Nullable Class<T> payloadClass) {
 		// Subclasses can override this method to return a context
 		return null;
 	}
@@ -291,11 +317,11 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 	private void logSendMessageResult(String endpointToUse, Message<T> message, @Nullable Throwable t) {
 		if (t == null) {
 			logger.trace("Message {} successfully sent to endpoint {} with id {}", message,
-				MessageHeaderUtils.getId(message), endpointToUse);
+					MessageHeaderUtils.getId(message), endpointToUse);
 		}
 		else {
 			logger.error("Error sending message {} to endpoint {}", MessageHeaderUtils.getId(message), endpointToUse,
-				unwrapCompletionException(t));
+					unwrapCompletionException(t));
 		}
 	}
 
@@ -303,29 +329,29 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 		return t instanceof CompletionException && t.getCause() != null ? t.getCause() : t;
 	}
 
-	private void logSendMessageBatchResult(String endpointToUse, Collection<Message<T>> messages, @Nullable Throwable t) {
+	private void logSendMessageBatchResult(String endpointToUse, Collection<Message<T>> messages,
+			@Nullable Throwable t) {
 		if (t == null) {
 			logger.trace("Messages {} successfully sent to endpoint {} with id {}", messages,
-				MessageHeaderUtils.getId(messages), endpointToUse);
+					MessageHeaderUtils.getId(messages), endpointToUse);
 		}
 		else {
 			logger.error("Error sending messages {} to endpoint {}", MessageHeaderUtils.getId(messages), endpointToUse,
-				unwrapCompletionException(t));
+					unwrapCompletionException(t));
 		}
 	}
 
-	protected  <V> V unwrapCompletionException(CompletableFuture<V> future) {
+	protected <V> V unwrapCompletionException(CompletableFuture<V> future) {
 		try {
 			return future.join();
 		}
 		catch (CompletionException ex) {
-			if (ex.getCause() instanceof RuntimeException re) {
+			if (ex.getCause()instanceof RuntimeException re) {
 				throw re;
 			}
 			throw new RuntimeException("Unexpected exception", ex);
 		}
 	}
-
 
 	/**
 	 * Options to be used by the template.
@@ -335,41 +361,38 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 	protected interface MessagingTemplateOptions<T, O extends MessagingTemplateOptions<T, O>> {
 
 		/**
-		 * Set the acknowledgement mode for this template.
-		 * Default is {@link TemplateAcknowledgementMode#ACKNOWLEDGE_ON_RECEIVE}
+		 * Set the acknowledgement mode for this template. Default is
+		 * {@link TemplateAcknowledgementMode#ACKNOWLEDGE_ON_RECEIVE}
 		 * @param acknowledgementMode the mode.
 		 * @return the options instance.
 		 */
 		O acknowledgementMode(TemplateAcknowledgementMode acknowledgementMode);
 
 		/**
-		 * Set the strategy to use when handling batch send operations with at least one failed message.
-		 * Default is {@link SendBatchFailureStrategy#THROW_EXCEPTION}
+		 * Set the strategy to use when handling batch send operations with at least one failed message. Default is
+		 * {@link SendBatchFailureStrategy#THROW_EXCEPTION}
 		 * @param sendBatchFailureStrategy the strategy.
 		 * @return the options instance.
 		 */
 		O sendBatchFailureStrategy(SendBatchFailureStrategy sendBatchFailureStrategy);
 
 		/**
-		 * Set the default maximum amount of time this template will wait for the maximum
-		 * number of messages before returning.
-		 * Default is 10 seconds.
+		 * Set the default maximum amount of time this template will wait for the maximum number of messages before
+		 * returning. Default is 10 seconds.
 		 * @param defaultPollTimeout the timeout.
 		 * @return the options instance.
 		 */
 		O defaultPollTimeout(Duration defaultPollTimeout);
 
 		/**
-		 * Set the default maximum number of messages to be retrieved in a single batch.
-		 * Default is 10.
+		 * Set the default maximum number of messages to be retrieved in a single batch. Default is 10.
 		 * @param defaultMaxNumberOfMessages the maximum number of messages.
 		 * @return the options instance.
 		 */
 		O defaultMaxNumberOfMessages(Integer defaultMaxNumberOfMessages);
 
 		/**
-		 * Set the default endpoint name for this template.
-		 * Default is blank.
+		 * Set the default endpoint name for this template. Default is blank.
 		 * @param defaultEndpointName the default endpoint name.
 		 * @return the options instance.
 		 */
@@ -404,7 +427,8 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 	 * @param <T> the payload type
 	 * @param <O> the options type for returning in the chained methods.
 	 */
-	protected static abstract class AbstractMessagingTemplateOptions<T, O extends MessagingTemplateOptions<T, O>> implements MessagingTemplateOptions<T, O> {
+	protected static abstract class AbstractMessagingTemplateOptions<T, O extends MessagingTemplateOptions<T, O>>
+			implements MessagingTemplateOptions<T, O> {
 
 		private Duration defaultPollTimeout = DEFAULT_POLL_TIMEOUT;
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AbstractMessagingTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AbstractMessagingTemplate.java
@@ -1,0 +1,334 @@
+package io.awspring.cloud.sqs.operations;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.support.converter.AbstractMessagingMessageConverter;
+import io.awspring.cloud.sqs.support.converter.ContextAwareMessagingMessageConverter;
+import io.awspring.cloud.sqs.support.converter.MessageConversionContext;
+import io.awspring.cloud.sqs.support.converter.MessagingMessageConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.util.Assert;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public abstract class AbstractMessagingTemplate<T, S, R> implements MessagingOperations<T, R>,
+	AsyncMessagingOperations<T, R> {
+
+	private static final Logger logger = LoggerFactory.getLogger(AbstractMessagingTemplate.class);
+
+	private static final TemplateAcknowledgementMode DEFAULT_ACKNOWLEDGEMENT_MODE = TemplateAcknowledgementMode.ACKNOWLEDGE_ON_RECEIVE;
+
+	private static final Duration DEFAULT_POLL_TIMEOUT = Duration.ofSeconds(10);
+
+	private static final int DEFAULT_MAX_NUMBER_OF_MESSAGES = 10;
+
+	private static final String DEFAULT_ENDPOINT_NAME = "";
+
+	private final Map<String, Object> defaultAdditionalHeaders;
+
+	private final Duration defaultPollTimeout;
+
+	private final int defaultMaxNumberOfMessages;
+
+	private final String defaultEndpointName;
+
+	private final TemplateAcknowledgementMode acknowledgementMode;
+
+	@Nullable
+	private final Class<T> defaultPayloadClass;
+
+	private final MessagingMessageConverter<S> messageConverter;
+
+	protected AbstractMessagingTemplate(MessagingMessageConverter<S> messageConverter, AbstractMessagingTemplateOptions<T, ?> options) {
+		Assert.notNull(messageConverter, "messageConverter must not be null");
+		Assert.notNull(options, "options must not be null");
+		this.messageConverter = messageConverter;
+		this.defaultAdditionalHeaders = options.defaultAdditionalHeaders;
+		this.defaultMaxNumberOfMessages = options.defaultMaxNumberOfMessages;
+		this.defaultPollTimeout = options.defaultPollTimeout;
+		this.defaultPayloadClass = options.defaultPayloadClass;
+		this.defaultEndpointName = options.defaultEndpointName;
+		this.acknowledgementMode = options.acknowledgementMode;
+	}
+
+	public void setObjectMapper(ObjectMapper objectMapper) {
+		Assert.notNull(objectMapper, "objectMapper must not be null");
+		Assert.isInstanceOf(AbstractMessagingMessageConverter.class, this.messageConverter,
+			"objectMappers can only be set on AbstractMessagingMessageConverter instances.");
+		((AbstractMessagingMessageConverter<?>) this.messageConverter).setObjectMapper(objectMapper);
+	}
+
+	@Override
+	public Optional<Message<T>> receive() {
+		return receiveAsync().join();
+	}
+
+	@Override
+	public Optional<Message<T>> receive(@Nullable String endpoint, @Nullable Class<T> payloadClass, @Nullable Duration pollTimeout, @Nullable Map<String, Object> additionalHeaders) {
+		return receiveAsync(endpoint, payloadClass, pollTimeout, additionalHeaders).join();
+	}
+
+	@Override
+	public Collection<Message<T>> receiveMany() {
+		return receiveManyAsync().join();
+	}
+
+	@Override
+	public Collection<Message<T>> receiveMany(@Nullable String endpoint, @Nullable Class<T> payloadClass,
+											  @Nullable Duration pollTimeout, @Nullable Integer maxNumberOfMessages,
+											  @Nullable Map<String, Object> additionalHeaders) {
+		return receiveManyAsync(endpoint, payloadClass, pollTimeout, maxNumberOfMessages, additionalHeaders).join();
+	}
+
+	@Override
+	public CompletableFuture<Optional<Message<T>>> receiveAsync() {
+		return receiveAsync(null, null, null, null);
+	}
+
+	@Override
+	public CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String endpoint, @Nullable Class<T> payloadClass,
+																@Nullable Duration pollTimeout, @Nullable Map<String, Object> additionalHeaders) {
+		return receiveManyAsync(endpoint, payloadClass, pollTimeout, 1, additionalHeaders)
+			.thenApply(msgs -> msgs.isEmpty() ? Optional.empty() : Optional.of(msgs.iterator().next()));
+	}
+
+	@Override
+	public CompletableFuture<Collection<Message<T>>> receiveManyAsync() {
+		return receiveManyAsync(this.defaultEndpointName, this.defaultPayloadClass, this.defaultPollTimeout,
+			this.defaultMaxNumberOfMessages, this.defaultAdditionalHeaders);
+	}
+
+	@Override
+	public CompletableFuture<Collection<Message<T>>> receiveManyAsync(@Nullable String endpoint, @Nullable Class<T> payloadClass, @Nullable Duration pollTimeout,
+																	  @Nullable Integer maxNumberOfMessages, @Nullable Map<String, Object> additionalHeaders) {
+		Map<String, Object> headers = getAdditionalHeadersToReceive(additionalHeaders);
+		return doReceiveAsync(getEndpointName(endpoint),
+			getOrDefault(pollTimeout, this.defaultPollTimeout, "pollTimeout"),
+			getOrDefault(maxNumberOfMessages, this.defaultMaxNumberOfMessages, "defaultMaxNumberOfMessages"),
+			headers)
+			.thenApply(messages -> convertReceivedMessages(getEndpointName(endpoint), payloadClass, messages, headers))
+			.thenCompose(messages -> handleAcknowledgement(getEndpointName(endpoint), messages));
+	}
+
+	private Map<String, Object> getAdditionalHeadersToReceive(@Nullable Map<String, Object> additionalHeaders) {
+		Map<String, Object> headers = new HashMap<>(this.defaultAdditionalHeaders);
+		if (additionalHeaders != null) {
+			headers.putAll(additionalHeaders);
+		}
+		return headers;
+	}
+
+	private Collection<Message<T>> convertReceivedMessages(String endpoint, @Nullable Class<T> payloadClass,
+														   Collection<S> messages, Map<String, Object> additionalHeaders) {
+		return messages.stream().map(message -> convertReceivedMessage(getEndpointName(endpoint), message,
+				payloadClass != null ? payloadClass : this.defaultPayloadClass))
+			.map(message -> addAdditionalHeaders(message, additionalHeaders))
+			.collect(Collectors.toList());
+	}
+
+	protected Message<T> addAdditionalHeaders(Message<T> message, Map<String, Object> additionalHeaders) {
+		Map<String, Object> headersToAdd = handleAdditionalHeaders(additionalHeaders);
+		return headersToAdd.isEmpty()
+			? message
+			: MessageBuilder.createMessage(message.getPayload(), doAddAdditionalHeaders(message.getHeaders(), headersToAdd));
+	}
+
+	private MessageHeaders doAddAdditionalHeaders(Map<String, Object> headers, Map<String, Object> headersToAdd) {
+		MessageHeaderAccessor accessor = new MessageHeaderAccessor();
+		accessor.copyHeaders(headers);
+		accessor.copyHeaders(headersToAdd);
+		return accessor.toMessageHeaders();
+	}
+
+	protected abstract Map<String, Object> handleAdditionalHeaders(Map<String, Object> additionalHeaders);
+
+	private CompletableFuture<Collection<Message<T>>> handleAcknowledgement(@Nullable String endpoint, Collection<Message<T>> messages) {
+		return TemplateAcknowledgementMode.ACKNOWLEDGE_ON_RECEIVE.equals(this.acknowledgementMode) && !messages.isEmpty()
+			? acknowledgeMessages(getEndpointName(endpoint), messages).thenApply(theVoid -> messages)
+			: CompletableFuture.completedFuture(messages);
+	}
+
+	protected abstract CompletableFuture<Void> acknowledgeMessages(String endpointName, Collection<Message<T>> messages);
+
+	private String getEndpointName(@Nullable String endpoint) {
+		return getOrDefault(endpoint, this.defaultEndpointName, "endpointName");
+	}
+
+	private <V> V getOrDefault(@Nullable V value, V defaultValue, String valueName) {
+		return Objects.requireNonNull(value != null ? value : defaultValue, valueName + " not set and no default value provided");
+	}
+
+	@SuppressWarnings("unchecked")
+	private Message<T> convertReceivedMessage(String endpoint, S message, @Nullable Class<T> payloadClass) {
+		return this.messageConverter instanceof ContextAwareMessagingMessageConverter<S> contextConverter
+			? (Message<T>) contextConverter.toMessagingMessage(message, getMessageConversionContext(endpoint, payloadClass))
+			: (Message<T>) this.messageConverter.toMessagingMessage(message);
+	}
+
+	protected abstract CompletableFuture<Collection<S>> doReceiveAsync(String endpointName, Duration pollTimeout, Integer maxNumberOfMessages, Map<String, Object> additionalHEaders);
+
+	@Override
+	public UUID send(T payload) {
+		return sendAsync(payload).join();
+	}
+
+	@Override
+	public UUID send(@Nullable String endpointName, T payload) {
+		return sendAsync(endpointName, payload).join();
+	}
+
+	@Override
+	public UUID send(@Nullable String endpointName, Message<T> message) {
+		return sendAsync(endpointName, message).join();
+	}
+
+	@Override
+	public R send(@Nullable String endpointName, Collection<Message<T>> messages) {
+		return sendAsync(endpointName, messages).join();
+	}
+
+	@Override
+	public CompletableFuture<UUID> sendAsync(T payload) {
+		return sendAsync(null, payload);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public CompletableFuture<UUID> sendAsync(@Nullable String endpointName, T payload) {
+		return sendAsync(endpointName, payload instanceof Message ? (Message<T>) payload : MessageBuilder.withPayload(payload).build());
+	}
+
+	@Override
+	public CompletableFuture<UUID> sendAsync(@Nullable String endpointName, Message<T> message) {
+		return doSendAsync(getOrDefault(endpointName, this.defaultEndpointName, "endpointName"),
+			convertMessageToSend(message));
+	}
+
+	@Override
+	public CompletableFuture<R> sendAsync(@Nullable String endpointName, Collection<Message<T>> messages) {
+		return doSendBatchAsync(getOrDefault(endpointName, this.defaultEndpointName, "endpointName"),
+			convertMessagesToSend(messages));
+	}
+
+	private Collection<S> convertMessagesToSend(Collection<Message<T>> messages) {
+		return messages.stream().map(this::convertMessageToSend).collect(Collectors.toList());
+	}
+
+	private S convertMessageToSend(Message<T> message) {
+		return this.messageConverter.fromMessagingMessage(message);
+	}
+
+	protected abstract CompletableFuture<UUID> doSendAsync(String endpointName, S message);
+
+	protected abstract CompletableFuture<R> doSendBatchAsync(String endpointName, Collection<S> messages);
+
+	@Nullable
+	protected MessageConversionContext getMessageConversionContext(String endpointName, @Nullable Class<T> payloadClass) {
+		// Subclasses can override this to return a context
+		return null;
+	}
+
+	protected interface MessagingTemplateOptions<T, O extends MessagingTemplateOptions<T, O>> {
+
+		O acknowledgementMode(TemplateAcknowledgementMode defaultAcknowledgementMode);
+
+		O pollTimeout(Duration defaultPollTimeout);
+
+		O maxNumberOfMessages(Integer defaultMaxNumberOfMessages);
+
+		O endpointName(String defaultEndpointName);
+
+		O payloadClass(Class<T> defaultPayloadClass);
+
+		O additionalHeader(String name, Object value);
+
+		O additionalHeaders(Map<String, Object> defaultAdditionalHeaders);
+
+	}
+
+	protected static abstract class AbstractMessagingTemplateOptions<T, O extends MessagingTemplateOptions<T, O>> implements MessagingTemplateOptions<T, O> {
+
+		private Duration defaultPollTimeout = DEFAULT_POLL_TIMEOUT;
+
+		private int defaultMaxNumberOfMessages = DEFAULT_MAX_NUMBER_OF_MESSAGES;
+
+		private String defaultEndpointName = DEFAULT_ENDPOINT_NAME;
+
+		private TemplateAcknowledgementMode acknowledgementMode = DEFAULT_ACKNOWLEDGEMENT_MODE;
+
+		private final Map<String, Object> defaultAdditionalHeaders = new HashMap<>();
+
+		@Nullable
+		private Class<T> defaultPayloadClass;
+
+		@Override
+		public O acknowledgementMode(TemplateAcknowledgementMode defaultAcknowledgementMode) {
+			Assert.notNull(defaultAcknowledgementMode, "defaultAcknowledgementMode must not be null");
+			this.acknowledgementMode = defaultAcknowledgementMode;
+			return self();
+		}
+
+		@Override
+		public O pollTimeout(Duration defaultPollTimeout) {
+			Assert.notNull(defaultPollTimeout, "pollTimeout must not be null");
+			this.defaultPollTimeout = defaultPollTimeout;
+			return self();
+		}
+
+		@Override
+		public O maxNumberOfMessages(Integer defaultMaxNumberOfMessages) {
+			Assert.isTrue(defaultMaxNumberOfMessages > 0, "defaultMaxNumberOfMessages must be greater than zero");
+			this.defaultMaxNumberOfMessages = defaultMaxNumberOfMessages;
+			return self();
+		}
+
+		@Override
+		public O endpointName(String defaultEndpointName) {
+			Assert.hasText(defaultEndpointName, "defaultEndpointName must have text");
+			this.defaultEndpointName = defaultEndpointName;
+			return self();
+		}
+
+		@Override
+		public O payloadClass(Class<T> defaultPayloadClass) {
+			Assert.notNull(defaultPayloadClass, "defaultPayloadClass must not be null");
+			this.defaultPayloadClass = defaultPayloadClass;
+			return self();
+		}
+
+		@Override
+		public O additionalHeader(String name, Object value) {
+			Assert.notNull(name, "name must not be null");
+			Assert.notNull(value, "value must not be null");
+			this.defaultAdditionalHeaders.put(name, value);
+			return self();
+		}
+
+		@Override
+		public O additionalHeaders(Map<String, Object> defaultAdditionalHeaders) {
+			Assert.notNull(defaultAdditionalHeaders, "defaultAdditionalHeaders must not be null");
+			this.defaultAdditionalHeaders.putAll(defaultAdditionalHeaders);
+			return self();
+		}
+
+		@SuppressWarnings("unchecked")
+		public O self() {
+			return (O) this;
+		}
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AbstractMessagingTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AbstractMessagingTemplate.java
@@ -129,8 +129,8 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 
 	@Override
 	public CompletableFuture<Collection<Message<T>>> receiveManyAsync(@Nullable String endpoint,
-			@Nullable Class<? extends T> payloadClass, @Nullable Duration pollTimeout, @Nullable Integer maxNumberOfMessages,
-			@Nullable Map<String, Object> additionalHeaders) {
+			@Nullable Class<? extends T> payloadClass, @Nullable Duration pollTimeout,
+			@Nullable Integer maxNumberOfMessages, @Nullable Map<String, Object> additionalHeaders) {
 		String endpointToUse = getEndpointName(endpoint);
 		logger.trace("Receiving messages from endpoint {}", endpointToUse);
 		Map<String, Object> headers = getAdditionalHeadersToReceive(additionalHeaders);
@@ -350,74 +350,6 @@ public abstract class AbstractMessagingTemplate<T, S> implements MessagingOperat
 			}
 			throw new RuntimeException("Unexpected exception", ex);
 		}
-	}
-
-	/**
-	 * Options to be used by the template.
-	 * @param <T> the payload type.
-	 * @param <O> the options subclass to be returned by the chained methods.
-	 */
-	protected interface MessagingTemplateOptions<T, O extends MessagingTemplateOptions<T, O>> {
-
-		/**
-		 * Set the acknowledgement mode for this template. Default is {@link TemplateAcknowledgementMode#ACKNOWLEDGE}
-		 * @param acknowledgementMode the mode.
-		 * @return the options instance.
-		 */
-		O acknowledgementMode(TemplateAcknowledgementMode acknowledgementMode);
-
-		/**
-		 * Set the strategy to use when handling batch send operations with at least one failed message. Default is
-		 * {@link SendBatchFailureHandlingStrategy#THROW}
-		 * @param sendBatchFailureHandlingStrategy the strategy.
-		 * @return the options instance.
-		 */
-		O sendBatchFailureHandlingStrategy(SendBatchFailureHandlingStrategy sendBatchFailureHandlingStrategy);
-
-		/**
-		 * Set the default maximum amount of time this template will wait for the maximum number of messages before
-		 * returning. Default is 10 seconds.
-		 * @param defaultPollTimeout the timeout.
-		 * @return the options instance.
-		 */
-		O defaultPollTimeout(Duration defaultPollTimeout);
-
-		/**
-		 * Set the default maximum number of messages to be retrieved in a single batch. Default is 10.
-		 * @param defaultMaxNumberOfMessages the maximum number of messages.
-		 * @return the options instance.
-		 */
-		O defaultMaxNumberOfMessages(Integer defaultMaxNumberOfMessages);
-
-		/**
-		 * Set the default endpoint name for this template. Default is blank.
-		 * @param defaultEndpointName the default endpoint name.
-		 * @return the options instance.
-		 */
-		O defaultEndpointName(String defaultEndpointName);
-
-		/**
-		 * The default class to which this template should convert payloads to.
-		 * @param defaultPayloadClass the default payload class.
-		 * @return the options instance.
-		 */
-		O defaultPayloadClass(Class<T> defaultPayloadClass);
-
-		/**
-		 * Set a default header to be added to received messages.
-		 * @param name the header name.
-		 * @param value the header value.
-		 * @return the options instance.
-		 */
-		O additionalHeaderForReceive(String name, Object value);
-
-		/**
-		 * Set default headers to be added to received messages.
-		 * @param defaultAdditionalHeaders the headers.
-		 * @return the options instance.
-		 */
-		O additionalHeadersForReceive(Map<String, Object> defaultAdditionalHeaders);
-
 	}
 
 	/**

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
@@ -1,7 +1,19 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.operations;
-
-import org.springframework.lang.Nullable;
-import org.springframework.messaging.Message;
 
 import java.time.Duration;
 import java.util.Collection;
@@ -9,10 +21,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
 
 /**
- * Asynchronous messaging operations. Implementations should have defaults for {@link Nullable} fields,
- * and can provide chained methods interfaces for a more fluent API.
+ * Asynchronous messaging operations. Implementations should have defaults for {@link Nullable} fields, and can provide
+ * chained methods interfaces for a more fluent API.
  *
  * @author Tomaz Fernandes
  * @since 3.0
@@ -20,8 +34,8 @@ import java.util.concurrent.CompletableFuture;
 public interface AsyncMessagingOperations<T> {
 
 	/**
-	 * Send a {@link Message} to the default endpoint with the provided payload.
-	 * The payload will be serialized if necessary.
+	 * Send a {@link Message} to the default endpoint with the provided payload. The payload will be serialized if
+	 * necessary.
 	 *
 	 * @param payload the payload to send.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
@@ -29,8 +43,7 @@ public interface AsyncMessagingOperations<T> {
 	CompletableFuture<SendResult<T>> sendAsync(T payload);
 
 	/**
-	 * Send a message to the provided endpoint with the provided payload.
-	 * The payload will be serialized if necessary.
+	 * Send a message to the provided endpoint with the provided payload. The payload will be serialized if necessary.
 	 *
 	 * @param endpointName the endpoint to send the message to.
 	 * @param payload the payload to send.
@@ -39,9 +52,8 @@ public interface AsyncMessagingOperations<T> {
 	CompletableFuture<SendResult<T>> sendAsync(@Nullable String endpointName, T payload);
 
 	/**
-	 * Send the provided message along with its headers to the provided endpoint.
-	 * The payload will be serialized if necessary, and headers will be converted
-	 * to the specific messaging system metadata types.
+	 * Send the provided message along with its headers to the provided endpoint. The payload will be serialized if
+	 * necessary, and headers will be converted to the specific messaging system metadata types.
 	 *
 	 * @param endpointName the endpoint to send the message to.
 	 * @param message the message to be sent.
@@ -50,76 +62,70 @@ public interface AsyncMessagingOperations<T> {
 	CompletableFuture<SendResult<T>> sendAsync(@Nullable String endpointName, Message<T> message);
 
 	/**
-	 * Send the provided messages along with their headers to the provided endpoint.
-	 * The payloads will be serialized if necessary, and headers will be converted
-	 * to the specific messaging system metadata types.
+	 * Send the provided messages along with their headers to the provided endpoint. The payloads will be serialized if
+	 * necessary, and headers will be converted to the specific messaging system metadata types.
 	 *
 	 * @param endpointName the endpoint to send the messages to.
 	 * @param messages the messages to be sent.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
 	 */
-	CompletableFuture<SendResult.Batch<T>> sendManyAsync(@Nullable String endpointName, Collection<Message<T>> messages);
+	CompletableFuture<SendResult.Batch<T>> sendManyAsync(@Nullable String endpointName,
+			Collection<Message<T>> messages);
 
 	/**
 	 * Receive a message from the default endpoint with default settings.
-	 * @return a {@link CompletableFuture} to be completed with the message,
-	 * or {@link Optional#empty()} if none is returned.
+	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
+	 * returned.
 	 */
 	CompletableFuture<Optional<Message<T>>> receiveAsync();
 
 	/**
-	 * Receive a message from the provided endpoint and convert the payload to the
-	 * provided class. If no message is returned after the specified {@link Duration},
-	 * an {@link Optional#empty()} is returned.
+	 * Receive a message from the provided endpoint and convert the payload to the provided class. If no message is
+	 * returned after the specified {@link Duration}, an {@link Optional#empty()} is returned.
 	 * <p>
-	 * Any headers provided in the additional headers parameter will be added to the
-	 * {@link Message} instances returned by this method.
-	 * The implementation can also allow some specific headers to change particular settings,
-	 * in which case the headers are removed before sending.
-	 * See the implementation javadocs for more information.
+	 * Any headers provided in the additional headers parameter will be added to the {@link Message} instances returned
+	 * by this method. The implementation can also allow some specific headers to change particular settings, in which
+	 * case the headers are removed before sending. See the implementation javadocs for more information.
 	 *
 	 * @param endpointName the endpoint from which to receive the messages.
 	 * @param payloadClass the class to which the payload should be converted to.
 	 * @param pollTimeout the maximum amount of time to wait for messages.
 	 * @param additionalHeaders headers to be added to the received messages.
-	 * @return a {@link CompletableFuture} to be completed with the message,
-	 * or {@link Optional#empty()} if none is returned.
+	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
+	 * returned.
 	 */
-	CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String endpointName,
-														 @Nullable Class<T> payloadClass,
-														 @Nullable Duration pollTimeout,
-														 @Nullable Map<String, Object> additionalHeaders);
+	CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String endpointName, @Nullable Class<T> payloadClass,
+			@Nullable Duration pollTimeout, @Nullable Map<String, Object> additionalHeaders);
 
 	/**
 	 * Receive a batch of messages from the default endpoint with default settings.
-	 * @return a {@link CompletableFuture} to be completed with the messages,
-	 * or an empty collection if none is returned.
+	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
+	 * returned.
 	 */
 	CompletableFuture<Collection<Message<T>>> receiveManyAsync();
 
 	/**
-	 * Receive a batch of messages from the provided endpoint and convert the payloads to the
-	 * provided class. If no message is returned after the specified {@link Duration},
-	 * an empty collection is returned.
+	 * Receive a batch of messages from the provided endpoint and convert the payloads to the provided class. If no
+	 * message is returned after the specified {@link Duration}, an empty collection is returned.
 	 * <p>
-	 * Any headers provided in the additional headers parameter will be added to the
-	 * {@link Message} instances returned by this method.
-	 * The implementation can also allow some specific headers to change particular settings,
-	 * in which case the headers are removed before sending.
-	 * See the implementation javadocs for more information.
+	 * Any headers provided in the additional headers parameter will be added to the {@link Message} instances returned
+	 * by this method. The implementation can also allow some specific headers to change particular settings, in which
+	 * case the headers are removed before sending. See the implementation javadocs for more information.
 	 *
 	 * @param endpointName the endpoint from which to receive the messages.
 	 * @param payloadClass the class to which the payloads should be converted to.
 	 * @param pollTimeout the maximum amount of time to wait for messages.
 	 * @param maxNumberOfMessages the maximum number of messages to receive.
 	 * @param additionalHeaders headers to be added to the received messages.
-	 * @return a {@link CompletableFuture} to be completed with the messages,
-	 * or an empty collection if none is returned.
+	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
+	 * returned.
 	 */
+	// @formatter:off
 	CompletableFuture<Collection<Message<T>>> receiveManyAsync(@Nullable String endpointName,
 															   @Nullable Class<T> payloadClass,
 															   @Nullable Duration pollTimeout,
 															   @Nullable Integer maxNumberOfMessages,
 															   @Nullable Map<String, Object> additionalHeaders);
+	// @formatter:on
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
@@ -94,7 +94,7 @@ public interface AsyncMessagingOperations<T> {
 	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
 	 * returned.
 	 */
-	CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String endpointName, @Nullable Class<T> payloadClass,
+	CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String endpointName, @Nullable Class<? extends T> payloadClass,
 			@Nullable Duration pollTimeout, @Nullable Map<String, Object> additionalHeaders);
 
 	/**
@@ -122,7 +122,7 @@ public interface AsyncMessagingOperations<T> {
 	 */
 	// @formatter:off
 	CompletableFuture<Collection<Message<T>>> receiveManyAsync(@Nullable String endpointName,
-															   @Nullable Class<T> payloadClass,
+															   @Nullable Class<? extends T> payloadClass,
 															   @Nullable Duration pollTimeout,
 															   @Nullable Integer maxNumberOfMessages,
 															   @Nullable Map<String, Object> additionalHeaders);

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
@@ -11,29 +11,112 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 /**
+ * Asynchronous messaging operations. Implementations should have defaults for {@link Nullable} fields,
+ * and can provide chained methods interfaces for a more fluent API.
+ *
  * @author Tomaz Fernandes
  * @since 3.0
  */
 public interface AsyncMessagingOperations<T, R> {
 
+	/**
+	 * Send a {@link Message} to the default endpoint with the provided payload.
+	 * The payload will be serialized if necessary.
+	 *
+	 * @param payload the payload to send.
+	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
+	 */
 	CompletableFuture<UUID> sendAsync(T payload);
 
+	/**
+	 * Send a message to the provided endpoint with the provided payload.
+	 * The payload will be serialized if necessary.
+	 *
+	 * @param endpointName the endpoint to send the message to.
+	 * @param payload the payload to send.
+	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
+	 */
 	CompletableFuture<UUID> sendAsync(@Nullable String endpointName, T payload);
 
+	/**
+	 * Send the provided message along with its headers to the provided endpoint.
+	 * The payload will be serialized if necessary, and headers will be converted
+	 * to the specific messaging system metadata types.
+	 *
+	 * @param endpointName the endpoint to send the message to.
+	 * @param message the message to be sent.
+	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
+	 */
 	CompletableFuture<UUID> sendAsync(@Nullable String endpointName, Message<T> message);
 
-	CompletableFuture<R> sendAsync(@Nullable String endpointName, Collection<Message<T>> message);
+	/**
+	 * Send the provided messages along with their headers to the provided endpoint.
+	 * The payloads will be serialized if necessary, and headers will be converted
+	 * to the specific messaging system metadata types.
+	 *
+	 * @param endpointName the endpoint to send the messages to.
+	 * @param messages the messages to be sent.
+	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
+	 */
+	CompletableFuture<R> sendAsync(@Nullable String endpointName, Collection<Message<T>> messages);
 
+	/**
+	 * Receive a message from the default endpoint with default settings.
+	 * @return a {@link CompletableFuture} to be completed with the message,
+	 * or {@link Optional#empty()} if none is returned.
+	 */
 	CompletableFuture<Optional<Message<T>>> receiveAsync();
 
-	CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String endpoint,
+	/**
+	 * Receive a message from the provided endpoint and convert the payload to the
+	 * provided class. If no message is returned after the specified {@link Duration},
+	 * an {@link Optional#empty()} is returned.
+	 * <p>
+	 * Any headers provided in the additional headers parameter will be added to the
+	 * {@link Message} instances returned by this method.
+	 * The implementation can also allow some specific headers to change particular settings,
+	 * in which case the headers are removed before sending.
+	 * See the implementation javadocs for more information.
+	 *
+	 * @param endpointName the endpoint from which to receive the messages.
+	 * @param payloadClass the class to which the payload should be converted to.
+	 * @param pollTimeout the maximum amount of time to wait for messages.
+	 * @param additionalHeaders headers to be added to the received messages.
+	 * @return a {@link CompletableFuture} to be completed with the message,
+	 * or {@link Optional#empty()} if none is returned.
+	 */
+	CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String endpointName,
 														 @Nullable Class<T> payloadClass,
 														 @Nullable Duration pollTimeout,
 														 @Nullable Map<String, Object> additionalHeaders);
 
+	/**
+	 * Receive a batch of messages from the default endpoint with default settings.
+	 * @return a {@link CompletableFuture} to be completed with the messages,
+	 * or an empty collection if none is returned.
+	 */
 	CompletableFuture<Collection<Message<T>>> receiveManyAsync();
 
-	CompletableFuture<Collection<Message<T>>> receiveManyAsync(@Nullable String endpoint,
+	/**
+	 * Receive a batch of messages from the provided endpoint and convert the payloads to the
+	 * provided class. If no message is returned after the specified {@link Duration},
+	 * an empty collection is returned.
+	 * <p>
+	 * Any headers provided in the additional headers parameter will be added to the
+	 * {@link Message} instances returned by this method.
+	 * The implementation can also allow some specific headers to change particular settings,
+	 * in which case the headers are removed before sending.
+	 * See the implementation javadocs for more information.
+	 *
+	 * @param endpointName the endpoint from which to receive the messages.
+	 * @param payloadClass the class to which the payloads should be converted to.
+	 * @param pollTimeout the maximum amount of time to wait for messages.
+	 * @param maxNumberOfMessages the maximum number of messages to receive.
+	 * @param additionalHeaders headers to be added to the received messages.
+	 * @return a {@link CompletableFuture} to be completed with the messages,
+	 * or an empty collection if none is returned.
+	 */
+	CompletableFuture<Collection<Message<T>>> receiveManyAsync(@Nullable String endpointName,
 															   @Nullable Class<T> payloadClass,
 															   @Nullable Duration pollTimeout,
 															   @Nullable Integer maxNumberOfMessages,

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
@@ -1,0 +1,42 @@
+package io.awspring.cloud.sqs.operations;
+
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 3.0
+ */
+public interface AsyncMessagingOperations<T, R> {
+
+	CompletableFuture<UUID> sendAsync(T payload);
+
+	CompletableFuture<UUID> sendAsync(@Nullable String endpointName, T payload);
+
+	CompletableFuture<UUID> sendAsync(@Nullable String endpointName, Message<T> message);
+
+	CompletableFuture<R> sendAsync(@Nullable String endpointName, Collection<Message<T>> message);
+
+	CompletableFuture<Optional<Message<T>>> receiveAsync();
+
+	CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String endpoint,
+														 @Nullable Class<T> payloadClass,
+														 @Nullable Duration pollTimeout,
+														 @Nullable Map<String, Object> additionalHeaders);
+
+	CompletableFuture<Collection<Message<T>>> receiveManyAsync();
+
+	CompletableFuture<Collection<Message<T>>> receiveManyAsync(@Nullable String endpoint,
+															   @Nullable Class<T> payloadClass,
+															   @Nullable Duration pollTimeout,
+															   @Nullable Integer maxNumberOfMessages,
+															   @Nullable Map<String, Object> additionalHeaders);
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
@@ -17,7 +17,6 @@ package io.awspring.cloud.sqs.operations;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -49,7 +48,7 @@ public interface AsyncMessagingOperations {
 	 * @param payload the payload to send.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
 	 */
-	<T> CompletableFuture<SendResult<T>> sendAsync(@Nullable String queue, T payload);
+	<T> CompletableFuture<SendResult<T>> sendAsync(String queue, T payload);
 
 	/**
 	 * Send the provided message along with its headers to the provided queue. The payload will be serialized if
@@ -59,7 +58,7 @@ public interface AsyncMessagingOperations {
 	 * @param message the message to be sent.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
 	 */
-	<T> CompletableFuture<SendResult<T>> sendAsync(@Nullable String queue, Message<T> message);
+	<T> CompletableFuture<SendResult<T>> sendAsync(String queue, Message<T> message);
 
 	/**
 	 * Send the provided messages along with their headers to the provided queue. The payloads will be serialized if
@@ -69,15 +68,14 @@ public interface AsyncMessagingOperations {
 	 * @param messages the messages to be sent.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
 	 */
-	<T> CompletableFuture<SendResult.Batch<T>> sendManyAsync(@Nullable String queue,
-			Collection<Message<T>> messages);
+	<T> CompletableFuture<SendResult.Batch<T>> sendManyAsync(String queue, Collection<Message<T>> messages);
 
 	/**
 	 * Receive a message from the default queue with default settings.
 	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
 	 * returned.
 	 */
-	<T> CompletableFuture<Optional<Message<T>>> receiveAsync();
+	CompletableFuture<Optional<Message<?>>> receiveAsync();
 
 	/**
 	 * Receive a message from the provided queue and convert the payload to the provided class. If no message is
@@ -89,28 +87,21 @@ public interface AsyncMessagingOperations {
 	 *
 	 * @param queue the queue from which to receive the messages.
 	 * @param payloadClass the class to which the payload should be converted to.
-	 * @param pollTimeout the maximum amount of time to wait for messages.
-	 * @param additionalHeaders headers to be added to the received messages.
 	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
 	 * returned.
 	 */
-	// @formatter:off
-	<T> CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String queue,
-														 @Nullable Class<T> payloadClass,
-														 @Nullable Duration pollTimeout,
-														 @Nullable Map<String, Object> additionalHeaders);
-	// @formatter:on
+	<T> CompletableFuture<Optional<Message<T>>> receiveAsync(String queue, Class<T> payloadClass);
 
 	/**
 	 * Receive a batch of messages from the default queue with default settings.
 	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
 	 * returned.
 	 */
-	<T> CompletableFuture<Collection<Message<T>>> receiveManyAsync();
+	CompletableFuture<Collection<Message<?>>> receiveManyAsync();
 
 	/**
-	 * Receive a batch of messages from the provided queue and convert the payloads to the provided class. If no
-	 * message is returned after the specified {@link Duration}, an empty collection is returned.
+	 * Receive a batch of messages from the provided queue and convert the payloads to the provided class. If no message
+	 * is returned after the specified {@link Duration}, an empty collection is returned.
 	 * <p>
 	 * Any headers provided in the additional headers parameter will be added to the {@link Message} instances returned
 	 * by this method. The implementation can also allow some specific headers to change particular settings, in which
@@ -118,18 +109,9 @@ public interface AsyncMessagingOperations {
 	 *
 	 * @param queue the queue from which to receive the messages.
 	 * @param payloadClass the class to which the payloads should be converted to.
-	 * @param pollTimeout the maximum amount of time to wait for messages.
-	 * @param maxNumberOfMessages the maximum number of messages to receive.
-	 * @param additionalHeaders headers to be added to the received messages.
 	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
 	 * returned.
 	 */
-	// @formatter:off
-	<T> CompletableFuture<Collection<Message<T>>> receiveManyAsync(@Nullable String queue,
-															   @Nullable Class<T> payloadClass,
-															   @Nullable Duration pollTimeout,
-															   @Nullable Integer maxNumberOfMessages,
-															   @Nullable Map<String, Object> additionalHeaders);
-	// @formatter:on
+	<T> CompletableFuture<Collection<Message<T>>> receiveManyAsync(String queue, Class<T> payloadClass);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
@@ -94,8 +94,12 @@ public interface AsyncMessagingOperations<T> {
 	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
 	 * returned.
 	 */
-	CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String endpointName, @Nullable Class<? extends T> payloadClass,
-			@Nullable Duration pollTimeout, @Nullable Map<String, Object> additionalHeaders);
+	// @formatter:off
+	CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String endpointName,
+														 @Nullable Class<? extends T> payloadClass,
+														 @Nullable Duration pollTimeout,
+														 @Nullable Map<String, Object> additionalHeaders);
+	// @formatter:on
 
 	/**
 	 * Receive a batch of messages from the default endpoint with default settings.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
@@ -34,7 +34,7 @@ import org.springframework.messaging.Message;
 public interface AsyncMessagingOperations {
 
 	/**
-	 * Send a {@link Message} to the default endpoint with the provided payload. The payload will be serialized if
+	 * Send a {@link Message} to the default queue with the provided payload. The payload will be serialized if
 	 * necessary.
 	 *
 	 * @param payload the payload to send.
@@ -43,51 +43,51 @@ public interface AsyncMessagingOperations {
 	<T> CompletableFuture<SendResult<T>> sendAsync(T payload);
 
 	/**
-	 * Send a message to the provided endpoint with the provided payload. The payload will be serialized if necessary.
+	 * Send a message to the provided queue with the provided payload. The payload will be serialized if necessary.
 	 *
-	 * @param endpointName the endpoint to send the message to.
+	 * @param queue the queue to send the message to.
 	 * @param payload the payload to send.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
 	 */
-	<T> CompletableFuture<SendResult<T>> sendAsync(@Nullable String endpointName, T payload);
+	<T> CompletableFuture<SendResult<T>> sendAsync(@Nullable String queue, T payload);
 
 	/**
-	 * Send the provided message along with its headers to the provided endpoint. The payload will be serialized if
+	 * Send the provided message along with its headers to the provided queue. The payload will be serialized if
 	 * necessary, and headers will be converted to the specific messaging system metadata types.
 	 *
-	 * @param endpointName the endpoint to send the message to.
+	 * @param queue the queue to send the message to.
 	 * @param message the message to be sent.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
 	 */
-	<T> CompletableFuture<SendResult<T>> sendAsync(@Nullable String endpointName, Message<T> message);
+	<T> CompletableFuture<SendResult<T>> sendAsync(@Nullable String queue, Message<T> message);
 
 	/**
-	 * Send the provided messages along with their headers to the provided endpoint. The payloads will be serialized if
+	 * Send the provided messages along with their headers to the provided queue. The payloads will be serialized if
 	 * necessary, and headers will be converted to the specific messaging system metadata types.
 	 *
-	 * @param endpointName the endpoint to send the messages to.
+	 * @param queue the queue to send the messages to.
 	 * @param messages the messages to be sent.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
 	 */
-	<T> CompletableFuture<SendResult.Batch<T>> sendManyAsync(@Nullable String endpointName,
+	<T> CompletableFuture<SendResult.Batch<T>> sendManyAsync(@Nullable String queue,
 			Collection<Message<T>> messages);
 
 	/**
-	 * Receive a message from the default endpoint with default settings.
+	 * Receive a message from the default queue with default settings.
 	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
 	 * returned.
 	 */
 	<T> CompletableFuture<Optional<Message<T>>> receiveAsync();
 
 	/**
-	 * Receive a message from the provided endpoint and convert the payload to the provided class. If no message is
+	 * Receive a message from the provided queue and convert the payload to the provided class. If no message is
 	 * returned after the specified {@link Duration}, an {@link Optional#empty()} is returned.
 	 * <p>
 	 * Any headers provided in the additional headers parameter will be added to the {@link Message} instances returned
 	 * by this method. The implementation can also allow some specific headers to change particular settings, in which
 	 * case the headers are removed before sending. See the implementation javadocs for more information.
 	 *
-	 * @param endpointName the endpoint from which to receive the messages.
+	 * @param queue the queue from which to receive the messages.
 	 * @param payloadClass the class to which the payload should be converted to.
 	 * @param pollTimeout the maximum amount of time to wait for messages.
 	 * @param additionalHeaders headers to be added to the received messages.
@@ -95,28 +95,28 @@ public interface AsyncMessagingOperations {
 	 * returned.
 	 */
 	// @formatter:off
-	<T> CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String endpointName,
+	<T> CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String queue,
 														 @Nullable Class<T> payloadClass,
 														 @Nullable Duration pollTimeout,
 														 @Nullable Map<String, Object> additionalHeaders);
 	// @formatter:on
 
 	/**
-	 * Receive a batch of messages from the default endpoint with default settings.
+	 * Receive a batch of messages from the default queue with default settings.
 	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
 	 * returned.
 	 */
 	<T> CompletableFuture<Collection<Message<T>>> receiveManyAsync();
 
 	/**
-	 * Receive a batch of messages from the provided endpoint and convert the payloads to the provided class. If no
+	 * Receive a batch of messages from the provided queue and convert the payloads to the provided class. If no
 	 * message is returned after the specified {@link Duration}, an empty collection is returned.
 	 * <p>
 	 * Any headers provided in the additional headers parameter will be added to the {@link Message} instances returned
 	 * by this method. The implementation can also allow some specific headers to change particular settings, in which
 	 * case the headers are removed before sending. See the implementation javadocs for more information.
 	 *
-	 * @param endpointName the endpoint from which to receive the messages.
+	 * @param queue the queue from which to receive the messages.
 	 * @param payloadClass the class to which the payloads should be converted to.
 	 * @param pollTimeout the maximum amount of time to wait for messages.
 	 * @param maxNumberOfMessages the maximum number of messages to receive.
@@ -125,7 +125,7 @@ public interface AsyncMessagingOperations {
 	 * returned.
 	 */
 	// @formatter:off
-	<T> CompletableFuture<Collection<Message<T>>> receiveManyAsync(@Nullable String endpointName,
+	<T> CompletableFuture<Collection<Message<T>>> receiveManyAsync(@Nullable String queue,
 															   @Nullable Class<T> payloadClass,
 															   @Nullable Duration pollTimeout,
 															   @Nullable Integer maxNumberOfMessages,

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
@@ -79,11 +79,7 @@ public interface AsyncMessagingOperations {
 
 	/**
 	 * Receive a message from the provided queue and convert the payload to the provided class. If no message is
-	 * returned after the specified {@link Duration}, an {@link Optional#empty()} is returned.
-	 * <p>
-	 * Any headers provided in the additional headers parameter will be added to the {@link Message} instances returned
-	 * by this method. The implementation can also allow some specific headers to change particular settings, in which
-	 * case the headers are removed before sending. See the implementation javadocs for more information.
+	 * returned after the default {@link Duration}, an {@link Optional#empty()} is returned.
 	 *
 	 * @param queue the queue from which to receive the messages.
 	 * @param payloadClass the class to which the payload should be converted to.
@@ -101,11 +97,7 @@ public interface AsyncMessagingOperations {
 
 	/**
 	 * Receive a batch of messages from the provided queue and convert the payloads to the provided class. If no message
-	 * is returned after the specified {@link Duration}, an empty collection is returned.
-	 * <p>
-	 * Any headers provided in the additional headers parameter will be added to the {@link Message} instances returned
-	 * by this method. The implementation can also allow some specific headers to change particular settings, in which
-	 * case the headers are removed before sending. See the implementation javadocs for more information.
+	 * is returned after the default {@link Duration}, an empty collection is returned.
 	 *
 	 * @param queue the queue from which to receive the messages.
 	 * @param payloadClass the class to which the payloads should be converted to.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
@@ -31,7 +31,7 @@ import org.springframework.messaging.Message;
  * @author Tomaz Fernandes
  * @since 3.0
  */
-public interface AsyncMessagingOperations<T> {
+public interface AsyncMessagingOperations {
 
 	/**
 	 * Send a {@link Message} to the default endpoint with the provided payload. The payload will be serialized if
@@ -40,7 +40,7 @@ public interface AsyncMessagingOperations<T> {
 	 * @param payload the payload to send.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
 	 */
-	CompletableFuture<SendResult<T>> sendAsync(T payload);
+	<T> CompletableFuture<SendResult<T>> sendAsync(T payload);
 
 	/**
 	 * Send a message to the provided endpoint with the provided payload. The payload will be serialized if necessary.
@@ -49,7 +49,7 @@ public interface AsyncMessagingOperations<T> {
 	 * @param payload the payload to send.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
 	 */
-	CompletableFuture<SendResult<T>> sendAsync(@Nullable String endpointName, T payload);
+	<T> CompletableFuture<SendResult<T>> sendAsync(@Nullable String endpointName, T payload);
 
 	/**
 	 * Send the provided message along with its headers to the provided endpoint. The payload will be serialized if
@@ -59,7 +59,7 @@ public interface AsyncMessagingOperations<T> {
 	 * @param message the message to be sent.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
 	 */
-	CompletableFuture<SendResult<T>> sendAsync(@Nullable String endpointName, Message<T> message);
+	<T> CompletableFuture<SendResult<T>> sendAsync(@Nullable String endpointName, Message<T> message);
 
 	/**
 	 * Send the provided messages along with their headers to the provided endpoint. The payloads will be serialized if
@@ -69,7 +69,7 @@ public interface AsyncMessagingOperations<T> {
 	 * @param messages the messages to be sent.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
 	 */
-	CompletableFuture<SendResult.Batch<T>> sendManyAsync(@Nullable String endpointName,
+	<T> CompletableFuture<SendResult.Batch<T>> sendManyAsync(@Nullable String endpointName,
 			Collection<Message<T>> messages);
 
 	/**
@@ -77,7 +77,7 @@ public interface AsyncMessagingOperations<T> {
 	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
 	 * returned.
 	 */
-	CompletableFuture<Optional<Message<T>>> receiveAsync();
+	<T> CompletableFuture<Optional<Message<T>>> receiveAsync();
 
 	/**
 	 * Receive a message from the provided endpoint and convert the payload to the provided class. If no message is
@@ -95,8 +95,8 @@ public interface AsyncMessagingOperations<T> {
 	 * returned.
 	 */
 	// @formatter:off
-	CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String endpointName,
-														 @Nullable Class<? extends T> payloadClass,
+	<T> CompletableFuture<Optional<Message<T>>> receiveAsync(@Nullable String endpointName,
+														 @Nullable Class<T> payloadClass,
 														 @Nullable Duration pollTimeout,
 														 @Nullable Map<String, Object> additionalHeaders);
 	// @formatter:on
@@ -106,7 +106,7 @@ public interface AsyncMessagingOperations<T> {
 	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
 	 * returned.
 	 */
-	CompletableFuture<Collection<Message<T>>> receiveManyAsync();
+	<T> CompletableFuture<Collection<Message<T>>> receiveManyAsync();
 
 	/**
 	 * Receive a batch of messages from the provided endpoint and convert the payloads to the provided class. If no
@@ -125,8 +125,8 @@ public interface AsyncMessagingOperations<T> {
 	 * returned.
 	 */
 	// @formatter:off
-	CompletableFuture<Collection<Message<T>>> receiveManyAsync(@Nullable String endpointName,
-															   @Nullable Class<? extends T> payloadClass,
+	<T> CompletableFuture<Collection<Message<T>>> receiveManyAsync(@Nullable String endpointName,
+															   @Nullable Class<T> payloadClass,
 															   @Nullable Duration pollTimeout,
 															   @Nullable Integer maxNumberOfMessages,
 															   @Nullable Map<String, Object> additionalHeaders);

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java
@@ -17,7 +17,7 @@ import java.util.concurrent.CompletableFuture;
  * @author Tomaz Fernandes
  * @since 3.0
  */
-public interface AsyncMessagingOperations<T, R> {
+public interface AsyncMessagingOperations<T> {
 
 	/**
 	 * Send a {@link Message} to the default endpoint with the provided payload.
@@ -26,7 +26,7 @@ public interface AsyncMessagingOperations<T, R> {
 	 * @param payload the payload to send.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
 	 */
-	CompletableFuture<UUID> sendAsync(T payload);
+	CompletableFuture<SendResult<T>> sendAsync(T payload);
 
 	/**
 	 * Send a message to the provided endpoint with the provided payload.
@@ -36,7 +36,7 @@ public interface AsyncMessagingOperations<T, R> {
 	 * @param payload the payload to send.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
 	 */
-	CompletableFuture<UUID> sendAsync(@Nullable String endpointName, T payload);
+	CompletableFuture<SendResult<T>> sendAsync(@Nullable String endpointName, T payload);
 
 	/**
 	 * Send the provided message along with its headers to the provided endpoint.
@@ -47,7 +47,7 @@ public interface AsyncMessagingOperations<T, R> {
 	 * @param message the message to be sent.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
 	 */
-	CompletableFuture<UUID> sendAsync(@Nullable String endpointName, Message<T> message);
+	CompletableFuture<SendResult<T>> sendAsync(@Nullable String endpointName, Message<T> message);
 
 	/**
 	 * Send the provided messages along with their headers to the provided endpoint.
@@ -58,7 +58,7 @@ public interface AsyncMessagingOperations<T, R> {
 	 * @param messages the messages to be sent.
 	 * @return a {@link CompletableFuture} to be completed with the message's {@link UUID}.
 	 */
-	CompletableFuture<R> sendAsync(@Nullable String endpointName, Collection<Message<T>> messages);
+	CompletableFuture<SendResult.Batch<T>> sendManyAsync(@Nullable String endpointName, Collection<Message<T>> messages);
 
 	/**
 	 * Receive a message from the default endpoint with default settings.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperationFailedException.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperationFailedException.java
@@ -1,0 +1,29 @@
+package io.awspring.cloud.sqs.operations;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Exception to represent the failure of a Messaging Operation.
+ * @author Tomaz Fernandes
+ * @since 3.0
+ */
+public class MessagingOperationFailedException extends RuntimeException {
+
+	/**
+	 * Create an instance with the provided error message.
+	 * @param msg the message.
+	 */
+	public MessagingOperationFailedException(String msg) {
+		super(msg);
+	}
+
+	/**
+	 * Create an instance with the provided error message and cause, if any.
+	 * @param msg the error message.
+	 * @param cause the cause.
+	 */
+	public MessagingOperationFailedException(@Nullable String msg, @Nullable Throwable cause) {
+		super(msg, cause);
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperationFailedException.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperationFailedException.java
@@ -1,13 +1,27 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.operations;
-
-import org.springframework.core.NestedRuntimeException;
-import org.springframework.lang.Nullable;
-import org.springframework.messaging.Message;
-import org.springframework.util.Assert;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
+import org.springframework.core.NestedRuntimeException;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
 
 /**
  * Exception to represent the failure of a Messaging Operation.
@@ -44,7 +58,8 @@ public class MessagingOperationFailedException extends NestedRuntimeException {
 	 * @param message the message with which the operation failed.
 	 * @param cause the cause.
 	 */
-	public MessagingOperationFailedException(String msg, String endpoint, Message<?> message, @Nullable Throwable cause) {
+	public MessagingOperationFailedException(String msg, String endpoint, Message<?> message,
+			@Nullable Throwable cause) {
 		this(msg, endpoint, Collections.singletonList(message), cause);
 	}
 
@@ -56,7 +71,7 @@ public class MessagingOperationFailedException extends NestedRuntimeException {
 	 * @param cause the cause.
 	 */
 	public <T> MessagingOperationFailedException(String msg, String endpoint, Collection<Message<T>> messages,
-												 @Nullable Throwable cause) {
+			@Nullable Throwable cause) {
 		super(msg, cause);
 		this.endpoint = endpoint;
 		this.failedMessages = Collections.unmodifiableCollection(messages);

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperationFailedException.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperationFailedException.java
@@ -1,20 +1,31 @@
 package io.awspring.cloud.sqs.operations;
 
+import org.springframework.core.NestedRuntimeException;
 import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
 
 /**
  * Exception to represent the failure of a Messaging Operation.
  * @author Tomaz Fernandes
  * @since 3.0
  */
-public class MessagingOperationFailedException extends RuntimeException {
+public class MessagingOperationFailedException extends NestedRuntimeException {
+
+	private final String endpoint;
+
+	private final Collection<Message<?>> failedMessages;
 
 	/**
 	 * Create an instance with the provided error message.
 	 * @param msg the message.
 	 */
-	public MessagingOperationFailedException(String msg) {
-		super(msg);
+	public MessagingOperationFailedException(String msg, String endpoint) {
+		this(msg, endpoint, null);
 	}
 
 	/**
@@ -22,8 +33,58 @@ public class MessagingOperationFailedException extends RuntimeException {
 	 * @param msg the error message.
 	 * @param cause the cause.
 	 */
-	public MessagingOperationFailedException(@Nullable String msg, @Nullable Throwable cause) {
+	public MessagingOperationFailedException(String msg, String endpoint, @Nullable Throwable cause) {
+		this(msg, endpoint, Collections.emptyList(), cause);
+	}
+
+	/**
+	 * Create an instance with the provided parameters and a single message.
+	 * @param msg the error message.
+	 * @param endpoint the endpoint with which the operation failed.
+	 * @param message the message with which the operation failed.
+	 * @param cause the cause.
+	 */
+	public MessagingOperationFailedException(String msg, String endpoint, Message<?> message, @Nullable Throwable cause) {
+		this(msg, endpoint, Collections.singletonList(message), cause);
+	}
+
+	/**
+	 * Create an instance with the provided parameters and a batch of messages.
+	 * @param msg the error message.
+	 * @param endpoint the endpoint with which the operation failed.
+	 * @param messages the messages with which the operation failed.
+	 * @param cause the cause.
+	 */
+	public <T> MessagingOperationFailedException(String msg, String endpoint, Collection<Message<T>> messages,
+												 @Nullable Throwable cause) {
 		super(msg, cause);
+		this.endpoint = endpoint;
+		this.failedMessages = Collections.unmodifiableCollection(messages);
+	}
+
+	/**
+	 * Get the endpoint which the operation failed.
+	 * @return the endpoint.
+	 */
+	public String getEndpoint() {
+		return this.endpoint;
+	}
+
+	/**
+	 * The failed messages.
+	 * @return the messages.
+	 */
+	public Collection<Message<?>> getFailedMessages() {
+		return this.failedMessages;
+	}
+
+	/**
+	 * A single failed message, if present.
+	 * @return the message if present.
+	 */
+	public Optional<Message<?>> getFailedMessage() {
+		Assert.isTrue(this.failedMessages.size() < 2, "More than one message found");
+		return this.failedMessages.stream().findFirst();
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
@@ -113,8 +113,12 @@ public interface MessagingOperations<T> {
 	 * @param additionalHeaders headers to be added to the received messages.
 	 * @return the messages, or {@link Optional#empty()} if none is returned.
 	 */
-	Collection<Message<T>> receiveMany(@Nullable String endpointName, @Nullable Class<T> payloadClass,
-			@Nullable Duration pollTimeout, @Nullable Integer maxNumberOfMessages,
-			@Nullable Map<String, Object> additionalHeaders);
+	// @formatter:off
+	Collection<Message<T>> receiveMany(@Nullable String endpointName,
+									   @Nullable Class<T> payloadClass,
+									   @Nullable Duration pollTimeout,
+									   @Nullable Integer maxNumberOfMessages,
+									   @Nullable Map<String, Object> additionalHeaders);
+	// @formatter:on
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
@@ -1,0 +1,41 @@
+package io.awspring.cloud.sqs.operations;
+
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 3.0
+ */
+public interface MessagingOperations<T, R> {
+
+	UUID send(T payload);
+
+	UUID send(@Nullable String endpointName, T payload);
+
+	UUID send(@Nullable String endpointName, Message<T> message);
+
+	R send(@Nullable String endpointName, Collection<Message<T>> messages);
+
+	Optional<Message<T>> receive();
+
+	Optional<Message<T>> receive(@Nullable String endpointName,
+								 @Nullable Class<T> payloadClass,
+								 @Nullable Duration pollTimeout,
+								 @Nullable Map<String, Object> additionalHeaders);
+
+	Collection<Message<T>> receiveMany();
+
+	Collection<Message<T>> receiveMany(@Nullable String endpointName,
+									   @Nullable Class<T> payloadClass,
+									   @Nullable Duration pollTimeout,
+									   @Nullable Integer maxNumberOfMessages,
+									   @Nullable Map<String, Object> additionalHeaders);
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
@@ -33,7 +33,7 @@ import org.springframework.messaging.Message;
 public interface MessagingOperations {
 
 	/**
-	 * Send a {@link Message} to the default endpoint with the provided payload. The payload will be serialized if
+	 * Send a {@link Message} to the default queue with the provided payload. The payload will be serialized if
 	 * necessary.
 	 *
 	 * @param payload the payload to send.
@@ -42,79 +42,79 @@ public interface MessagingOperations {
 	<T> SendResult<T> send(T payload);
 
 	/**
-	 * Send a message to the provided endpoint with the provided payload. The payload will be serialized if necessary.
+	 * Send a message to the provided queue with the provided payload. The payload will be serialized if necessary.
 	 *
-	 * @param endpointName the endpoint to send the message to.
+	 * @param queue the queue to send the message to.
 	 * @param payload the payload to send.
 	 * @return The message's {@link UUID}.
 	 */
-	<T> SendResult<T> send(@Nullable String endpointName, T payload);
+	<T> SendResult<T> send(@Nullable String queue, T payload);
 
 	/**
-	 * Send the provided message along with its headers to the provided endpoint. The payload will be serialized if
+	 * Send the provided message along with its headers to the provided queue. The payload will be serialized if
 	 * necessary, and headers will be converted to the specific messaging system metadata types.
 	 *
-	 * @param endpointName the endpoint to send the message to.
+	 * @param queue the queue to send the message to.
 	 * @param message the message to be sent.
 	 * @return The message's {@link UUID}.
 	 */
-	<T> SendResult<T> send(@Nullable String endpointName, Message<T> message);
+	<T> SendResult<T> send(@Nullable String queue, Message<T> message);
 
 	/**
-	 * Send the provided messages along with their headers to the provided endpoint. The payloads will be serialized if
+	 * Send the provided messages along with their headers to the provided queue. The payloads will be serialized if
 	 * necessary, and headers will be converted to the specific messaging system metadata types.
 	 *
-	 * @param endpointName the endpoint to send the messages to.
+	 * @param queue the queue to send the messages to.
 	 * @param messages the messages to be sent.
 	 * @return The message's {@link UUID}.
 	 */
-	<T> SendResult.Batch<T> sendMany(@Nullable String endpointName, Collection<Message<T>> messages);
+	<T> SendResult.Batch<T> sendMany(@Nullable String queue, Collection<Message<T>> messages);
 
 	/**
-	 * Receive a message from the default endpoint with default settings.
+	 * Receive a message from the default queue with default settings.
 	 * @return the message or {@link Optional#empty()} if none is returned.
 	 */
 	<T> Optional<Message<T>> receive();
 
 	/**
-	 * Receive a message from the provided endpoint and convert the payload to the provided class. If no message is
+	 * Receive a message from the provided queue and convert the payload to the provided class. If no message is
 	 * returned after the specified {@link Duration}, an {@link Optional#empty()} is returned.
 	 * <p>
 	 * Any headers provided in the additional headers parameter will be added to the {@link Message} instances returned
 	 * by this method. The implementation can also allow some specific headers to change particular settings, in which
 	 * case the headers are removed before sending. See the implementation javadocs for more information.
 	 *
-	 * @param endpointName the endpoint from which to receive the messages.
+	 * @param queue the queue from which to receive the messages.
 	 * @param payloadClass the class to which the payload should be converted to.
 	 * @param pollTimeout the maximum amount of time to wait for messages.
 	 * @param additionalHeaders headers to be added to the received messages.
 	 * @return the message, or {@link Optional#empty()} if none is returned.
 	 */
-	<T> Optional<Message<T>> receive(@Nullable String endpointName, @Nullable Class<T> payloadClass,
+	<T> Optional<Message<T>> receive(@Nullable String queue, @Nullable Class<T> payloadClass,
 			@Nullable Duration pollTimeout, @Nullable Map<String, Object> additionalHeaders);
 
 	/**
-	 * Receive a batch of messages from the default endpoint with default settings.
+	 * Receive a batch of messages from the default queue with default settings.
 	 * @return The messages, or an empty collection if none is returned.
 	 */
 	<T> Collection<Message<T>> receiveMany();
 
 	/**
-	 * Receive a message from the provided endpoint and convert the payload to the provided class. If no message is
+	 * Receive a message from the provided queue and convert the payload to the provided class. If no message is
 	 * returned after the specified {@link Duration}, an {@link Optional#empty()} is returned.
 	 * <p>
 	 * Any headers provided in the additional headers parameter will be added to the {@link Message} instances returned
 	 * by this method. The implementation can also allow some specific headers to change particular settings, in which
 	 * case the headers are removed before sending. See the implementation javadocs for more information.
 	 *
-	 * @param endpointName the endpoint from which to receive the messages.
+	 * @param queue the queue from which to receive the messages.
 	 * @param payloadClass the class to which the payloads should be converted to.
 	 * @param pollTimeout the maximum amount of time to wait for messages.
 	 * @param additionalHeaders headers to be added to the received messages.
 	 * @return the messages, or {@link Optional#empty()} if none is returned.
 	 */
 	// @formatter:off
-	<T> Collection<Message<T>> receiveMany(@Nullable String endpointName,
+	<T> Collection<Message<T>> receiveMany(@Nullable String queue,
 									   @Nullable Class<T> payloadClass,
 									   @Nullable Duration pollTimeout,
 									   @Nullable Integer maxNumberOfMessages,

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
@@ -8,7 +8,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Synchronous messaging operations.
@@ -18,7 +17,7 @@ import java.util.concurrent.CompletableFuture;
  * @author Tomaz Fernandes
  * @since 3.0
  */
-public interface MessagingOperations<T, R> {
+public interface MessagingOperations<T> {
 
 	/**
 	 * Send a {@link Message} to the default endpoint with the provided payload.
@@ -27,7 +26,7 @@ public interface MessagingOperations<T, R> {
 	 * @param payload the payload to send.
 	 * @return The message's {@link UUID}.
 	 */
-	UUID send(T payload);
+	SendResult<T> send(T payload);
 
 	/**
 	 * Send a message to the provided endpoint with the provided payload.
@@ -37,7 +36,7 @@ public interface MessagingOperations<T, R> {
 	 * @param payload the payload to send.
 	 * @return The message's {@link UUID}.
 	 */
-	UUID send(@Nullable String endpointName, T payload);
+	SendResult<T> send(@Nullable String endpointName, T payload);
 
 	/**
 	 * Send the provided message along with its headers to the provided endpoint.
@@ -48,7 +47,7 @@ public interface MessagingOperations<T, R> {
 	 * @param message the message to be sent.
 	 * @return The message's {@link UUID}.
 	 */
-	UUID send(@Nullable String endpointName, Message<T> message);
+	SendResult<T> send(@Nullable String endpointName, Message<T> message);
 
 	/**
 	 * Send the provided messages along with their headers to the provided endpoint.
@@ -59,7 +58,7 @@ public interface MessagingOperations<T, R> {
 	 * @param messages the messages to be sent.
 	 * @return The message's {@link UUID}.
 	 */
-	R send(@Nullable String endpointName, Collection<Message<T>> messages);
+	SendResult.Batch<T> sendMany(@Nullable String endpointName, Collection<Message<T>> messages);
 
 	/**
 	 * Receive a message from the default endpoint with default settings.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.sqs.operations;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
@@ -75,7 +76,11 @@ public interface MessagingOperations {
 	Optional<Message<?>> receive();
 
 	/**
-	 * Receive a message from the default queue with default settings.
+	 * Receive a message from the provided queue and convert the payload to the provided class. If no message is
+	 * returned after the default {@link Duration}, an {@link Optional#empty()} is returned.
+	 *
+	 * @param queue the queue from which to receive the messages.
+	 * @param payloadClass the class to which the payload should be converted to.
 	 * @return the message or {@link Optional#empty()} if none is returned.
 	 */
 	<T> Optional<Message<T>> receive(String queue, Class<T> payloadClass);
@@ -87,7 +92,11 @@ public interface MessagingOperations {
 	Collection<Message<?>> receiveMany();
 
 	/**
-	 * Receive a batch of messages from the default queue with default settings.
+	 * Receive a batch of messages from the provided queue and convert the payloads to the provided class. If no message
+	 * is returned after the default {@link Duration}, an empty collection is returned.
+	 *
+	 * @param queue the queue from which to receive the messages.
+	 * @param payloadClass the class to which the payloads should be converted to.
 	 * @return The messages, or an empty collection if none is returned.
 	 */
 	<T> Collection<Message<T>> receiveMany(String queue, Class<T> payloadClass);

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
@@ -30,7 +30,7 @@ import org.springframework.messaging.Message;
  * @author Tomaz Fernandes
  * @since 3.0
  */
-public interface MessagingOperations<T> {
+public interface MessagingOperations {
 
 	/**
 	 * Send a {@link Message} to the default endpoint with the provided payload. The payload will be serialized if
@@ -39,7 +39,7 @@ public interface MessagingOperations<T> {
 	 * @param payload the payload to send.
 	 * @return The message's {@link UUID}.
 	 */
-	SendResult<T> send(T payload);
+	<T> SendResult<T> send(T payload);
 
 	/**
 	 * Send a message to the provided endpoint with the provided payload. The payload will be serialized if necessary.
@@ -48,7 +48,7 @@ public interface MessagingOperations<T> {
 	 * @param payload the payload to send.
 	 * @return The message's {@link UUID}.
 	 */
-	SendResult<T> send(@Nullable String endpointName, T payload);
+	<T> SendResult<T> send(@Nullable String endpointName, T payload);
 
 	/**
 	 * Send the provided message along with its headers to the provided endpoint. The payload will be serialized if
@@ -58,7 +58,7 @@ public interface MessagingOperations<T> {
 	 * @param message the message to be sent.
 	 * @return The message's {@link UUID}.
 	 */
-	SendResult<T> send(@Nullable String endpointName, Message<T> message);
+	<T> SendResult<T> send(@Nullable String endpointName, Message<T> message);
 
 	/**
 	 * Send the provided messages along with their headers to the provided endpoint. The payloads will be serialized if
@@ -68,13 +68,13 @@ public interface MessagingOperations<T> {
 	 * @param messages the messages to be sent.
 	 * @return The message's {@link UUID}.
 	 */
-	SendResult.Batch<T> sendMany(@Nullable String endpointName, Collection<Message<T>> messages);
+	<T> SendResult.Batch<T> sendMany(@Nullable String endpointName, Collection<Message<T>> messages);
 
 	/**
 	 * Receive a message from the default endpoint with default settings.
 	 * @return the message or {@link Optional#empty()} if none is returned.
 	 */
-	Optional<Message<T>> receive();
+	<T> Optional<Message<T>> receive();
 
 	/**
 	 * Receive a message from the provided endpoint and convert the payload to the provided class. If no message is
@@ -90,14 +90,14 @@ public interface MessagingOperations<T> {
 	 * @param additionalHeaders headers to be added to the received messages.
 	 * @return the message, or {@link Optional#empty()} if none is returned.
 	 */
-	Optional<Message<T>> receive(@Nullable String endpointName, @Nullable Class<T> payloadClass,
+	<T> Optional<Message<T>> receive(@Nullable String endpointName, @Nullable Class<T> payloadClass,
 			@Nullable Duration pollTimeout, @Nullable Map<String, Object> additionalHeaders);
 
 	/**
 	 * Receive a batch of messages from the default endpoint with default settings.
 	 * @return The messages, or an empty collection if none is returned.
 	 */
-	Collection<Message<T>> receiveMany();
+	<T> Collection<Message<T>> receiveMany();
 
 	/**
 	 * Receive a message from the provided endpoint and convert the payload to the provided class. If no message is
@@ -114,7 +114,7 @@ public interface MessagingOperations<T> {
 	 * @return the messages, or {@link Optional#empty()} if none is returned.
 	 */
 	// @formatter:off
-	Collection<Message<T>> receiveMany(@Nullable String endpointName,
+	<T> Collection<Message<T>> receiveMany(@Nullable String endpointName,
 									   @Nullable Class<T> payloadClass,
 									   @Nullable Duration pollTimeout,
 									   @Nullable Integer maxNumberOfMessages,

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
@@ -1,18 +1,31 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.operations;
-
-import org.springframework.lang.Nullable;
-import org.springframework.messaging.Message;
 
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
 
 /**
- * Synchronous messaging operations.
- * Implementations should have defaults for {@link Nullable} fields,
- * and can provide chained methods interfaces to provide a more fluent API.
+ * Synchronous messaging operations. Implementations should have defaults for {@link Nullable} fields, and can provide
+ * chained methods interfaces to provide a more fluent API.
  *
  * @author Tomaz Fernandes
  * @since 3.0
@@ -20,8 +33,8 @@ import java.util.UUID;
 public interface MessagingOperations<T> {
 
 	/**
-	 * Send a {@link Message} to the default endpoint with the provided payload.
-	 * The payload will be serialized if necessary.
+	 * Send a {@link Message} to the default endpoint with the provided payload. The payload will be serialized if
+	 * necessary.
 	 *
 	 * @param payload the payload to send.
 	 * @return The message's {@link UUID}.
@@ -29,8 +42,7 @@ public interface MessagingOperations<T> {
 	SendResult<T> send(T payload);
 
 	/**
-	 * Send a message to the provided endpoint with the provided payload.
-	 * The payload will be serialized if necessary.
+	 * Send a message to the provided endpoint with the provided payload. The payload will be serialized if necessary.
 	 *
 	 * @param endpointName the endpoint to send the message to.
 	 * @param payload the payload to send.
@@ -39,9 +51,8 @@ public interface MessagingOperations<T> {
 	SendResult<T> send(@Nullable String endpointName, T payload);
 
 	/**
-	 * Send the provided message along with its headers to the provided endpoint.
-	 * The payload will be serialized if necessary, and headers will be converted
-	 * to the specific messaging system metadata types.
+	 * Send the provided message along with its headers to the provided endpoint. The payload will be serialized if
+	 * necessary, and headers will be converted to the specific messaging system metadata types.
 	 *
 	 * @param endpointName the endpoint to send the message to.
 	 * @param message the message to be sent.
@@ -50,9 +61,8 @@ public interface MessagingOperations<T> {
 	SendResult<T> send(@Nullable String endpointName, Message<T> message);
 
 	/**
-	 * Send the provided messages along with their headers to the provided endpoint.
-	 * The payloads will be serialized if necessary, and headers will be converted
-	 * to the specific messaging system metadata types.
+	 * Send the provided messages along with their headers to the provided endpoint. The payloads will be serialized if
+	 * necessary, and headers will be converted to the specific messaging system metadata types.
 	 *
 	 * @param endpointName the endpoint to send the messages to.
 	 * @param messages the messages to be sent.
@@ -67,15 +77,12 @@ public interface MessagingOperations<T> {
 	Optional<Message<T>> receive();
 
 	/**
-	 * Receive a message from the provided endpoint and convert the payload to the
-	 * provided class. If no message is returned after the specified {@link Duration},
-	 * an {@link Optional#empty()} is returned.
+	 * Receive a message from the provided endpoint and convert the payload to the provided class. If no message is
+	 * returned after the specified {@link Duration}, an {@link Optional#empty()} is returned.
 	 * <p>
-	 * Any headers provided in the additional headers parameter will be added to the
-	 * {@link Message} instances returned by this method.
-	 * The implementation can also allow some specific headers to change particular settings,
-	 * in which case the headers are removed before sending.
-	 * See the implementation javadocs for more information.
+	 * Any headers provided in the additional headers parameter will be added to the {@link Message} instances returned
+	 * by this method. The implementation can also allow some specific headers to change particular settings, in which
+	 * case the headers are removed before sending. See the implementation javadocs for more information.
 	 *
 	 * @param endpointName the endpoint from which to receive the messages.
 	 * @param payloadClass the class to which the payload should be converted to.
@@ -83,10 +90,8 @@ public interface MessagingOperations<T> {
 	 * @param additionalHeaders headers to be added to the received messages.
 	 * @return the message, or {@link Optional#empty()} if none is returned.
 	 */
-	Optional<Message<T>> receive(@Nullable String endpointName,
-								 @Nullable Class<T> payloadClass,
-								 @Nullable Duration pollTimeout,
-								 @Nullable Map<String, Object> additionalHeaders);
+	Optional<Message<T>> receive(@Nullable String endpointName, @Nullable Class<T> payloadClass,
+			@Nullable Duration pollTimeout, @Nullable Map<String, Object> additionalHeaders);
 
 	/**
 	 * Receive a batch of messages from the default endpoint with default settings.
@@ -95,15 +100,12 @@ public interface MessagingOperations<T> {
 	Collection<Message<T>> receiveMany();
 
 	/**
-	 * Receive a message from the provided endpoint and convert the payload to the
-	 * provided class. If no message is returned after the specified {@link Duration},
-	 * an {@link Optional#empty()} is returned.
+	 * Receive a message from the provided endpoint and convert the payload to the provided class. If no message is
+	 * returned after the specified {@link Duration}, an {@link Optional#empty()} is returned.
 	 * <p>
-	 * Any headers provided in the additional headers parameter will be added to the
-	 * {@link Message} instances returned by this method.
-	 * The implementation can also allow some specific headers to change particular settings,
-	 * in which case the headers are removed before sending.
-	 * See the implementation javadocs for more information.
+	 * Any headers provided in the additional headers parameter will be added to the {@link Message} instances returned
+	 * by this method. The implementation can also allow some specific headers to change particular settings, in which
+	 * case the headers are removed before sending. See the implementation javadocs for more information.
 	 *
 	 * @param endpointName the endpoint from which to receive the messages.
 	 * @param payloadClass the class to which the payloads should be converted to.
@@ -111,10 +113,8 @@ public interface MessagingOperations<T> {
 	 * @param additionalHeaders headers to be added to the received messages.
 	 * @return the messages, or {@link Optional#empty()} if none is returned.
 	 */
-	Collection<Message<T>> receiveMany(@Nullable String endpointName,
-									   @Nullable Class<T> payloadClass,
-									   @Nullable Duration pollTimeout,
-									   @Nullable Integer maxNumberOfMessages,
-									   @Nullable Map<String, Object> additionalHeaders);
+	Collection<Message<T>> receiveMany(@Nullable String endpointName, @Nullable Class<T> payloadClass,
+			@Nullable Duration pollTimeout, @Nullable Integer maxNumberOfMessages,
+			@Nullable Map<String, Object> additionalHeaders);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
@@ -15,9 +15,7 @@
  */
 package io.awspring.cloud.sqs.operations;
 
-import java.time.Duration;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.lang.Nullable;
@@ -48,7 +46,7 @@ public interface MessagingOperations {
 	 * @param payload the payload to send.
 	 * @return The message's {@link UUID}.
 	 */
-	<T> SendResult<T> send(@Nullable String queue, T payload);
+	<T> SendResult<T> send(String queue, T payload);
 
 	/**
 	 * Send the provided message along with its headers to the provided queue. The payload will be serialized if
@@ -58,7 +56,7 @@ public interface MessagingOperations {
 	 * @param message the message to be sent.
 	 * @return The message's {@link UUID}.
 	 */
-	<T> SendResult<T> send(@Nullable String queue, Message<T> message);
+	<T> SendResult<T> send(String queue, Message<T> message);
 
 	/**
 	 * Send the provided messages along with their headers to the provided queue. The payloads will be serialized if
@@ -68,57 +66,30 @@ public interface MessagingOperations {
 	 * @param messages the messages to be sent.
 	 * @return The message's {@link UUID}.
 	 */
-	<T> SendResult.Batch<T> sendMany(@Nullable String queue, Collection<Message<T>> messages);
+	<T> SendResult.Batch<T> sendMany(String queue, Collection<Message<T>> messages);
 
 	/**
 	 * Receive a message from the default queue with default settings.
 	 * @return the message or {@link Optional#empty()} if none is returned.
 	 */
-	<T> Optional<Message<T>> receive();
+	Optional<Message<?>> receive();
 
 	/**
-	 * Receive a message from the provided queue and convert the payload to the provided class. If no message is
-	 * returned after the specified {@link Duration}, an {@link Optional#empty()} is returned.
-	 * <p>
-	 * Any headers provided in the additional headers parameter will be added to the {@link Message} instances returned
-	 * by this method. The implementation can also allow some specific headers to change particular settings, in which
-	 * case the headers are removed before sending. See the implementation javadocs for more information.
-	 *
-	 * @param queue the queue from which to receive the messages.
-	 * @param payloadClass the class to which the payload should be converted to.
-	 * @param pollTimeout the maximum amount of time to wait for messages.
-	 * @param additionalHeaders headers to be added to the received messages.
-	 * @return the message, or {@link Optional#empty()} if none is returned.
+	 * Receive a message from the default queue with default settings.
+	 * @return the message or {@link Optional#empty()} if none is returned.
 	 */
-	<T> Optional<Message<T>> receive(@Nullable String queue, @Nullable Class<T> payloadClass,
-			@Nullable Duration pollTimeout, @Nullable Map<String, Object> additionalHeaders);
+	<T> Optional<Message<T>> receive(String queue, Class<T> payloadClass);
 
 	/**
 	 * Receive a batch of messages from the default queue with default settings.
 	 * @return The messages, or an empty collection if none is returned.
 	 */
-	<T> Collection<Message<T>> receiveMany();
+	Collection<Message<?>> receiveMany();
 
 	/**
-	 * Receive a message from the provided queue and convert the payload to the provided class. If no message is
-	 * returned after the specified {@link Duration}, an {@link Optional#empty()} is returned.
-	 * <p>
-	 * Any headers provided in the additional headers parameter will be added to the {@link Message} instances returned
-	 * by this method. The implementation can also allow some specific headers to change particular settings, in which
-	 * case the headers are removed before sending. See the implementation javadocs for more information.
-	 *
-	 * @param queue the queue from which to receive the messages.
-	 * @param payloadClass the class to which the payloads should be converted to.
-	 * @param pollTimeout the maximum amount of time to wait for messages.
-	 * @param additionalHeaders headers to be added to the received messages.
-	 * @return the messages, or {@link Optional#empty()} if none is returned.
+	 * Receive a batch of messages from the default queue with default settings.
+	 * @return The messages, or an empty collection if none is returned.
 	 */
-	// @formatter:off
-	<T> Collection<Message<T>> receiveMany(@Nullable String queue,
-									   @Nullable Class<T> payloadClass,
-									   @Nullable Duration pollTimeout,
-									   @Nullable Integer maxNumberOfMessages,
-									   @Nullable Map<String, Object> additionalHeaders);
-	// @formatter:on
+	<T> Collection<Message<T>> receiveMany(String queue, Class<T> payloadClass);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java
@@ -8,30 +8,110 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 /**
+ * Synchronous messaging operations.
+ * Implementations should have defaults for {@link Nullable} fields,
+ * and can provide chained methods interfaces to provide a more fluent API.
+ *
  * @author Tomaz Fernandes
  * @since 3.0
  */
 public interface MessagingOperations<T, R> {
 
+	/**
+	 * Send a {@link Message} to the default endpoint with the provided payload.
+	 * The payload will be serialized if necessary.
+	 *
+	 * @param payload the payload to send.
+	 * @return The message's {@link UUID}.
+	 */
 	UUID send(T payload);
 
+	/**
+	 * Send a message to the provided endpoint with the provided payload.
+	 * The payload will be serialized if necessary.
+	 *
+	 * @param endpointName the endpoint to send the message to.
+	 * @param payload the payload to send.
+	 * @return The message's {@link UUID}.
+	 */
 	UUID send(@Nullable String endpointName, T payload);
 
+	/**
+	 * Send the provided message along with its headers to the provided endpoint.
+	 * The payload will be serialized if necessary, and headers will be converted
+	 * to the specific messaging system metadata types.
+	 *
+	 * @param endpointName the endpoint to send the message to.
+	 * @param message the message to be sent.
+	 * @return The message's {@link UUID}.
+	 */
 	UUID send(@Nullable String endpointName, Message<T> message);
 
+	/**
+	 * Send the provided messages along with their headers to the provided endpoint.
+	 * The payloads will be serialized if necessary, and headers will be converted
+	 * to the specific messaging system metadata types.
+	 *
+	 * @param endpointName the endpoint to send the messages to.
+	 * @param messages the messages to be sent.
+	 * @return The message's {@link UUID}.
+	 */
 	R send(@Nullable String endpointName, Collection<Message<T>> messages);
 
+	/**
+	 * Receive a message from the default endpoint with default settings.
+	 * @return the message or {@link Optional#empty()} if none is returned.
+	 */
 	Optional<Message<T>> receive();
 
+	/**
+	 * Receive a message from the provided endpoint and convert the payload to the
+	 * provided class. If no message is returned after the specified {@link Duration},
+	 * an {@link Optional#empty()} is returned.
+	 * <p>
+	 * Any headers provided in the additional headers parameter will be added to the
+	 * {@link Message} instances returned by this method.
+	 * The implementation can also allow some specific headers to change particular settings,
+	 * in which case the headers are removed before sending.
+	 * See the implementation javadocs for more information.
+	 *
+	 * @param endpointName the endpoint from which to receive the messages.
+	 * @param payloadClass the class to which the payload should be converted to.
+	 * @param pollTimeout the maximum amount of time to wait for messages.
+	 * @param additionalHeaders headers to be added to the received messages.
+	 * @return the message, or {@link Optional#empty()} if none is returned.
+	 */
 	Optional<Message<T>> receive(@Nullable String endpointName,
 								 @Nullable Class<T> payloadClass,
 								 @Nullable Duration pollTimeout,
 								 @Nullable Map<String, Object> additionalHeaders);
 
+	/**
+	 * Receive a batch of messages from the default endpoint with default settings.
+	 * @return The messages, or an empty collection if none is returned.
+	 */
 	Collection<Message<T>> receiveMany();
 
+	/**
+	 * Receive a message from the provided endpoint and convert the payload to the
+	 * provided class. If no message is returned after the specified {@link Duration},
+	 * an {@link Optional#empty()} is returned.
+	 * <p>
+	 * Any headers provided in the additional headers parameter will be added to the
+	 * {@link Message} instances returned by this method.
+	 * The implementation can also allow some specific headers to change particular settings,
+	 * in which case the headers are removed before sending.
+	 * See the implementation javadocs for more information.
+	 *
+	 * @param endpointName the endpoint from which to receive the messages.
+	 * @param payloadClass the class to which the payloads should be converted to.
+	 * @param pollTimeout the maximum amount of time to wait for messages.
+	 * @param additionalHeaders headers to be added to the received messages.
+	 * @return the messages, or {@link Optional#empty()} if none is returned.
+	 */
 	Collection<Message<T>> receiveMany(@Nullable String endpointName,
 									   @Nullable Class<T> payloadClass,
 									   @Nullable Duration pollTimeout,

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingTemplateOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingTemplateOptions.java
@@ -60,14 +60,6 @@ public interface MessagingTemplateOptions<O extends MessagingTemplateOptions<O>>
 	O defaultMaxNumberOfMessages(Integer defaultMaxNumberOfMessages);
 
 	/**
-	 * Set the default endpoint for this template. Default is blank.
-	 *
-	 * @param defaultEndpointName the default endpoint.
-	 * @return the options instance.
-	 */
-	O defaultEndpointName(String defaultEndpointName);
-
-	/**
 	 * The default class to which this template should convert payloads to.
 	 *
 	 * @param defaultPayloadClass the default payload class.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingTemplateOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingTemplateOptions.java
@@ -21,10 +21,9 @@ import java.util.Map;
 /**
  * Options to be used by the template.
  *
- * @param <T> the payload type.
  * @param <O> the options subclass to be returned by the chained methods.
  */
-public interface MessagingTemplateOptions<T, O extends MessagingTemplateOptions<T, O>> {
+public interface MessagingTemplateOptions<O extends MessagingTemplateOptions<O>> {
 
 	/**
 	 * Set the acknowledgement mode for this template. Default is {@link TemplateAcknowledgementMode#ACKNOWLEDGE}
@@ -74,7 +73,7 @@ public interface MessagingTemplateOptions<T, O extends MessagingTemplateOptions<
 	 * @param defaultPayloadClass the default payload class.
 	 * @return the options instance.
 	 */
-	O defaultPayloadClass(Class<T> defaultPayloadClass);
+	O defaultPayloadClass(Class<?> defaultPayloadClass);
 
 	/**
 	 * Set a default header to be added to received messages.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingTemplateOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingTemplateOptions.java
@@ -60,9 +60,9 @@ public interface MessagingTemplateOptions<O extends MessagingTemplateOptions<O>>
 	O defaultMaxNumberOfMessages(Integer defaultMaxNumberOfMessages);
 
 	/**
-	 * Set the default endpoint name for this template. Default is blank.
+	 * Set the default endpoint for this template. Default is blank.
 	 *
-	 * @param defaultEndpointName the default endpoint name.
+	 * @param defaultEndpointName the default endpoint.
 	 * @return the options instance.
 	 */
 	O defaultEndpointName(String defaultEndpointName);

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingTemplateOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingTemplateOptions.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.operations;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Options to be used by the template.
+ *
+ * @param <T> the payload type.
+ * @param <O> the options subclass to be returned by the chained methods.
+ */
+public interface MessagingTemplateOptions<T, O extends MessagingTemplateOptions<T, O>> {
+
+	/**
+	 * Set the acknowledgement mode for this template. Default is {@link TemplateAcknowledgementMode#ACKNOWLEDGE}
+	 *
+	 * @param acknowledgementMode the mode.
+	 * @return the options instance.
+	 */
+	O acknowledgementMode(TemplateAcknowledgementMode acknowledgementMode);
+
+	/**
+	 * Set the strategy to use when handling batch send operations with at least one failed message. Default is
+	 * {@link SendBatchFailureHandlingStrategy#THROW}
+	 *
+	 * @param sendBatchFailureHandlingStrategy the strategy.
+	 * @return the options instance.
+	 */
+	O sendBatchFailureHandlingStrategy(SendBatchFailureHandlingStrategy sendBatchFailureHandlingStrategy);
+
+	/**
+	 * Set the default maximum amount of time this template will wait for the maximum number of messages before
+	 * returning. Default is 10 seconds.
+	 *
+	 * @param defaultPollTimeout the timeout.
+	 * @return the options instance.
+	 */
+	O defaultPollTimeout(Duration defaultPollTimeout);
+
+	/**
+	 * Set the default maximum number of messages to be retrieved in a single batch. Default is 10.
+	 *
+	 * @param defaultMaxNumberOfMessages the maximum number of messages.
+	 * @return the options instance.
+	 */
+	O defaultMaxNumberOfMessages(Integer defaultMaxNumberOfMessages);
+
+	/**
+	 * Set the default endpoint name for this template. Default is blank.
+	 *
+	 * @param defaultEndpointName the default endpoint name.
+	 * @return the options instance.
+	 */
+	O defaultEndpointName(String defaultEndpointName);
+
+	/**
+	 * The default class to which this template should convert payloads to.
+	 *
+	 * @param defaultPayloadClass the default payload class.
+	 * @return the options instance.
+	 */
+	O defaultPayloadClass(Class<T> defaultPayloadClass);
+
+	/**
+	 * Set a default header to be added to received messages.
+	 *
+	 * @param name the header name.
+	 * @param value the header value.
+	 * @return the options instance.
+	 */
+	O additionalHeaderForReceive(String name, Object value);
+
+	/**
+	 * Set default headers to be added to received messages.
+	 *
+	 * @param defaultAdditionalHeaders the headers.
+	 * @return the options instance.
+	 */
+	O additionalHeadersForReceive(Map<String, Object> defaultAdditionalHeaders);
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendBatchFailureHandlingStrategy.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendBatchFailureHandlingStrategy.java
@@ -15,28 +15,23 @@
  */
 package io.awspring.cloud.sqs.operations;
 
-import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement;
-
 /**
- * Acknowledgement modes to be used by a {@link org.springframework.messaging.core.MessageReceivingOperations}
- * implementation.
+ * The strategy to use when handling a send batch operation that has at least one failed message.
  *
  * @author Tomaz Fernandes
  * @since 3.0
  */
-public enum TemplateAcknowledgementMode {
+public enum SendBatchFailureHandlingStrategy {
 
 	/**
-	 * Don't acknowledge messages automatically. The message or messages can be acknowledged later with
-	 * {@link io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement#acknowledge} or
-	 * {@link Acknowledgement#acknowledgeAsync()}
+	 * Throw a {@link SendBatchOperationFailedException} containing a {@link SendResult.Batch} object. This is the
+	 * default strategy.
 	 */
-	MANUAL,
+	THROW,
 
 	/**
-	 * Acknowledge received messages. Any exceptions that might occur in the acknowledging process are wrapped and
-	 * rethrown.
+	 * Do not throw an exception and return the {@link SendResult.Batch} object directly.
 	 */
-	ACKNOWLEDGE
+	DO_NOT_THROW
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendBatchFailureStrategy.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendBatchFailureStrategy.java
@@ -6,7 +6,7 @@ package io.awspring.cloud.sqs.operations;
  * @author Tomaz Fernandes
  * @since 3.0
  */
-public enum SendBatchOperationFailureStrategy {
+public enum SendBatchFailureStrategy {
 
 	/**
 	 * Throw a {@link SendBatchOperationFailedException} with a {@link SendResult.Batch} object.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendBatchFailureStrategy.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendBatchFailureStrategy.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.operations;
 
 /**

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendBatchOperationFailedException.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendBatchOperationFailedException.java
@@ -31,7 +31,7 @@ public class SendBatchOperationFailedException extends MessagingOperationFailedE
 	 */
 	public SendBatchOperationFailedException(String msg, String endpoint, SendResult.Batch<?> sendBatchResult,
 											 @Nullable Throwable cause) {
-		super(msg, endpoint, sendBatchResult.failed().stream().map(result -> result.result().message()).toList(), cause);
+		super(msg, endpoint, sendBatchResult.failed().stream().map(SendResult.Failed::message).toList(), cause);
 		this.sendBatchResult = sendBatchResult;
 	}
 
@@ -41,6 +41,16 @@ public class SendBatchOperationFailedException extends MessagingOperationFailedE
 	 */
 	public SendResult.Batch<?> getSendBatchResult() {
 		return this.sendBatchResult;
+	}
+
+	/**
+	 * Get the detailed result of the batch send attempt,
+	 * casting the result to the provided payload type.
+	 * @return the result.
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> SendResult.Batch<T> getSendBatchResult(Class<T> payloadClass) {
+		return (SendResult.Batch<T>) this.sendBatchResult;
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendBatchOperationFailedException.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendBatchOperationFailedException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.operations;
 
 import org.springframework.lang.Nullable;
@@ -30,7 +45,7 @@ public class SendBatchOperationFailedException extends MessagingOperationFailedE
 	 * @param cause the exception cause.
 	 */
 	public SendBatchOperationFailedException(String msg, String endpoint, SendResult.Batch<?> sendBatchResult,
-											 @Nullable Throwable cause) {
+			@Nullable Throwable cause) {
 		super(msg, endpoint, sendBatchResult.failed().stream().map(SendResult.Failed::message).toList(), cause);
 		this.sendBatchResult = sendBatchResult;
 	}
@@ -44,8 +59,7 @@ public class SendBatchOperationFailedException extends MessagingOperationFailedE
 	}
 
 	/**
-	 * Get the detailed result of the batch send attempt,
-	 * casting the result to the provided payload type.
+	 * Get the detailed result of the batch send attempt, casting the result to the provided payload type.
 	 * @return the result.
 	 */
 	@SuppressWarnings("unchecked")

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendBatchOperationFailedException.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendBatchOperationFailedException.java
@@ -1,0 +1,46 @@
+package io.awspring.cloud.sqs.operations;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Exception representing a partial or complete failure in sending a batch of messages to an endpoint.
+ *
+ * @author Tomaz Fernandes
+ * @since 3.0
+ */
+public class SendBatchOperationFailedException extends MessagingOperationFailedException {
+
+	private final SendResult.Batch<?> sendBatchResult;
+
+	/**
+	 * Create an instance with the provided arguments.
+	 * @param msg the error message.
+	 * @param endpoint the endpoint to which the messages were sent to.
+	 * @param sendBatchResult the detailed result of the batch send attempt..
+	 */
+	public SendBatchOperationFailedException(String msg, String endpoint, SendResult.Batch<?> sendBatchResult) {
+		this(msg, endpoint, sendBatchResult, null);
+	}
+
+	/**
+	 * Create an instance with the provided arguments.
+	 * @param msg the error message.
+	 * @param endpoint the endpoint to which the messages were sent to.
+	 * @param sendBatchResult the detailed result of the send message.
+	 * @param cause the exception cause.
+	 */
+	public SendBatchOperationFailedException(String msg, String endpoint, SendResult.Batch<?> sendBatchResult,
+											 @Nullable Throwable cause) {
+		super(msg, endpoint, sendBatchResult.failed().stream().map(result -> result.result().message()).toList(), cause);
+		this.sendBatchResult = sendBatchResult;
+	}
+
+	/**
+	 * Get the detailed result of the batch send attempt.
+	 * @return the result.
+	 */
+	public SendResult.Batch<?> getSendBatchResult() {
+		return this.sendBatchResult;
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendBatchOperationFailureStrategy.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendBatchOperationFailureStrategy.java
@@ -1,0 +1,21 @@
+package io.awspring.cloud.sqs.operations;
+
+/**
+ * The strategy to use when handling a send batch operation that has at least one failed message.
+ *
+ * @author Tomaz Fernandes
+ * @since 3.0
+ */
+public enum SendBatchOperationFailureStrategy {
+
+	/**
+	 * Throw a {@link SendBatchOperationFailedException} with a {@link SendResult.Batch} object.
+	 */
+	THROW_EXCEPTION,
+
+	/**
+	 * Do not throw an exception and return the {@link SendResult.Batch} object directly.
+	 */
+	RETURN_RESULT
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendResult.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendResult.java
@@ -1,0 +1,33 @@
+package io.awspring.cloud.sqs.operations;
+
+import org.springframework.messaging.Message;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * The result of a send operation.
+ * @param messageId the message id as returned by the endpoint.
+ * @param message the message.
+ * @param additionalInformation additional information on the send operation.
+ * @param <T> the message payload type.
+ */
+public record SendResult<T>(UUID messageId, String endpoint, Message<T> message, Map<String, Object> additionalInformation) {
+
+	/**
+	 * The result of a batch send operation.
+	 * @param successful the {@link SendResult} for messages successfully sent.
+	 * @param failed the {@link SendResult} for messages that failed to be sent.
+	 * @param <T> the message payload type.
+	 */
+	public record Batch<T>(Collection<SendResult<T>> successful, Collection<SendResult.Failed<T>> failed) {}
+
+	/**
+	 * The result of a failed send operation.
+	 * @param errorMessage a message with information on the error.
+	 * @param <T> the message payload type.
+	 */
+	public record Failed<T> (String errorMessage, SendResult<T> result) {}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendResult.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SendResult.java
@@ -8,8 +8,8 @@ import java.util.UUID;
 
 /**
  * The result of a send operation.
- * @param messageId the message id as returned by the endpoint.
- * @param message the message.
+ * @param messageId the message id as returned by the endpoint if successful, the id from the original {@link Message} if failed.
+ * @param message the message that was sent, with any additional headers added by the framework.
  * @param additionalInformation additional information on the send operation.
  * @param <T> the message payload type.
  */
@@ -28,6 +28,6 @@ public record SendResult<T>(UUID messageId, String endpoint, Message<T> message,
 	 * @param errorMessage a message with information on the error.
 	 * @param <T> the message payload type.
 	 */
-	public record Failed<T> (String errorMessage, SendResult<T> result) {}
+	public record Failed<T> (String errorMessage, String endpoint, Message<T> message, Map<String, Object> additionalInformation) {}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
@@ -10,22 +10,69 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 /**
+ * Sqs-specific asynchronous messaging operations for Standard and Fifo queues.
+ * <p>
+ * Note that the Standard queue methods can be used for Fifo queues
+ * as long as necessary headers are added for required attributes such
+ * as message deduplication id.
+ * See {@link io.awspring.cloud.sqs.listener.SqsHeaders} for reference
+ * of available headers.
+ * <p>
+ * Fifo queue methods accept the required attributes and add a random value
+ * if none is specified.
+ * 
  * @author Tomaz Fernandes
  * @since 3.0
- * @param <T>
+ * @param <T> the message payload type, or {@link Object}.
  */
 public interface SqsAsyncOperations<T> extends AsyncMessagingOperations<T, SendMessageBatchResponse> {
 
+	/**
+	 * Send a message to a Standard SQS queue using the {@link SqsSendOptions.Standard} options.
+	 * @param to a {@link SqsSendOptions.Standard} consumer.
+	 * @return a {@link CompletableFuture} to be completed with the {@link UUID} of the message.
+	 */
 	CompletableFuture<UUID> sendAsync(Consumer<SqsSendOptions.Standard<T>> to);
 
+	/**
+	 * Send a message to a Fifo SQS queue using the {@link SqsSendOptions.Fifo} options.
+	 * @param to a {@link SqsSendOptions.Fifo} consumer.
+	 * @return a {@link CompletableFuture} to be completed with the {@link UUID} of the message.
+	 */
 	CompletableFuture<UUID> sendFifoAsync(Consumer<SqsSendOptions.Fifo<T>> to);
 
+	/**
+	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.
+	 * @param from a {@link SqsReceiveOptions.Standard} consumer.
+	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()}
+	 * if none is returned.
+	 */
 	CompletableFuture<Optional<Message<T>>> receiveAsync(Consumer<SqsReceiveOptions.Standard<T>> from);
 
+	/**
+	 * Receive a message from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo} options.
+	 * @param from a {@link SqsReceiveOptions.Fifo} consumer.
+	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()}
+	 * if none is returned.
+	 */
 	CompletableFuture<Optional<Message<T>>> receiveFifoAsync(Consumer<SqsReceiveOptions.Fifo<T>> from);
 
+	/**
+	 * Receive a batch of messages from a Standard SQS queue using the {@link SqsReceiveOptions.Standard}
+	 * options.
+	 * @param from a {@link SqsReceiveOptions.Standard} consumer.
+	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection
+	 * if none is returned.
+	 */
 	CompletableFuture<Collection<Message<T>>> receiveManyAsync(Consumer<SqsReceiveOptions.Standard<T>> from);
 
+	/**
+	 * Receive a batch of messages from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo}
+	 * options.
+	 * @param from a {@link SqsReceiveOptions.Fifo} consumer.
+	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection
+	 * if none is returned.
+	 */
 	CompletableFuture<Collection<Message<T>>> receiveManyFifoAsync(Consumer<SqsReceiveOptions.Fifo<T>> from);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
@@ -24,13 +24,7 @@ import org.springframework.messaging.Message;
 
 /**
  * Sqs-specific asynchronous messaging operations for Standard and Fifo queues.
- * <p>
- * Note that the Standard queue methods can be used for Fifo queues as long as necessary headers are added for required
- * attributes such as message deduplication id. See {@link io.awspring.cloud.sqs.listener.SqsHeaders} for reference of
- * available headers.
- * <p>
- * Fifo queue methods accept the required attributes and add a random value if none is specified.
- * 
+ *
  * @author Tomaz Fernandes
  * @since 3.0
  */
@@ -49,7 +43,15 @@ public interface SqsAsyncOperations extends AsyncMessagingOperations {
 	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
 	 * returned.
 	 */
-	<T> CompletableFuture<Optional<Message<T>>> receiveAsync(Consumer<SqsReceiveOptions<T>> from);
+	CompletableFuture<Optional<Message<?>>> receiveAsync(Consumer<SqsReceiveOptions> from);
+
+	/**
+	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions} options.
+	 * @param from a {@link SqsReceiveOptions} consumer.
+	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
+	 * returned.
+	 */
+	<T> CompletableFuture<Optional<Message<T>>> receiveAsync(Consumer<SqsReceiveOptions> from, Class<T> payloadClass);
 
 	/**
 	 * Receive a batch of messages from a Standard SQS queue using the {@link SqsReceiveOptions} options.
@@ -57,6 +59,15 @@ public interface SqsAsyncOperations extends AsyncMessagingOperations {
 	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
 	 * returned.
 	 */
-	<T> CompletableFuture<Collection<Message<T>>> receiveManyAsync(Consumer<SqsReceiveOptions<T>> from);
+	CompletableFuture<Collection<Message<?>>> receiveManyAsync(Consumer<SqsReceiveOptions> from);
+
+	/**
+	 * Receive a batch of messages from a Standard SQS queue using the {@link SqsReceiveOptions} options.
+	 * @param from a {@link SqsReceiveOptions} consumer.
+	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
+	 * returned.
+	 */
+	<T> CompletableFuture<Collection<Message<T>>> receiveManyAsync(Consumer<SqsReceiveOptions> from,
+			Class<T> payloadClass);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
@@ -1,0 +1,31 @@
+package io.awspring.cloud.sqs.operations;
+
+import org.springframework.messaging.Message;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 3.0
+ * @param <T>
+ */
+public interface SqsAsyncOperations<T> extends AsyncMessagingOperations<T, SendMessageBatchResponse> {
+
+	CompletableFuture<UUID> sendAsync(Consumer<SqsSendOptions.Standard<T>> to);
+
+	CompletableFuture<UUID> sendFifoAsync(Consumer<SqsSendOptions.Fifo<T>> to);
+
+	CompletableFuture<Optional<Message<T>>> receiveAsync(Consumer<SqsReceiveOptions.Standard<T>> from);
+
+	CompletableFuture<Optional<Message<T>>> receiveFifoAsync(Consumer<SqsReceiveOptions.Fifo<T>> from);
+
+	CompletableFuture<Collection<Message<T>>> receiveManyAsync(Consumer<SqsReceiveOptions.Standard<T>> from);
+
+	CompletableFuture<Collection<Message<T>>> receiveManyFifoAsync(Consumer<SqsReceiveOptions.Fifo<T>> from);
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
@@ -20,9 +20,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
-import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 
 /**
  * Sqs-specific asynchronous messaging operations for Standard and Fifo queues.
@@ -39,57 +37,26 @@ import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 public interface SqsAsyncOperations extends AsyncMessagingOperations {
 
 	/**
-	 * Send a message to a Standard SQS queue using the {@link SqsSendOptions.Standard} options.
-	 * @param to a {@link SqsSendOptions.Standard} consumer.
+	 * Send a message to a Standard SQS queue using {@link SqsSendOptions}.
+	 * @param to a {@link SqsSendOptions} consumer.
 	 * @return a {@link CompletableFuture} to be completed with the {@link UUID} of the message.
 	 */
-	<T> CompletableFuture<SendResult<T>> sendAsync(Consumer<SqsSendOptions.Standard<T>> to);
+	<T> CompletableFuture<SendResult<T>> sendAsync(Consumer<SqsSendOptions<T>> to);
 
 	/**
-	 * Send a message to a Fifo SQS queue using the {@link SqsSendOptions.Fifo} options.
-	 * @param to a {@link SqsSendOptions.Fifo} consumer.
-	 * @return a {@link CompletableFuture} to be completed with the {@link UUID} of the message.
-	 */
-	<T> CompletableFuture<SendResult<T>> sendFifoAsync(Consumer<SqsSendOptions.Fifo<T>> to);
-
-	/**
-	 * Send a batch of messages to a Fifo SQS queue.
-	 * @param endpoint the endpoint to which to send the messages or null to use the default.
-	 * @param messages the messages.
-	 * @return a {@link CompletableFuture} to be completed with the {@link SendMessageBatchResponse}.
-	 */
-	<T> CompletableFuture<SendResult.Batch<T>> sendFifoAsync(@Nullable String endpoint, Collection<Message<T>> messages);
-
-	/**
-	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.
-	 * @param from a {@link SqsReceiveOptions.Standard} consumer.
+	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions} options.
+	 * @param from a {@link SqsReceiveOptions} consumer.
 	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
 	 * returned.
 	 */
-	<T> CompletableFuture<Optional<Message<T>>> receiveAsync(Consumer<SqsReceiveOptions.Standard<T>> from);
+	<T> CompletableFuture<Optional<Message<T>>> receiveAsync(Consumer<SqsReceiveOptions<T>> from);
 
 	/**
-	 * Receive a message from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo} options.
-	 * @param from a {@link SqsReceiveOptions.Fifo} consumer.
-	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
-	 * returned.
-	 */
-	<T> CompletableFuture<Optional<Message<T>>> receiveFifoAsync(Consumer<SqsReceiveOptions.Fifo<T>> from);
-
-	/**
-	 * Receive a batch of messages from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.
-	 * @param from a {@link SqsReceiveOptions.Standard} consumer.
+	 * Receive a batch of messages from a Standard SQS queue using the {@link SqsReceiveOptions} options.
+	 * @param from a {@link SqsReceiveOptions} consumer.
 	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
 	 * returned.
 	 */
-	<T> CompletableFuture<Collection<Message<T>>> receiveManyAsync(Consumer<SqsReceiveOptions.Standard<T>> from);
-
-	/**
-	 * Receive a batch of messages from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo} options.
-	 * @param from a {@link SqsReceiveOptions.Fifo} consumer.
-	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
-	 * returned.
-	 */
-	<T> CompletableFuture<Collection<Message<T>>> receiveManyFifoAsync(Consumer<SqsReceiveOptions.Fifo<T>> from);
+	<T> CompletableFuture<Collection<Message<T>>> receiveManyAsync(Consumer<SqsReceiveOptions<T>> from);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
@@ -1,26 +1,37 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.operations;
-
-import org.springframework.lang.Nullable;
-import org.springframework.messaging.Message;
-import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 
 /**
  * Sqs-specific asynchronous messaging operations for Standard and Fifo queues.
  * <p>
- * Note that the Standard queue methods can be used for Fifo queues
- * as long as necessary headers are added for required attributes such
- * as message deduplication id.
- * See {@link io.awspring.cloud.sqs.listener.SqsHeaders} for reference
- * of available headers.
+ * Note that the Standard queue methods can be used for Fifo queues as long as necessary headers are added for required
+ * attributes such as message deduplication id. See {@link io.awspring.cloud.sqs.listener.SqsHeaders} for reference of
+ * available headers.
  * <p>
- * Fifo queue methods accept the required attributes and add a random value
- * if none is specified.
+ * Fifo queue methods accept the required attributes and add a random value if none is specified.
  * 
  * @author Tomaz Fernandes
  * @since 3.0
@@ -53,34 +64,32 @@ public interface SqsAsyncOperations<T> extends AsyncMessagingOperations<T> {
 	/**
 	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.
 	 * @param from a {@link SqsReceiveOptions.Standard} consumer.
-	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()}
-	 * if none is returned.
+	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
+	 * returned.
 	 */
 	CompletableFuture<Optional<Message<T>>> receiveAsync(Consumer<SqsReceiveOptions.Standard<T>> from);
 
 	/**
 	 * Receive a message from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo} options.
 	 * @param from a {@link SqsReceiveOptions.Fifo} consumer.
-	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()}
-	 * if none is returned.
+	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
+	 * returned.
 	 */
 	CompletableFuture<Optional<Message<T>>> receiveFifoAsync(Consumer<SqsReceiveOptions.Fifo<T>> from);
 
 	/**
-	 * Receive a batch of messages from a Standard SQS queue using the {@link SqsReceiveOptions.Standard}
-	 * options.
+	 * Receive a batch of messages from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.
 	 * @param from a {@link SqsReceiveOptions.Standard} consumer.
-	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection
-	 * if none is returned.
+	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
+	 * returned.
 	 */
 	CompletableFuture<Collection<Message<T>>> receiveManyAsync(Consumer<SqsReceiveOptions.Standard<T>> from);
 
 	/**
-	 * Receive a batch of messages from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo}
-	 * options.
+	 * Receive a batch of messages from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo} options.
 	 * @param from a {@link SqsReceiveOptions.Fifo} consumer.
-	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection
-	 * if none is returned.
+	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
+	 * returned.
 	 */
 	CompletableFuture<Collection<Message<T>>> receiveManyFifoAsync(Consumer<SqsReceiveOptions.Fifo<T>> from);
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
@@ -26,21 +26,21 @@ import java.util.function.Consumer;
  * @since 3.0
  * @param <T> the message payload type, or {@link Object}.
  */
-public interface SqsAsyncOperations<T> extends AsyncMessagingOperations<T, SendMessageBatchResponse> {
+public interface SqsAsyncOperations<T> extends AsyncMessagingOperations<T> {
 
 	/**
 	 * Send a message to a Standard SQS queue using the {@link SqsSendOptions.Standard} options.
 	 * @param to a {@link SqsSendOptions.Standard} consumer.
 	 * @return a {@link CompletableFuture} to be completed with the {@link UUID} of the message.
 	 */
-	CompletableFuture<UUID> sendAsync(Consumer<SqsSendOptions.Standard<T>> to);
+	CompletableFuture<SendResult<T>> sendAsync(Consumer<SqsSendOptions.Standard<T>> to);
 
 	/**
 	 * Send a message to a Fifo SQS queue using the {@link SqsSendOptions.Fifo} options.
 	 * @param to a {@link SqsSendOptions.Fifo} consumer.
 	 * @return a {@link CompletableFuture} to be completed with the {@link UUID} of the message.
 	 */
-	CompletableFuture<UUID> sendFifoAsync(Consumer<SqsSendOptions.Fifo<T>> to);
+	CompletableFuture<SendResult<T>> sendFifoAsync(Consumer<SqsSendOptions.Fifo<T>> to);
 
 	/**
 	 * Send a batch of messages to a Fifo SQS queue.
@@ -48,7 +48,7 @@ public interface SqsAsyncOperations<T> extends AsyncMessagingOperations<T, SendM
 	 * @param messages the messages.
 	 * @return a {@link CompletableFuture} to be completed with the {@link SendMessageBatchResponse}.
 	 */
-	CompletableFuture<SendMessageBatchResponse> sendFifoAsync(@Nullable String endpoint, Collection<Message<T>> messages);
+	CompletableFuture<SendResult.Batch<T>> sendFifoAsync(@Nullable String endpoint, Collection<Message<T>> messages);
 
 	/**
 	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
@@ -1,5 +1,6 @@
 package io.awspring.cloud.sqs.operations;
 
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 
@@ -40,6 +41,14 @@ public interface SqsAsyncOperations<T> extends AsyncMessagingOperations<T, SendM
 	 * @return a {@link CompletableFuture} to be completed with the {@link UUID} of the message.
 	 */
 	CompletableFuture<UUID> sendFifoAsync(Consumer<SqsSendOptions.Fifo<T>> to);
+
+	/**
+	 * Send a batch of messages to a Fifo SQS queue.
+	 * @param endpoint the endpoint to which to send the messages or null to use the default.
+	 * @param messages the messages.
+	 * @return a {@link CompletableFuture} to be completed with the {@link SendMessageBatchResponse}.
+	 */
+	CompletableFuture<SendMessageBatchResponse> sendFifoAsync(@Nullable String endpoint, Collection<Message<T>> messages);
 
 	/**
 	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
@@ -31,14 +31,14 @@ import org.springframework.messaging.Message;
 public interface SqsAsyncOperations extends AsyncMessagingOperations {
 
 	/**
-	 * Send a message to a Standard SQS queue using {@link SqsSendOptions}.
+	 * Send a message using {@link SqsSendOptions}.
 	 * @param to a {@link SqsSendOptions} consumer.
 	 * @return a {@link CompletableFuture} to be completed with the {@link UUID} of the message.
 	 */
 	<T> CompletableFuture<SendResult<T>> sendAsync(Consumer<SqsSendOptions<T>> to);
 
 	/**
-	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions} options.
+	 * Receive a message using the {@link SqsReceiveOptions} options.
 	 * @param from a {@link SqsReceiveOptions} consumer.
 	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
 	 * returned.
@@ -46,7 +46,7 @@ public interface SqsAsyncOperations extends AsyncMessagingOperations {
 	CompletableFuture<Optional<Message<?>>> receiveAsync(Consumer<SqsReceiveOptions> from);
 
 	/**
-	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions} options.
+	 * Receive a message using the {@link SqsReceiveOptions} options and convert the payload to the provided class.
 	 * @param from a {@link SqsReceiveOptions} consumer.
 	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
 	 * returned.
@@ -54,7 +54,7 @@ public interface SqsAsyncOperations extends AsyncMessagingOperations {
 	<T> CompletableFuture<Optional<Message<T>>> receiveAsync(Consumer<SqsReceiveOptions> from, Class<T> payloadClass);
 
 	/**
-	 * Receive a batch of messages from a Standard SQS queue using the {@link SqsReceiveOptions} options.
+	 * Receive a batch of messages using the {@link SqsReceiveOptions} options.
 	 * @param from a {@link SqsReceiveOptions} consumer.
 	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
 	 * returned.
@@ -62,7 +62,8 @@ public interface SqsAsyncOperations extends AsyncMessagingOperations {
 	CompletableFuture<Collection<Message<?>>> receiveManyAsync(Consumer<SqsReceiveOptions> from);
 
 	/**
-	 * Receive a batch of messages from a Standard SQS queue using the {@link SqsReceiveOptions} options.
+	 * Receive a batch of messages using the {@link SqsReceiveOptions} options and convert the payloads to the provided
+	 * class.
 	 * @param from a {@link SqsReceiveOptions} consumer.
 	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
 	 * returned.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java
@@ -35,23 +35,22 @@ import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
  * 
  * @author Tomaz Fernandes
  * @since 3.0
- * @param <T> the message payload type, or {@link Object}.
  */
-public interface SqsAsyncOperations<T> extends AsyncMessagingOperations<T> {
+public interface SqsAsyncOperations extends AsyncMessagingOperations {
 
 	/**
 	 * Send a message to a Standard SQS queue using the {@link SqsSendOptions.Standard} options.
 	 * @param to a {@link SqsSendOptions.Standard} consumer.
 	 * @return a {@link CompletableFuture} to be completed with the {@link UUID} of the message.
 	 */
-	CompletableFuture<SendResult<T>> sendAsync(Consumer<SqsSendOptions.Standard<T>> to);
+	<T> CompletableFuture<SendResult<T>> sendAsync(Consumer<SqsSendOptions.Standard<T>> to);
 
 	/**
 	 * Send a message to a Fifo SQS queue using the {@link SqsSendOptions.Fifo} options.
 	 * @param to a {@link SqsSendOptions.Fifo} consumer.
 	 * @return a {@link CompletableFuture} to be completed with the {@link UUID} of the message.
 	 */
-	CompletableFuture<SendResult<T>> sendFifoAsync(Consumer<SqsSendOptions.Fifo<T>> to);
+	<T> CompletableFuture<SendResult<T>> sendFifoAsync(Consumer<SqsSendOptions.Fifo<T>> to);
 
 	/**
 	 * Send a batch of messages to a Fifo SQS queue.
@@ -59,7 +58,7 @@ public interface SqsAsyncOperations<T> extends AsyncMessagingOperations<T> {
 	 * @param messages the messages.
 	 * @return a {@link CompletableFuture} to be completed with the {@link SendMessageBatchResponse}.
 	 */
-	CompletableFuture<SendResult.Batch<T>> sendFifoAsync(@Nullable String endpoint, Collection<Message<T>> messages);
+	<T> CompletableFuture<SendResult.Batch<T>> sendFifoAsync(@Nullable String endpoint, Collection<Message<T>> messages);
 
 	/**
 	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.
@@ -67,7 +66,7 @@ public interface SqsAsyncOperations<T> extends AsyncMessagingOperations<T> {
 	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
 	 * returned.
 	 */
-	CompletableFuture<Optional<Message<T>>> receiveAsync(Consumer<SqsReceiveOptions.Standard<T>> from);
+	<T> CompletableFuture<Optional<Message<T>>> receiveAsync(Consumer<SqsReceiveOptions.Standard<T>> from);
 
 	/**
 	 * Receive a message from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo} options.
@@ -75,7 +74,7 @@ public interface SqsAsyncOperations<T> extends AsyncMessagingOperations<T> {
 	 * @return a {@link CompletableFuture} to be completed with the message, or {@link Optional#empty()} if none is
 	 * returned.
 	 */
-	CompletableFuture<Optional<Message<T>>> receiveFifoAsync(Consumer<SqsReceiveOptions.Fifo<T>> from);
+	<T> CompletableFuture<Optional<Message<T>>> receiveFifoAsync(Consumer<SqsReceiveOptions.Fifo<T>> from);
 
 	/**
 	 * Receive a batch of messages from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.
@@ -83,7 +82,7 @@ public interface SqsAsyncOperations<T> extends AsyncMessagingOperations<T> {
 	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
 	 * returned.
 	 */
-	CompletableFuture<Collection<Message<T>>> receiveManyAsync(Consumer<SqsReceiveOptions.Standard<T>> from);
+	<T> CompletableFuture<Collection<Message<T>>> receiveManyAsync(Consumer<SqsReceiveOptions.Standard<T>> from);
 
 	/**
 	 * Receive a batch of messages from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo} options.
@@ -91,6 +90,6 @@ public interface SqsAsyncOperations<T> extends AsyncMessagingOperations<T> {
 	 * @return a {@link CompletableFuture} to be completed with the messages, or an empty collection if none is
 	 * returned.
 	 */
-	CompletableFuture<Collection<Message<T>>> receiveManyFifoAsync(Consumer<SqsReceiveOptions.Fifo<T>> from);
+	<T> CompletableFuture<Collection<Message<T>>> receiveManyFifoAsync(Consumer<SqsReceiveOptions.Fifo<T>> from);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
@@ -30,35 +30,36 @@ import org.springframework.messaging.Message;
 public interface SqsOperations extends MessagingOperations {
 
 	/**
-	 * Send a message to a Standard SQS queue using the {@link SqsSendOptions} options.
+	 * Send a message using the {@link SqsSendOptions} options.
 	 * @param to a {@link SqsSendOptions} consumer.
 	 * @return The {@link UUID} of the message.
 	 */
 	<T> SendResult<T> send(Consumer<SqsSendOptions<T>> to);
 
 	/**
-	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions} options.
+	 * Receive a message using {@link SqsReceiveOptions}.
 	 * @param from a {@link SqsReceiveOptions} consumer.
 	 * @return The message, or an empty collection if none is returned.
 	 */
 	Optional<Message<?>> receive(Consumer<SqsReceiveOptions> from);
 
 	/**
-	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions} options.
+	 * Receive a message using {@link SqsReceiveOptions} and convert the payload to the provided class.
 	 * @param from a {@link SqsReceiveOptions} consumer.
+	 * @param payloadClass to class to convert the payload to.
 	 * @return The message, or an empty collection if none is returned.
 	 */
 	<T> Optional<Message<T>> receive(Consumer<SqsReceiveOptions> from, Class<T> payloadClass);
 
 	/**
-	 * Receive a batch of messages from a Standard SQS queue using {@link SqsReceiveOptions}.
+	 * Receive a batch of messages using {@link SqsReceiveOptions}.
 	 * @param from a {@link SqsReceiveOptions} consumer.
 	 * @return The message, or an empty collection if none is returned.
 	 */
 	Collection<Message<?>> receiveMany(Consumer<SqsReceiveOptions> from);
 
 	/**
-	 * Receive a batch of messages from a Standard SQS queue using {@link SqsReceiveOptions}.
+	 * Receive a batch of messages using {@link SqsReceiveOptions} and convert the payloads to the provided class.
 	 * @param from a {@link SqsReceiveOptions} consumer.
 	 * @return The message, or an empty collection if none is returned.
 	 */

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
@@ -1,0 +1,30 @@
+package io.awspring.cloud.sqs.operations;
+
+import org.springframework.messaging.Message;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 3.0
+ * @param <T>
+ */
+public interface SqsOperations<T> extends MessagingOperations<T, SendMessageBatchResponse> {
+
+	UUID send(Consumer<SqsSendOptions.Standard<T>> to);
+
+	UUID sendFifo(Consumer<SqsSendOptions.Fifo<T>> to);
+
+	Optional<Message<T>> receive(Consumer<SqsReceiveOptions.Standard<T>> from);
+
+	Optional<Message<T>> receiveFifo(Consumer<SqsReceiveOptions.Fifo<T>> from);
+
+	Collection<Message<T>> receiveMany(Consumer<SqsReceiveOptions.Standard<T>> from);
+
+	Collection<Message<T>> receiveManyFifo(Consumer<SqsReceiveOptions.Fifo<T>> from);
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
@@ -6,7 +6,6 @@ import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 /**
@@ -47,7 +46,7 @@ public interface SqsOperations<T> extends MessagingOperations<T> {
 	 * @param messages the messages.
 	 * @return the {@link SendMessageBatchResponse}
 	 */
-	SendResult.Batch<T> sendFifo(String endpoint, Collection<Message<T>> messages);
+	SendResult.Batch<T> sendManyFifo(String endpoint, Collection<Message<T>> messages);
 
 	/**
 	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
@@ -20,70 +20,33 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 import org.springframework.messaging.Message;
-import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 
 /**
  * Sqs-specific synchronous messaging operations for Standard and Fifo queues.
- * <p>
- * Note that the Standard queue methods can be used for Fifo queues as long as necessary headers are added for required
- * attributes such as message deduplication id. See {@link io.awspring.cloud.sqs.listener.SqsHeaders} for reference of
- * available headers.
- * <p>
- * Fifo queue methods accept the required attributes and add a random value if none is specified.
- *
  * @author Tomaz Fernandes
  * @since 3.0
  */
 public interface SqsOperations extends MessagingOperations {
 
 	/**
-	 * Send a message to a Standard SQS queue using the {@link SqsSendOptions.Standard} options.
-	 * @param to a {@link SqsSendOptions.Standard} consumer.
+	 * Send a message to a Standard SQS queue using the {@link SqsSendOptions} options.
+	 * @param to a {@link SqsSendOptions} consumer.
 	 * @return The {@link UUID} of the message.
 	 */
-	<T> SendResult<T> send(Consumer<SqsSendOptions.Standard<T>> to);
+	<T> SendResult<T> send(Consumer<SqsSendOptions<T>> to);
 
 	/**
-	 * Send a message to a Fifo SQS queue using the {@link SqsSendOptions.Fifo} options.
-	 * @param to a {@link SqsSendOptions.Fifo} consumer.
-	 * @return The {@link UUID} of the message.
-	 */
-	<T> SendResult<T> sendFifo(Consumer<SqsSendOptions.Fifo<T>> to);
-
-	/**
-	 * Send a batch of messages to a Fifo SQS queue.
-	 * @param endpoint the endpoint to which to send the messages.
-	 * @param messages the messages.
-	 * @return the {@link SendMessageBatchResponse}
-	 */
-	<T> SendResult.Batch<T> sendManyFifo(String endpoint, Collection<Message<T>> messages);
-
-	/**
-	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.
-	 * @param from a {@link SqsReceiveOptions.Standard} consumer.
+	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions} options.
+	 * @param from a {@link SqsReceiveOptions} consumer.
 	 * @return The message, or an empty collection if none is returned.
 	 */
-	<T> Optional<Message<T>> receive(Consumer<SqsReceiveOptions.Standard<T>> from);
+	<T> Optional<Message<T>> receive(Consumer<SqsReceiveOptions<T>> from);
 
 	/**
-	 * Receive a message from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo} options.
-	 * @param from a {@link SqsReceiveOptions.Fifo} consumer.
+	 * Receive a batch of messages from a Standard SQS queue using {@link SqsReceiveOptions}.
+	 * @param from a {@link SqsReceiveOptions} consumer.
 	 * @return The message, or an empty collection if none is returned.
 	 */
-	<T> Optional<Message<T>> receiveFifo(Consumer<SqsReceiveOptions.Fifo<T>> from);
-
-	/**
-	 * Receive a batch of messages from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.
-	 * @param from a {@link SqsReceiveOptions.Standard} consumer.
-	 * @return The message, or an empty collection if none is returned.
-	 */
-	<T> Collection<Message<T>> receiveMany(Consumer<SqsReceiveOptions.Standard<T>> from);
-
-	/**
-	 * Receive a batch of messages from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo} options.
-	 * @param from a {@link SqsReceiveOptions.Fifo} consumer.
-	 * @return The message, or an empty collection if none is returned.
-	 */
-	<T> Collection<Message<T>> receiveManyFifo(Consumer<SqsReceiveOptions.Fifo<T>> from);
+	<T> Collection<Message<T>> receiveMany(Consumer<SqsReceiveOptions<T>> from);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
@@ -23,23 +23,23 @@ import java.util.function.Consumer;
  *
  * @author Tomaz Fernandes
  * @since 3.0
- * @param <T>
+ * @param <T> the payload type
  */
-public interface SqsOperations<T> extends MessagingOperations<T, SendMessageBatchResponse> {
+public interface SqsOperations<T> extends MessagingOperations<T> {
 
 	/**
 	 * Send a message to a Standard SQS queue using the {@link SqsSendOptions.Standard} options.
 	 * @param to a {@link SqsSendOptions.Standard} consumer.
 	 * @return The {@link UUID} of the message.
 	 */
-	UUID send(Consumer<SqsSendOptions.Standard<T>> to);
+	SendResult<T> send(Consumer<SqsSendOptions.Standard<T>> to);
 
 	/**
 	 * Send a message to a Fifo SQS queue using the {@link SqsSendOptions.Fifo} options.
 	 * @param to a {@link SqsSendOptions.Fifo} consumer.
 	 * @return The {@link UUID} of the message.
 	 */
-	UUID sendFifo(Consumer<SqsSendOptions.Fifo<T>> to);
+	SendResult<T> sendFifo(Consumer<SqsSendOptions.Fifo<T>> to);
 
 	/**
 	 * Send a batch of messages to a Fifo SQS queue.
@@ -47,7 +47,7 @@ public interface SqsOperations<T> extends MessagingOperations<T, SendMessageBatc
 	 * @param messages the messages.
 	 * @return the {@link SendMessageBatchResponse}
 	 */
-	SendMessageBatchResponse sendFifo(String endpoint, Collection<Message<T>> messages);
+	SendResult.Batch<T> sendFifo(String endpoint, Collection<Message<T>> messages);
 
 	/**
 	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
@@ -6,25 +6,69 @@ import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 /**
+ * Sqs-specific synchronous messaging operations for Standard and Fifo queues.
+ * <p>
+ * Note that the Standard queue methods can be used for Fifo queues
+ * as long as necessary headers are added for required attributes such
+ * as message deduplication id.
+ * See {@link io.awspring.cloud.sqs.listener.SqsHeaders} for reference
+ * of available headers.
+ * <p>
+ * Fifo queue methods accept the required attributes and add a random value
+ * if none is specified.
+ *
  * @author Tomaz Fernandes
  * @since 3.0
  * @param <T>
  */
 public interface SqsOperations<T> extends MessagingOperations<T, SendMessageBatchResponse> {
 
+	/**
+	 * Send a message to a Standard SQS queue using the {@link SqsSendOptions.Standard} options.
+	 * @param to a {@link SqsSendOptions.Standard} consumer.
+	 * @return The {@link UUID} of the message.
+	 */
 	UUID send(Consumer<SqsSendOptions.Standard<T>> to);
 
+	/**
+	 * Send a message to a Fifo SQS queue using the {@link SqsSendOptions.Fifo} options.
+	 * @param to a {@link SqsSendOptions.Fifo} consumer.
+	 * @return The {@link UUID} of the message.
+	 */
 	UUID sendFifo(Consumer<SqsSendOptions.Fifo<T>> to);
 
+	/**
+	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.
+	 * @param from a {@link SqsReceiveOptions.Standard} consumer.
+	 * @return The message, or an empty collection if none is returned.
+	 */
 	Optional<Message<T>> receive(Consumer<SqsReceiveOptions.Standard<T>> from);
 
+	/**
+	 * Receive a message from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo} options.
+	 * @param from a {@link SqsReceiveOptions.Fifo} consumer.
+	 * @return The message, or an empty collection if none is returned.
+	 */
 	Optional<Message<T>> receiveFifo(Consumer<SqsReceiveOptions.Fifo<T>> from);
 
+	/**
+	 * Receive a batch of messages from a Standard SQS queue using the {@link SqsReceiveOptions.Standard}
+	 * options.
+	 * @param from a {@link SqsReceiveOptions.Standard} consumer.
+	 * @return The message, or an empty collection if none is returned.
+	 */
 	Collection<Message<T>> receiveMany(Consumer<SqsReceiveOptions.Standard<T>> from);
 
+	/**
+	 * Receive a batch of messages from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo}
+	 * options.
+	 * @param from a {@link SqsReceiveOptions.Fifo} consumer.
+	 * @return The message, or an empty collection if none is returned.
+	 */
 	Collection<Message<T>> receiveManyFifo(Consumer<SqsReceiveOptions.Fifo<T>> from);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
@@ -23,6 +23,7 @@ import org.springframework.messaging.Message;
 
 /**
  * Sqs-specific synchronous messaging operations for Standard and Fifo queues.
+ *
  * @author Tomaz Fernandes
  * @since 3.0
  */
@@ -40,13 +41,27 @@ public interface SqsOperations extends MessagingOperations {
 	 * @param from a {@link SqsReceiveOptions} consumer.
 	 * @return The message, or an empty collection if none is returned.
 	 */
-	<T> Optional<Message<T>> receive(Consumer<SqsReceiveOptions<T>> from);
+	Optional<Message<?>> receive(Consumer<SqsReceiveOptions> from);
+
+	/**
+	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions} options.
+	 * @param from a {@link SqsReceiveOptions} consumer.
+	 * @return The message, or an empty collection if none is returned.
+	 */
+	<T> Optional<Message<T>> receive(Consumer<SqsReceiveOptions> from, Class<T> payloadClass);
 
 	/**
 	 * Receive a batch of messages from a Standard SQS queue using {@link SqsReceiveOptions}.
 	 * @param from a {@link SqsReceiveOptions} consumer.
 	 * @return The message, or an empty collection if none is returned.
 	 */
-	<T> Collection<Message<T>> receiveMany(Consumer<SqsReceiveOptions<T>> from);
+	Collection<Message<?>> receiveMany(Consumer<SqsReceiveOptions> from);
+
+	/**
+	 * Receive a batch of messages from a Standard SQS queue using {@link SqsReceiveOptions}.
+	 * @param from a {@link SqsReceiveOptions} consumer.
+	 * @return The message, or an empty collection if none is returned.
+	 */
+	<T> Collection<Message<T>> receiveMany(Consumer<SqsReceiveOptions> from, Class<T> payloadClass);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
@@ -33,23 +33,22 @@ import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
  *
  * @author Tomaz Fernandes
  * @since 3.0
- * @param <T> the payload type
  */
-public interface SqsOperations<T> extends MessagingOperations<T> {
+public interface SqsOperations extends MessagingOperations {
 
 	/**
 	 * Send a message to a Standard SQS queue using the {@link SqsSendOptions.Standard} options.
 	 * @param to a {@link SqsSendOptions.Standard} consumer.
 	 * @return The {@link UUID} of the message.
 	 */
-	SendResult<T> send(Consumer<SqsSendOptions.Standard<T>> to);
+	<T> SendResult<T> send(Consumer<SqsSendOptions.Standard<T>> to);
 
 	/**
 	 * Send a message to a Fifo SQS queue using the {@link SqsSendOptions.Fifo} options.
 	 * @param to a {@link SqsSendOptions.Fifo} consumer.
 	 * @return The {@link UUID} of the message.
 	 */
-	SendResult<T> sendFifo(Consumer<SqsSendOptions.Fifo<T>> to);
+	<T> SendResult<T> sendFifo(Consumer<SqsSendOptions.Fifo<T>> to);
 
 	/**
 	 * Send a batch of messages to a Fifo SQS queue.
@@ -57,34 +56,34 @@ public interface SqsOperations<T> extends MessagingOperations<T> {
 	 * @param messages the messages.
 	 * @return the {@link SendMessageBatchResponse}
 	 */
-	SendResult.Batch<T> sendManyFifo(String endpoint, Collection<Message<T>> messages);
+	<T> SendResult.Batch<T> sendManyFifo(String endpoint, Collection<Message<T>> messages);
 
 	/**
 	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.
 	 * @param from a {@link SqsReceiveOptions.Standard} consumer.
 	 * @return The message, or an empty collection if none is returned.
 	 */
-	Optional<Message<T>> receive(Consumer<SqsReceiveOptions.Standard<T>> from);
+	<T> Optional<Message<T>> receive(Consumer<SqsReceiveOptions.Standard<T>> from);
 
 	/**
 	 * Receive a message from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo} options.
 	 * @param from a {@link SqsReceiveOptions.Fifo} consumer.
 	 * @return The message, or an empty collection if none is returned.
 	 */
-	Optional<Message<T>> receiveFifo(Consumer<SqsReceiveOptions.Fifo<T>> from);
+	<T> Optional<Message<T>> receiveFifo(Consumer<SqsReceiveOptions.Fifo<T>> from);
 
 	/**
 	 * Receive a batch of messages from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.
 	 * @param from a {@link SqsReceiveOptions.Standard} consumer.
 	 * @return The message, or an empty collection if none is returned.
 	 */
-	Collection<Message<T>> receiveMany(Consumer<SqsReceiveOptions.Standard<T>> from);
+	<T> Collection<Message<T>> receiveMany(Consumer<SqsReceiveOptions.Standard<T>> from);
 
 	/**
 	 * Receive a batch of messages from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo} options.
 	 * @param from a {@link SqsReceiveOptions.Fifo} consumer.
 	 * @return The message, or an empty collection if none is returned.
 	 */
-	Collection<Message<T>> receiveManyFifo(Consumer<SqsReceiveOptions.Fifo<T>> from);
+	<T> Collection<Message<T>> receiveManyFifo(Consumer<SqsReceiveOptions.Fifo<T>> from);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
@@ -1,24 +1,35 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.operations;
-
-import org.springframework.messaging.Message;
-import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
+import org.springframework.messaging.Message;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 
 /**
  * Sqs-specific synchronous messaging operations for Standard and Fifo queues.
  * <p>
- * Note that the Standard queue methods can be used for Fifo queues
- * as long as necessary headers are added for required attributes such
- * as message deduplication id.
- * See {@link io.awspring.cloud.sqs.listener.SqsHeaders} for reference
- * of available headers.
+ * Note that the Standard queue methods can be used for Fifo queues as long as necessary headers are added for required
+ * attributes such as message deduplication id. See {@link io.awspring.cloud.sqs.listener.SqsHeaders} for reference of
+ * available headers.
  * <p>
- * Fifo queue methods accept the required attributes and add a random value
- * if none is specified.
+ * Fifo queue methods accept the required attributes and add a random value if none is specified.
  *
  * @author Tomaz Fernandes
  * @since 3.0
@@ -63,16 +74,14 @@ public interface SqsOperations<T> extends MessagingOperations<T> {
 	Optional<Message<T>> receiveFifo(Consumer<SqsReceiveOptions.Fifo<T>> from);
 
 	/**
-	 * Receive a batch of messages from a Standard SQS queue using the {@link SqsReceiveOptions.Standard}
-	 * options.
+	 * Receive a batch of messages from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.
 	 * @param from a {@link SqsReceiveOptions.Standard} consumer.
 	 * @return The message, or an empty collection if none is returned.
 	 */
 	Collection<Message<T>> receiveMany(Consumer<SqsReceiveOptions.Standard<T>> from);
 
 	/**
-	 * Receive a batch of messages from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo}
-	 * options.
+	 * Receive a batch of messages from a Fifo SQS queue using the {@link SqsReceiveOptions.Fifo} options.
 	 * @param from a {@link SqsReceiveOptions.Fifo} consumer.
 	 * @return The message, or an empty collection if none is returned.
 	 */

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java
@@ -42,6 +42,14 @@ public interface SqsOperations<T> extends MessagingOperations<T, SendMessageBatc
 	UUID sendFifo(Consumer<SqsSendOptions.Fifo<T>> to);
 
 	/**
+	 * Send a batch of messages to a Fifo SQS queue.
+	 * @param endpoint the endpoint to which to send the messages.
+	 * @param messages the messages.
+	 * @return the {@link SendMessageBatchResponse}
+	 */
+	SendMessageBatchResponse sendFifo(String endpoint, Collection<Message<T>> messages);
+
+	/**
 	 * Receive a message from a Standard SQS queue using the {@link SqsReceiveOptions.Standard} options.
 	 * @param from a {@link SqsReceiveOptions.Standard} consumer.
 	 * @return The message, or an empty collection if none is returned.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
@@ -22,14 +22,14 @@ import java.util.UUID;
 /**
  * Options for receiving messages from SQS queues, with a method chaining API.
  */
-public interface SqsReceiveOptions<T> {
+public interface SqsReceiveOptions {
 
 	/**
 	 * Set the queue name or url from which to receive messages from.
 	 * @param queue the queue name.
 	 * @return the options instance.
 	 */
-	SqsReceiveOptions<T> queue(String queue);
+	SqsReceiveOptions queue(String queue);
 
 	/**
 	 * Set the maximum amount of time to wait for messages in the queue before returning with less than maximum of
@@ -37,21 +37,14 @@ public interface SqsReceiveOptions<T> {
 	 * @param pollTimeout the amount of time.
 	 * @return the options instance.
 	 */
-	SqsReceiveOptions<T> pollTimeout(Duration pollTimeout);
-
-	/**
-	 * Set the class to which the payload should be converted to.
-	 * @param payloadClass the class.
-	 * @return the options instance.
-	 */
-	SqsReceiveOptions<T> payloadClass(Class<T> payloadClass);
+	SqsReceiveOptions pollTimeout(Duration pollTimeout);
 
 	/**
 	 * Set the visibility timeout to be applied by received messages.
 	 * @param visibilityTimeout the timeout.
 	 * @return the options instance.
 	 */
-	SqsReceiveOptions<T> visibilityTimeout(Duration visibilityTimeout);
+	SqsReceiveOptions visibilityTimeout(Duration visibilityTimeout);
 
 	/**
 	 * Provide a header name and value to be added to returned messages.
@@ -59,21 +52,21 @@ public interface SqsReceiveOptions<T> {
 	 * @param value the header value.
 	 * @return the options instance.
 	 */
-	SqsReceiveOptions<T> additionalHeader(String name, Object value);
+	SqsReceiveOptions additionalHeader(String name, Object value);
 
 	/**
 	 * Provide headers to be added to returned messages.
 	 * @param headers the headers to add.
 	 * @return the options instance.
 	 */
-	SqsReceiveOptions<T> additionalHeaders(Map<String, Object> headers);
+	SqsReceiveOptions additionalHeaders(Map<String, Object> headers);
 
 	/**
 	 * Set the maximum number of messages to be returned.
 	 * @param maxNumberOfMessages the number of messages.
 	 * @return the options instance.
 	 */
-	SqsReceiveOptions<T> maxNumberOfMessages(Integer maxNumberOfMessages);
+	SqsReceiveOptions maxNumberOfMessages(Integer maxNumberOfMessages);
 
 	/**
 	 * Set the receiveRequestAttemptId required attribute. If none is provided for a FIFO queue a random one is
@@ -81,6 +74,6 @@ public interface SqsReceiveOptions<T> {
 	 * @param receiveRequestAttemptId the id.
 	 * @return the options instance.
 	 */
-	SqsReceiveOptions<T> receiveRequestAttemptId(UUID receiveRequestAttemptId);
+	SqsReceiveOptions receiveRequestAttemptId(UUID receiveRequestAttemptId);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 public interface SqsReceiveOptions {
 
 	/**
-	 * Set the queue name or url from which to receive messages from.
+	 * Set the queue name, url or ARN from which to receive messages from.
 	 * @param queue the queue name.
 	 * @return the options instance.
 	 */

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
@@ -4,27 +4,83 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * Options for receiving messages from SQS queues, with a method chaining API.
+ * @param <T> the payload type.
+ * @param <O> the implementation class to be returned by the chained methods.
+ */
 public interface SqsReceiveOptions<T, O extends SqsReceiveOptions<T, O>> {
 
+	/**
+	 * Set the queue from which to receive messages from.
+	 * @param queue the queue name.
+	 * @return the options instance.
+	 */
 	O queue(String queue);
 
+	/**
+	 * Set the maximum amount of time to wait for messages in the queue
+	 * before returning with less than maximum of messages or empty.
+	 * @param pollTimeout the amount of time.
+	 * @return the options instance.
+	 */
 	O pollTimeout(Duration pollTimeout);
 
+	/**
+	 * Set the class to which the payload should be converted to.
+	 * @param payloadClass the class.
+	 * @return the options instance.
+	 */
 	O payloadClass(Class<T> payloadClass);
 
+	/**
+	 * Set the visibility timeout to be applied by received messages.
+	 * @param visibilityTimeout the timeout.
+	 * @return the options instance.
+	 */
 	O visibilityTimeout(Duration visibilityTimeout);
 
+	/**
+	 * Provide a header name and value to be added to returned messages.
+	 * @param name the header name.
+	 * @param value the header value.
+	 * @return the options instance.
+	 */
 	O additionalHeader(String name, Object value);
 
+	/**
+	 * Provide headers to be added to returned messages.
+	 * @param headers the headers to add.
+	 * @return the options instance.
+	 */
 	O additionalHeaders(Map<String, Object> headers);
 
+	/**
+	 * Set the maximum number of messages to be returned.
+	 * @param maxNumberOfMessages the number of messages.
+	 * @return the options instance.
+	 */
 	O maxNumberOfMessages(Integer maxNumberOfMessages);
 
+	/**
+	 * Specific options for Standard Sqs queues
+	 * @param <T> the payload type.
+	 */
 	interface Standard<T> extends SqsReceiveOptions<T, Standard<T>> {
 	}
 
+	/**
+	 * Specific options for Fifo Sqs queues.
+	 * @param <T> the payload type.
+	 */
 	interface Fifo<T> extends SqsReceiveOptions<T, Fifo<T>> {
 
+		/**
+		 * Set the receiveRequestAttemptId required attribute.
+		 * If none is provided a random one is generated.
+		 * @param receiveRequestAttemptId the id.
+		 * @return the options instance.
+		 */
 		Fifo<T> receiveRequestAttemptId(UUID receiveRequestAttemptId);
 
 	}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
@@ -21,16 +21,15 @@ import java.util.UUID;
 
 /**
  * Options for receiving messages from SQS queues, with a method chaining API.
- * @param <O> the implementation class to be returned by the chained methods.
  */
-public interface SqsReceiveOptions<T, O extends SqsReceiveOptions<T, O>> {
+public interface SqsReceiveOptions<T> {
 
 	/**
 	 * Set the queue from which to receive messages from.
 	 * @param queue the queue name.
 	 * @return the options instance.
 	 */
-	O queue(String queue);
+	SqsReceiveOptions<T> queue(String queue);
 
 	/**
 	 * Set the maximum amount of time to wait for messages in the queue before returning with less than maximum of
@@ -38,21 +37,21 @@ public interface SqsReceiveOptions<T, O extends SqsReceiveOptions<T, O>> {
 	 * @param pollTimeout the amount of time.
 	 * @return the options instance.
 	 */
-	O pollTimeout(Duration pollTimeout);
+	SqsReceiveOptions<T> pollTimeout(Duration pollTimeout);
 
 	/**
 	 * Set the class to which the payload should be converted to.
 	 * @param payloadClass the class.
 	 * @return the options instance.
 	 */
-	O payloadClass(Class<T> payloadClass);
+	SqsReceiveOptions<T> payloadClass(Class<T> payloadClass);
 
 	/**
 	 * Set the visibility timeout to be applied by received messages.
 	 * @param visibilityTimeout the timeout.
 	 * @return the options instance.
 	 */
-	O visibilityTimeout(Duration visibilityTimeout);
+	SqsReceiveOptions<T> visibilityTimeout(Duration visibilityTimeout);
 
 	/**
 	 * Provide a header name and value to be added to returned messages.
@@ -60,40 +59,28 @@ public interface SqsReceiveOptions<T, O extends SqsReceiveOptions<T, O>> {
 	 * @param value the header value.
 	 * @return the options instance.
 	 */
-	O additionalHeader(String name, Object value);
+	SqsReceiveOptions<T> additionalHeader(String name, Object value);
 
 	/**
 	 * Provide headers to be added to returned messages.
 	 * @param headers the headers to add.
 	 * @return the options instance.
 	 */
-	O additionalHeaders(Map<String, Object> headers);
+	SqsReceiveOptions<T> additionalHeaders(Map<String, Object> headers);
 
 	/**
 	 * Set the maximum number of messages to be returned.
 	 * @param maxNumberOfMessages the number of messages.
 	 * @return the options instance.
 	 */
-	O maxNumberOfMessages(Integer maxNumberOfMessages);
+	SqsReceiveOptions<T> maxNumberOfMessages(Integer maxNumberOfMessages);
 
 	/**
-	 * Specific options for Standard Sqs queues
+	 * Set the receiveRequestAttemptId required attribute. If none is provided for a FIFO queue a random one is
+	 * generated.
+	 * @param receiveRequestAttemptId the id.
+	 * @return the options instance.
 	 */
-	interface Standard<T> extends SqsReceiveOptions<T, Standard<T>> {
-	}
-
-	/**
-	 * Specific options for Fifo Sqs queues.
-	 */
-	interface Fifo<T> extends SqsReceiveOptions<T, Fifo<T>> {
-
-		/**
-		 * Set the receiveRequestAttemptId required attribute. If none is provided a random one is generated.
-		 * @param receiveRequestAttemptId the id.
-		 * @return the options instance.
-		 */
-		Fifo<T> receiveRequestAttemptId(UUID receiveRequestAttemptId);
-
-	}
+	SqsReceiveOptions<T> receiveRequestAttemptId(UUID receiveRequestAttemptId);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 public interface SqsReceiveOptions<T> {
 
 	/**
-	 * Set the queue from which to receive messages from.
+	 * Set the queue name or url from which to receive messages from.
 	 * @param queue the queue name.
 	 * @return the options instance.
 	 */

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.operations;
 
 import java.time.Duration;
@@ -19,8 +34,8 @@ public interface SqsReceiveOptions<T, O extends SqsReceiveOptions<T, O>> {
 	O queue(String queue);
 
 	/**
-	 * Set the maximum amount of time to wait for messages in the queue
-	 * before returning with less than maximum of messages or empty.
+	 * Set the maximum amount of time to wait for messages in the queue before returning with less than maximum of
+	 * messages or empty.
 	 * @param pollTimeout the amount of time.
 	 * @return the options instance.
 	 */
@@ -76,8 +91,7 @@ public interface SqsReceiveOptions<T, O extends SqsReceiveOptions<T, O>> {
 	interface Fifo<T> extends SqsReceiveOptions<T, Fifo<T>> {
 
 		/**
-		 * Set the receiveRequestAttemptId required attribute.
-		 * If none is provided a random one is generated.
+		 * Set the receiveRequestAttemptId required attribute. If none is provided a random one is generated.
 		 * @param receiveRequestAttemptId the id.
 		 * @return the options instance.
 		 */

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
@@ -46,7 +46,7 @@ public interface SqsReceiveOptions<T, O extends SqsReceiveOptions<T, O>> {
 	 * @param payloadClass the class.
 	 * @return the options instance.
 	 */
-	O payloadClass(Class<T> payloadClass);
+	O payloadClass(Class<? extends T> payloadClass);
 
 	/**
 	 * Set the visibility timeout to be applied by received messages.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
@@ -21,7 +21,6 @@ import java.util.UUID;
 
 /**
  * Options for receiving messages from SQS queues, with a method chaining API.
- * @param <T> the payload type.
  * @param <O> the implementation class to be returned by the chained methods.
  */
 public interface SqsReceiveOptions<T, O extends SqsReceiveOptions<T, O>> {
@@ -46,7 +45,7 @@ public interface SqsReceiveOptions<T, O extends SqsReceiveOptions<T, O>> {
 	 * @param payloadClass the class.
 	 * @return the options instance.
 	 */
-	O payloadClass(Class<? extends T> payloadClass);
+	O payloadClass(Class<T> payloadClass);
 
 	/**
 	 * Set the visibility timeout to be applied by received messages.
@@ -79,14 +78,12 @@ public interface SqsReceiveOptions<T, O extends SqsReceiveOptions<T, O>> {
 
 	/**
 	 * Specific options for Standard Sqs queues
-	 * @param <T> the payload type.
 	 */
 	interface Standard<T> extends SqsReceiveOptions<T, Standard<T>> {
 	}
 
 	/**
 	 * Specific options for Fifo Sqs queues.
-	 * @param <T> the payload type.
 	 */
 	interface Fifo<T> extends SqsReceiveOptions<T, Fifo<T>> {
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsReceiveOptions.java
@@ -1,0 +1,32 @@
+package io.awspring.cloud.sqs.operations;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+
+public interface SqsReceiveOptions<T, O extends SqsReceiveOptions<T, O>> {
+
+	O queue(String queue);
+
+	O pollTimeout(Duration pollTimeout);
+
+	O payloadClass(Class<T> payloadClass);
+
+	O visibilityTimeout(Duration visibilityTimeout);
+
+	O additionalHeader(String name, Object value);
+
+	O additionalHeaders(Map<String, Object> headers);
+
+	O maxNumberOfMessages(Integer maxNumberOfMessages);
+
+	interface Standard<T> extends SqsReceiveOptions<T, Standard<T>> {
+	}
+
+	interface Fifo<T> extends SqsReceiveOptions<T, Fifo<T>> {
+
+		Fifo<T> receiveRequestAttemptId(UUID receiveRequestAttemptId);
+
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
@@ -19,7 +19,7 @@ public interface SqsSendOptions<T, O extends SqsSendOptions<T, O>> {
 	O queue(String queue);
 
 	/**
-	 * The payload to send in the message. The payload will be serialized if necessary.
+	 * Set the  payload to send in the message. The payload will be serialized if necessary.
 	 * @param payload the payload.
 	 * @return the options instance.
 	 */

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
@@ -45,11 +45,11 @@ public interface SqsSendOptions<T, O extends SqsSendOptions<T, O>> {
 	O headers(Map<String, Object> headers);
 
 	/**
-	 * Set a delay for the message.
-	 * @param delay the delay.
+	 * Set a delay for the message in seconds.
+	 * @param delaySeconds the delay in seconds.
 	 * @return the options instance.
 	 */
-	O delay(Duration delay);
+	O delaySeconds(Integer delaySeconds);
 
 	/**
 	 * Specific options for Standard Sqs queues.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
@@ -1,6 +1,20 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.operations;
 
-import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
 
@@ -19,15 +33,14 @@ public interface SqsSendOptions<T, O extends SqsSendOptions<T, O>> {
 	O queue(String queue);
 
 	/**
-	 * Set the  payload to send in the message. The payload will be serialized if necessary.
+	 * Set the payload to send in the message. The payload will be serialized if necessary.
 	 * @param payload the payload.
 	 * @return the options instance.
 	 */
 	O payload(T payload);
 
 	/**
-	 * Add a header to be sent in the message. The header will be sent
-	 * as a MessageAttribute.
+	 * Add a header to be sent in the message. The header will be sent as a MessageAttribute.
 	 *
 	 * @param headerName the header name.
 	 * @param headerValue the header value.
@@ -36,8 +49,7 @@ public interface SqsSendOptions<T, O extends SqsSendOptions<T, O>> {
 	O header(String headerName, Object headerValue);
 
 	/**
-	 * Add headers to be sent in the message. The headers will be sent
-	 * as MessageAttributes.
+	 * Add headers to be sent in the message. The headers will be sent as MessageAttributes.
 	 *
 	 * @param headers the headers to add.
 	 * @return the options instance.
@@ -65,16 +77,14 @@ public interface SqsSendOptions<T, O extends SqsSendOptions<T, O>> {
 	interface Fifo<T> extends SqsSendOptions<T, Fifo<T>> {
 
 		/**
-		 * Set the messageGroupId for the message. If none is provided,
-		 * a random one is added.
+		 * Set the messageGroupId for the message. If none is provided, a random one is added.
 		 * @param messageGroupId the id.
 		 * @return the options instance.
 		 */
 		Fifo<T> messageGroupId(UUID messageGroupId);
 
 		/**
-		 * Set the messageDeduplicationId for the message. If none is provided,
-		 * a random on is added.
+		 * Set the messageDeduplicationId for the message. If none is provided, a random on is added.
 		 * @param messageDeduplicationId the id.
 		 * @return the options instance.
 		 */

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
@@ -21,23 +21,22 @@ import java.util.UUID;
 /**
  * Options for sending messages to SQS queues, with a method chaining API.
  * @param <T> the payload type.
- * @param <O> the implementation class to be returned by the chained methods.
  */
-public interface SqsSendOptions<T, O extends SqsSendOptions<T, O>> {
+public interface SqsSendOptions<T> {
 
 	/**
 	 * Set the queue to send the message to.
 	 * @param queue the queue name.
 	 * @return the options instance.
 	 */
-	O queue(String queue);
+	SqsSendOptions<T> queue(String queue);
 
 	/**
 	 * Set the payload to send in the message. The payload will be serialized if necessary.
 	 * @param payload the payload.
 	 * @return the options instance.
 	 */
-	O payload(T payload);
+	SqsSendOptions<T> payload(T payload);
 
 	/**
 	 * Add a header to be sent in the message. The header will be sent as a MessageAttribute.
@@ -46,7 +45,7 @@ public interface SqsSendOptions<T, O extends SqsSendOptions<T, O>> {
 	 * @param headerValue the header value.
 	 * @return the options instance.
 	 */
-	O header(String headerName, Object headerValue);
+	SqsSendOptions<T> header(String headerName, Object headerValue);
 
 	/**
 	 * Add headers to be sent in the message. The headers will be sent as MessageAttributes.
@@ -54,42 +53,27 @@ public interface SqsSendOptions<T, O extends SqsSendOptions<T, O>> {
 	 * @param headers the headers to add.
 	 * @return the options instance.
 	 */
-	O headers(Map<String, Object> headers);
+	SqsSendOptions<T> headers(Map<String, Object> headers);
 
 	/**
 	 * Set a delay for the message in seconds.
 	 * @param delaySeconds the delay in seconds.
 	 * @return the options instance.
 	 */
-	O delaySeconds(Integer delaySeconds);
+	SqsSendOptions<T> delaySeconds(Integer delaySeconds);
 
 	/**
-	 * Specific options for Standard Sqs queues.
-	 * @param <T> the payload type.
+	 * Set the messageGroupId for the message. If none is provided for a FIFO queue, a random one is added.
+	 * @param messageGroupId the id.
+	 * @return the options instance.
 	 */
-	interface Standard<T> extends SqsSendOptions<T, Standard<T>> {
-	}
+	SqsSendOptions<T> messageGroupId(UUID messageGroupId);
 
 	/**
-	 * Specific options for Fifo Sqs queues.
-	 * @param <T> the payload type.
+	 * Set the messageDeduplicationId for the message. If none is provided for a FIFO queue, a random one is added.
+	 * @param messageDeduplicationId the id.
+	 * @return the options instance.
 	 */
-	interface Fifo<T> extends SqsSendOptions<T, Fifo<T>> {
-
-		/**
-		 * Set the messageGroupId for the message. If none is provided, a random one is added.
-		 * @param messageGroupId the id.
-		 * @return the options instance.
-		 */
-		Fifo<T> messageGroupId(UUID messageGroupId);
-
-		/**
-		 * Set the messageDeduplicationId for the message. If none is provided, a random on is added.
-		 * @param messageDeduplicationId the id.
-		 * @return the options instance.
-		 */
-		Fifo<T> messageDeduplicationId(UUID messageDeduplicationId);
-
-	}
+	SqsSendOptions<T> messageDeduplicationId(UUID messageDeduplicationId);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
@@ -4,25 +4,80 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * Options for sending messages to SQS queues, with a method chaining API.
+ * @param <T> the payload type.
+ * @param <O> the implementation class to be returned by the chained methods.
+ */
 public interface SqsSendOptions<T, O extends SqsSendOptions<T, O>> {
 
+	/**
+	 * Set the queue to send the message to.
+	 * @param queue the queue name.
+	 * @return the options instance.
+	 */
 	O queue(String queue);
 
+	/**
+	 * The payload to send in the message. The payload will be serialized if necessary.
+	 * @param payload the payload.
+	 * @return the options instance.
+	 */
 	O payload(T payload);
 
+	/**
+	 * Add a header to be sent in the message. The header will be sent
+	 * as a MessageAttribute.
+	 *
+	 * @param headerName the header name.
+	 * @param headerValue the header value.
+	 * @return the options instance.
+	 */
 	O header(String headerName, Object headerValue);
 
+	/**
+	 * Add headers to be sent in the message. The headers will be sent
+	 * as MessageAttributes.
+	 *
+	 * @param headers the headers to add.
+	 * @return the options instance.
+	 */
 	O headers(Map<String, Object> headers);
 
+	/**
+	 * Set a delay for the message.
+	 * @param delay the delay.
+	 * @return the options instance.
+	 */
 	O delay(Duration delay);
 
+	/**
+	 * Specific options for Standard Sqs queues.
+	 * @param <T> the payload type.
+	 */
 	interface Standard<T> extends SqsSendOptions<T, Standard<T>> {
 	}
 
+	/**
+	 * Specific options for Fifo Sqs queues.
+	 * @param <T> the payload type.
+	 */
 	interface Fifo<T> extends SqsSendOptions<T, Fifo<T>> {
 
+		/**
+		 * Set the messageGroupId for the message. If none is provided,
+		 * a random one is added.
+		 * @param messageGroupId the id.
+		 * @return the options instance.
+		 */
 		Fifo<T> messageGroupId(UUID messageGroupId);
 
+		/**
+		 * Set the messageDeduplicationId for the message. If none is provided,
+		 * a random on is added.
+		 * @param messageDeduplicationId the id.
+		 * @return the options instance.
+		 */
 		Fifo<T> messageDeduplicationId(UUID messageDeduplicationId);
 
 	}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 public interface SqsSendOptions<T> {
 
 	/**
-	 * Set the queue name or url to send the message to.
+	 * Set the queue name, url or ARN to send the message to.
 	 * @param queue the queue name.
 	 * @return the options instance.
 	 */

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
@@ -1,0 +1,30 @@
+package io.awspring.cloud.sqs.operations;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+
+public interface SqsSendOptions<T, O extends SqsSendOptions<T, O>> {
+
+	O queue(String queue);
+
+	O payload(T payload);
+
+	O header(String headerName, Object headerValue);
+
+	O headers(Map<String, Object> headers);
+
+	O delay(Duration delay);
+
+	interface Standard<T> extends SqsSendOptions<T, Standard<T>> {
+	}
+
+	interface Fifo<T> extends SqsSendOptions<T, Fifo<T>> {
+
+		Fifo<T> messageGroupId(UUID messageGroupId);
+
+		Fifo<T> messageDeduplicationId(UUID messageDeduplicationId);
+
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 public interface SqsSendOptions<T> {
 
 	/**
-	 * Set the queue to send the message to.
+	 * Set the queue name or url to send the message to.
 	 * @param queue the queue name.
 	 * @return the options instance.
 	 */

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
@@ -1,0 +1,722 @@
+package io.awspring.cloud.sqs.operations;
+
+import io.awspring.cloud.sqs.MessageHeaderUtils;
+import io.awspring.cloud.sqs.QueueAttributesResolver;
+import io.awspring.cloud.sqs.listener.QueueAttributes;
+import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementCallback;
+import io.awspring.cloud.sqs.support.converter.MessageAttributeDataTypes;
+import io.awspring.cloud.sqs.support.converter.MessageConversionContext;
+import io.awspring.cloud.sqs.support.converter.MessagingMessageConverter;
+import io.awspring.cloud.sqs.support.converter.SqsMessageConversionContext;
+import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.Assert;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.BatchResultErrorEntry;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
+import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeNameForSends;
+import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeValue;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class SqsTemplate<T> extends AbstractMessagingTemplate<T, Message, SendMessageBatchResponse>
+	implements SqsOperations<T>, SqsAsyncOperations<T> {
+
+	private static final Logger logger = LoggerFactory.getLogger(SqsTemplate.class);
+
+	private final Map<String, CompletableFuture<QueueAttributes>> queueAttributesCache = new ConcurrentHashMap<>();
+
+	private final Map<String, SqsMessageConversionContext> conversionContextCache = new ConcurrentHashMap<>();
+
+	private final SqsAsyncClient sqsAsyncClient;
+
+	private final Collection<QueueAttributeName> queueAttributeNames;
+
+	private final QueueNotFoundStrategy queueNotFoundStrategy;
+
+	private final Collection<String> messageAttributeNames;
+
+	private final Collection<String> messageSystemAttributeNames;
+
+	private SqsTemplate(BuilderImpl<T> builder) {
+		super(builder.messageConverter, builder.options);
+		SqsTemplateOptionsImpl<T> options = builder.options;
+		this.sqsAsyncClient = builder.sqsAsyncClient;
+		this.messageAttributeNames = options.messageAttributeNames;
+		this.queueAttributeNames = options.queueAttributeNames;
+		this.queueNotFoundStrategy = options.queueNotFoundStrategy;
+		this.messageSystemAttributeNames = options.messageSystemAttributeNames;
+	}
+
+	public static <T> Builder<T> builder() {
+		return new BuilderImpl<>();
+	}
+
+	public static <T> SqsTemplate<T> newTemplate(SqsAsyncClient sqsAsyncClient) {
+		return new BuilderImpl<T>().sqsAsyncClient(sqsAsyncClient).build();
+	}
+
+	@Override
+	public UUID send(Consumer<SqsSendOptions.Standard<T>> to) {
+		return sendAsync(to).join();
+	}
+
+	@Override
+	public UUID sendFifo(Consumer<SqsSendOptions.Fifo<T>> to) {
+		return sendFifoAsync(to).join();
+	}
+
+	@Override
+	public CompletableFuture<UUID> sendAsync(Consumer<SqsSendOptions.Standard<T>> to) {
+		Assert.notNull(to, "to must not be null");
+		SendStandardOptionsImpl<T> options = new SendStandardOptionsImpl<>();
+		to.accept(options);
+		return sendAsync(options.queue, messageBuilderFromOptions(options).build());
+	}
+
+	@Override
+	public CompletableFuture<UUID> sendFifoAsync(Consumer<SqsSendOptions.Fifo<T>> to) {
+		Assert.notNull(to, "to must not be null");
+		SendFifoOptionsImpl<T> options = new SendFifoOptionsImpl<>();
+		to.accept(options);
+		MessageBuilder<T> builder = messageBuilderFromOptions(options);
+		builder.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER,
+			getUUIDOrRandom(options.messageGroupId));
+		builder.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER,
+			getUUIDOrRandom(options.messageDeduplicationId));
+		return sendAsync(options.queue, builder.build());
+	}
+
+	@Override
+	public Optional<org.springframework.messaging.Message<T>> receive(Consumer<SqsReceiveOptions.Standard<T>> from) {
+		return receiveAsync(from).join();
+	}
+
+	@Override
+	public Optional<org.springframework.messaging.Message<T>> receiveFifo(Consumer<SqsReceiveOptions.Fifo<T>> from) {
+		return receiveFifoAsync(from).join();
+	}
+
+	@Override
+	public Collection<org.springframework.messaging.Message<T>> receiveMany(Consumer<SqsReceiveOptions.Standard<T>> from) {
+		return receiveManyAsync(from).join();
+	}
+
+	@Override
+	public Collection<org.springframework.messaging.Message<T>> receiveManyFifo(Consumer<SqsReceiveOptions.Fifo<T>> from) {
+		return receiveManyFifoAsync(from).join();
+	}
+
+	@Override
+	public CompletableFuture<Optional<org.springframework.messaging.Message<T>>> receiveAsync(Consumer<SqsReceiveOptions.Standard<T>> from) {
+		Assert.notNull(from, "from must not be null");
+		ReceiveStandardOptionsImpl<T> options = new ReceiveStandardOptionsImpl<>();
+		from.accept(options);
+		Map<String, Object> additionalHeaders = getAdditionalHeaders(options);
+		return receiveAsync(options.queue, options.payloadClass, options.pollTimeout, additionalHeaders);
+	}
+
+	@Override
+	public CompletableFuture<Optional<org.springframework.messaging.Message<T>>> receiveFifoAsync(Consumer<SqsReceiveOptions.Fifo<T>> from) {
+		Assert.notNull(from, "from must not be null");
+		ReceiveFifoOptionsImpl<T> options = new ReceiveFifoOptionsImpl<>();
+		from.accept(options);
+		Map<String, Object> additionalHeaders = handleReceiveRequestHeader(options);
+		return receiveAsync(options.queue, options.payloadClass, options.pollTimeout, additionalHeaders);
+	}
+
+	@Override
+	public CompletableFuture<Collection<org.springframework.messaging.Message<T>>> receiveManyAsync(Consumer<SqsReceiveOptions.Standard<T>> from) {
+		Assert.notNull(from, "from must not be null");
+		ReceiveStandardOptionsImpl<T> options = new ReceiveStandardOptionsImpl<>();
+		from.accept(options);
+		Map<String, Object> additionalHeaders = getAdditionalHeaders(options);
+		return receiveManyAsync(options.queue, options.payloadClass, options.pollTimeout, options.maxNumberOfMessages, additionalHeaders);
+	}
+
+	@Override
+	public CompletableFuture<Collection<org.springframework.messaging.Message<T>>> receiveManyFifoAsync(Consumer<SqsReceiveOptions.Fifo<T>> from) {
+		Assert.notNull(from, "from must not be null");
+		ReceiveFifoOptionsImpl<T> options = new ReceiveFifoOptionsImpl<>();
+		from.accept(options);
+		Map<String, Object> additionalHeaders = handleReceiveRequestHeader(options);
+		return receiveManyAsync(options.queue, options.payloadClass, options.pollTimeout, options.maxNumberOfMessages, additionalHeaders);
+	}
+
+	private Map<String, Object> handleReceiveRequestHeader(ReceiveFifoOptionsImpl<T> options) {
+		Map<String, Object> additionalHeaders = getAdditionalHeaders(options);
+		additionalHeaders.put(SqsHeaders.SQS_RECEIVE_REQUEST_ATTEMPT_ID_HEADER,
+			getUUIDOrRandom(options.receiveRequestAttemptId));
+		return additionalHeaders;
+	}
+
+	private Map<String, Object> getAdditionalHeaders(AbstractSqsReceiveOptionsImpl<?, ?> options) {
+		Map<String, Object> additionalHeaders = new HashMap<>(options.additionalHeaders);
+		if (options.visibilityTimeout != null) {
+			additionalHeaders.put(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, options.visibilityTimeout);
+		}
+		return additionalHeaders;
+	}
+
+	private static UUID getUUIDOrRandom(@Nullable UUID uuid) {
+		return uuid != null ? uuid : UUID.randomUUID();
+	}
+
+	private MessageBuilder<T> messageBuilderFromOptions(AbstractSqsSendOptionsImpl<T, ?> options) {
+		Assert.notNull(options.payload, "payload must not be null");
+		MessageBuilder<T> builder = MessageBuilder
+			.withPayload(options.payload)
+			.copyHeaders(options.headers);
+		if (options.delay != null) {
+			builder.setHeader(SqsHeaders.SQS_DELAY_HEADER, options.delay);
+		}
+		return builder;
+	}
+
+	@Override
+	protected CompletableFuture<UUID> doSendAsync(String endpointName, Message message) {
+		logger.debug("Sending message with id {} to endpoint {}", endpointName, message.messageId());
+		return createSendMessageRequest(endpointName, message)
+			.thenCompose(this.sqsAsyncClient::sendMessage)
+			.thenApply(response -> UUID.fromString(response.messageId()));
+	}
+
+	private CompletableFuture<SendMessageRequest> createSendMessageRequest(String endpointName, Message message) {
+		return getQueueAttributes(endpointName)
+			.thenApply(queueAttributes -> doCreateSendMessageRequest(message, queueAttributes));
+	}
+
+	private SendMessageRequest doCreateSendMessageRequest(Message message, QueueAttributes queueAttributes) {
+		return SendMessageRequest.builder()
+			.queueUrl(queueAttributes.getQueueUrl())
+			.messageBody(message.body())
+			.messageDeduplicationId(message.attributes().get(MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID))
+			.messageGroupId(message.attributes().get(MessageSystemAttributeName.MESSAGE_GROUP_ID))
+			.delaySeconds(getDelaySeconds(message))
+			.messageAttributes(excludeKnownFields(message.messageAttributes()))
+			.messageSystemAttributes(mapMessageSystemAttributes(message))
+			.build();
+	}
+
+	@Override
+	protected CompletableFuture<SendMessageBatchResponse> doSendBatchAsync(String endpointName, Collection<Message> messages) {
+		logger.debug("Sending messages {} to endpoint {}", messages, endpointName);
+		return createSendMessageBatchRequest(endpointName, messages)
+			.thenCompose(this.sqsAsyncClient::sendMessageBatch);
+	}
+
+	@Nullable
+	@Override
+	protected MessageConversionContext getMessageConversionContext(String endpointName, Class<T> payloadClass) {
+		return this.conversionContextCache.computeIfAbsent(endpointName,
+			newEndpoint -> doGetSqsMessageConversionContext(endpointName, payloadClass));
+	}
+
+	private SqsMessageConversionContext doGetSqsMessageConversionContext(String newEndpoint, Class<T> payloadClass) {
+		SqsMessageConversionContext conversionContext = new SqsMessageConversionContext();
+		conversionContext.setSqsAsyncClient(this.sqsAsyncClient);
+		// At this point we'll already have retrieved and cached the queue attributes
+		CompletableFuture<QueueAttributes> queueAttributes = getQueueAttributes(newEndpoint);
+		Assert.isTrue(queueAttributes.isDone(), () -> "Queue attributes not done for " + newEndpoint);
+		conversionContext.setQueueAttributes(queueAttributes.join());
+		conversionContext.setPayloadClass(payloadClass);
+		conversionContext.setAcknowledgementCallback(new TemplateAcknowledgementCallback<>());
+		return conversionContext;
+	}
+
+	private CompletableFuture<SendMessageBatchRequest> createSendMessageBatchRequest(String endpointName, Collection<Message> messages) {
+		return getQueueAttributes(endpointName)
+			.thenApply(queueAttributes -> doCreateSendMessageBatchRequest(messages, queueAttributes));
+	}
+
+	private SendMessageBatchRequest doCreateSendMessageBatchRequest(Collection<Message> messages, QueueAttributes queueAttributes) {
+		return SendMessageBatchRequest.builder()
+			.queueUrl(queueAttributes.getQueueUrl())
+			.entries(messages.stream().map(this::createSendMessageBatchRequestEntry).collect(Collectors.toList()))
+			.build();
+	}
+
+	private SendMessageBatchRequestEntry createSendMessageBatchRequestEntry(Message message) {
+		return SendMessageBatchRequestEntry.builder()
+			.id(message.messageId())
+			.messageBody(message.body())
+			.messageDeduplicationId(message.attributes().get(MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID))
+			.messageGroupId(message.attributes().get(MessageSystemAttributeName.MESSAGE_GROUP_ID))
+			.delaySeconds(getDelaySeconds(message))
+			.messageAttributes(excludeKnownFields(message.messageAttributes()))
+			.messageSystemAttributes(mapMessageSystemAttributes(message))
+			.build();
+	}
+
+	private Map<String, MessageAttributeValue> excludeKnownFields(Map<String, MessageAttributeValue> messageAttributes) {
+		return messageAttributes
+			.entrySet()
+			.stream()
+			.filter(entry -> !SqsHeaders.SQS_DELAY_HEADER.equals(entry.getKey()))
+			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+	}
+
+	@Nullable
+	private Integer getDelaySeconds(Message message) {
+		return message.messageAttributes().containsKey(SqsHeaders.SQS_DELAY_HEADER)
+			? Integer.parseInt(message.messageAttributes().get(SqsHeaders.SQS_DELAY_HEADER).stringValue())
+			: null;
+	}
+
+	private Map<MessageSystemAttributeNameForSends, MessageSystemAttributeValue> mapMessageSystemAttributes(Message message) {
+		return message.attributes()
+			.entrySet()
+			.stream()
+			.filter(Predicate.not(entry -> isSkipAttribute(entry.getKey())))
+			.collect(Collectors.toMap(
+				entry -> MessageSystemAttributeNameForSends.fromValue(entry.getKey().name()),
+				entry -> MessageSystemAttributeValue.builder()
+					.dataType(MessageAttributeDataTypes.STRING)
+					.stringValue(entry.getValue())
+					.build())
+			);
+	}
+
+	private boolean isSkipAttribute(MessageSystemAttributeName name) {
+		return MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID.equals(name)
+			|| MessageSystemAttributeName.MESSAGE_GROUP_ID.equals(name);
+	}
+
+	private CompletableFuture<QueueAttributes> getQueueAttributes(String endpointName) {
+		return this.queueAttributesCache.computeIfAbsent(endpointName, newName ->
+			QueueAttributesResolver.builder()
+				.sqsAsyncClient(this.sqsAsyncClient)
+				.queueName(newName)
+				.queueNotFoundStrategy(this.queueNotFoundStrategy)
+				.queueAttributeNames(this.queueAttributeNames)
+				.build()
+				.resolveQueueAttributes());
+	}
+
+	@Override
+	protected Map<String, Object> handleAdditionalHeaders(Map<String, Object> additionalHeaders) {
+		HashMap<String, Object> headers = new HashMap<>(additionalHeaders);
+		headers.remove(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER);
+		headers.remove(SqsHeaders.SQS_RECEIVE_REQUEST_ATTEMPT_ID_HEADER);
+		return headers;
+	}
+
+	@Override
+	protected CompletableFuture<Void> acknowledgeMessages(String endpointName, Collection<org.springframework.messaging.Message<T>> messages) {
+		return deleteMessages(endpointName, messages.stream().map(message -> message.getHeaders().get(SqsHeaders.SQS_RECEIPT_HANDLE_HEADER, String.class))
+			.collect(Collectors.toList())).thenRun(() -> {});
+	}
+
+	@Override
+	protected CompletableFuture<Collection<Message>> doReceiveAsync(String endpointName, Duration pollTimeout,
+																	Integer maxNumberOfMessages,
+																	Map<String, Object> additionalHeaders) {
+		logger.trace("Receiving messages with settings: endpointName - {}, pollTimeout - {}, maxNumberOfMessages - {}, additionalHeaders - {}",
+			endpointName, pollTimeout, maxNumberOfMessages, additionalHeaders);
+		return createReceiveMessageRequest(endpointName, pollTimeout, maxNumberOfMessages, additionalHeaders)
+			.thenCompose(this.sqsAsyncClient::receiveMessage)
+			.thenApply(ReceiveMessageResponse::messages);
+	}
+
+	private CompletableFuture<Void> deleteMessages(String endpointName, Collection<String> receiptHandles) {
+		logger.trace("Acknowledging in queue {} messages {}", endpointName, receiptHandles);
+		return getQueueAttributes(endpointName)
+			.thenCompose(attributes -> this.sqsAsyncClient.deleteMessageBatch(DeleteMessageBatchRequest
+				.builder()
+				.queueUrl(attributes.getQueueUrl())
+				.entries(createDeleteMessageEntries(receiptHandles))
+				.build()))
+			.whenComplete((response, t) -> logAcknowledgement(endpointName, receiptHandles, response, t))
+			.thenRun(() -> {});
+	}
+
+	private void logAcknowledgement(String endpointName, Collection<String> receiptHandles,
+									DeleteMessageBatchResponse response, @Nullable Throwable t) {
+		if (t != null) {
+			logger.error("Error acknowledging im queue {} messages {}", endpointName, receiptHandles);
+		}
+		else if (!response.failed().isEmpty()) {
+			logger.error("Some messages could not be acknowledged in queue {}: {}", endpointName, response
+				.failed().stream().map(BatchResultErrorEntry::id).toList());
+		}
+		else {
+			logger.trace("Acknowledged messages in queue {}: {}", endpointName, receiptHandles);
+		}
+	}
+
+	private Collection<DeleteMessageBatchRequestEntry> createDeleteMessageEntries(Collection<String> receiptHandles) {
+		return receiptHandles.stream()
+			.map(handle -> DeleteMessageBatchRequestEntry.builder()
+				.id(UUID.randomUUID().toString()).receiptHandle(handle).build())
+			.collect(Collectors.toList());
+	}
+
+	private CompletableFuture<ReceiveMessageRequest> createReceiveMessageRequest(String endpointName, Duration pollTimeout,
+																				 Integer maxNumberOfMessages,
+																				 Map<String, Object> additionalHeaders) {
+		return getQueueAttributes(endpointName)
+			.thenApply(attributes -> doCreateReceiveMessageRequest(pollTimeout, maxNumberOfMessages, attributes, additionalHeaders));
+	}
+
+	private ReceiveMessageRequest doCreateReceiveMessageRequest(Duration pollTimeout, Integer maxNumberOfMessages,
+																QueueAttributes attributes, Map<String, Object> additionalHeaders) {
+		ReceiveMessageRequest.Builder builder = ReceiveMessageRequest.builder()
+			.queueUrl(attributes.getQueueUrl())
+			.maxNumberOfMessages(maxNumberOfMessages)
+			.messageAttributeNames(this.messageAttributeNames)
+			.attributeNamesWithStrings(this.messageSystemAttributeNames)
+			.waitTimeSeconds(pollTimeout.toSecondsPart());
+		if (additionalHeaders.containsKey(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER)) {
+			builder.visibilityTimeout(getValueAs(additionalHeaders, SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Duration.class)
+					.toSecondsPart());
+		}
+		if (additionalHeaders.containsKey(SqsHeaders.SQS_RECEIVE_REQUEST_ATTEMPT_ID_HEADER)) {
+			builder.receiveRequestAttemptId(getValueAs(additionalHeaders, SqsHeaders.SQS_RECEIVE_REQUEST_ATTEMPT_ID_HEADER, UUID.class)
+					.toString());
+		}
+		return builder.build();
+	}
+
+	private <V> V getValueAs(Map<String, Object> headers, String headerName, Class<V> valueClass) {
+		return valueClass.cast(headers.get(headerName));
+	}
+
+	private static SqsMessagingMessageConverter createDefaultMessageConverter() {
+		return new SqsMessagingMessageConverter();
+	}
+
+	public interface SqsTemplateOptions<T> extends MessagingTemplateOptions<T, SqsTemplateOptions<T>> {
+
+		SqsTemplateOptions<T> queueAttributeNames(Collection<QueueAttributeName> queueAttributeNames);
+
+		SqsTemplateOptions<T> queueNotFoundStrategy(QueueNotFoundStrategy queueNotFoundStrategy);
+
+		SqsTemplateOptions<T> messageAttributeNames(Collection<String> messageAttributeNames);
+
+		SqsTemplateOptions<T> messageSystemAttributeNames(Collection<String> messageSystemAttributeNames);
+
+	}
+
+	private static class SqsTemplateOptionsImpl<T> extends AbstractMessagingTemplateOptions<T, SqsTemplateOptions<T>> implements SqsTemplateOptions<T> {
+
+		private Collection<QueueAttributeName> queueAttributeNames = Collections.emptyList();
+
+		private QueueNotFoundStrategy queueNotFoundStrategy = QueueNotFoundStrategy.FAIL;
+
+		private Collection<String> messageAttributeNames = Collections.singletonList("All");
+
+		private Collection<String> messageSystemAttributeNames = Collections.singletonList("All");
+
+		@Override
+		public SqsTemplateOptions<T> queueAttributeNames(Collection<QueueAttributeName> queueAttributeNames) {
+			Assert.notEmpty(queueAttributeNames, "queueAttributeNames cannot be null or empty");
+			this.queueAttributeNames = queueAttributeNames;
+			return this;
+		}
+
+		@Override
+		public SqsTemplateOptions<T> queueNotFoundStrategy(QueueNotFoundStrategy queueNotFoundStrategy) {
+			Assert.notNull(queueNotFoundStrategy, "queueNotFoundStrategy cannot be null");
+			this.queueNotFoundStrategy = queueNotFoundStrategy;
+			return this;
+		}
+
+		@Override
+		public SqsTemplateOptions<T> messageAttributeNames(Collection<String> messageAttributeNames) {
+			this.messageAttributeNames = messageAttributeNames;
+			return this;
+		}
+
+		@Override
+		public SqsTemplateOptions<T> messageSystemAttributeNames(Collection<String> messageSystemAttributeNames) {
+			this.messageSystemAttributeNames = messageSystemAttributeNames;
+			return this;
+		}
+
+	}
+
+	public interface Builder<T> {
+
+		Builder<T> sqsAsyncClient(SqsAsyncClient sqsAsyncClient);
+
+		Builder<T> messageConverter(MessagingMessageConverter<Message> messageConverter);
+
+		Builder<T> defaultMessageConverter(Consumer<SqsMessagingMessageConverter> messageConverterConfigurer);
+
+		Builder<T> configure(Consumer<SqsTemplateOptions<T>> options);
+
+		SqsTemplate<T> build();
+
+	}
+
+	private static class BuilderImpl<T> implements Builder<T> {
+
+		private final SqsTemplateOptionsImpl<T> options;
+
+		private SqsAsyncClient sqsAsyncClient;
+
+		@Nullable
+		private MessagingMessageConverter<Message> messageConverter;
+
+		private BuilderImpl() {
+			this.options = new SqsTemplateOptionsImpl<>();
+		}
+
+		@Override
+		public Builder<T> sqsAsyncClient(SqsAsyncClient sqsAsyncClient) {
+			Assert.notNull(sqsAsyncClient, "sqsAsyncClient must not be null");
+			this.sqsAsyncClient = sqsAsyncClient;
+			return this;
+		}
+
+		@Override
+		public Builder<T> messageConverter(MessagingMessageConverter<Message> messageConverter) {
+			Assert.notNull(messageConverter, "messageConverter must not be null");
+			Assert.isNull(this.messageConverter, "messageConverter already configured");
+			this.messageConverter = messageConverter;
+			return this;
+		}
+
+		@Override
+		public Builder<T> defaultMessageConverter(Consumer<SqsMessagingMessageConverter> messageConverterConfigurer) {
+			Assert.notNull(messageConverterConfigurer, "messageConverterConfigurer must not be null");
+			Assert.isNull(this.messageConverter, "messageConverter already configured");
+			SqsMessagingMessageConverter defaultMessageConverter = createDefaultMessageConverter();
+			messageConverterConfigurer.accept(defaultMessageConverter);
+			this.messageConverter = defaultMessageConverter;
+			return this;
+		}
+
+		@Override
+		public Builder<T> configure(Consumer<SqsTemplateOptions<T>> options) {
+			Assert.notNull(options, "options must not be null");
+			options.accept(this.options);
+			return this;
+		}
+
+		@Override
+		public SqsTemplate<T> build() {
+			Assert.notNull(this.sqsAsyncClient, "no sqsAsyncClient set");
+			if (this.messageConverter == null) {
+				this.messageConverter = createDefaultMessageConverter();
+			}
+			return new SqsTemplate<>(this);
+		}
+
+	}
+
+	private static abstract class AbstractSqsSendOptionsImpl<T, O extends SqsSendOptions<T, O>> implements SqsSendOptions<T, O> {
+
+		protected final Map<String, Object> headers = new HashMap<>();
+
+		@Nullable
+		protected String queue;
+
+		@Nullable
+		protected T payload;
+
+		@Nullable
+		protected Duration delay;
+
+		@Override
+		public O queue(String queue) {
+			this.queue = queue;
+			return self();
+		}
+
+		@Override
+		public O payload(T payload) {
+			this.payload = payload;
+			return self();
+		}
+
+		@Override
+		public O header(String headerName, Object headerValue) {
+			this.headers.put(headerName, headerValue);
+			return self();
+		}
+
+		@Override
+		public O headers(Map<String, Object> headers) {
+			this.headers.putAll(headers);
+			return self();
+		}
+
+		@Override
+		public O delay(Duration delay) {
+			this.delay = delay;
+			return self();
+		}
+
+		@SuppressWarnings("unchecked")
+		private O self() {
+			return (O) this;
+		}
+	}
+
+	private static class SendStandardOptionsImpl<T> extends AbstractSqsSendOptionsImpl<T, SqsSendOptions.Standard<T>> implements SqsSendOptions.Standard<T> {
+	}
+
+	private static class SendFifoOptionsImpl<T> extends AbstractSqsSendOptionsImpl<T, SqsSendOptions.Fifo<T>> implements SqsSendOptions.Fifo<T> {
+
+		@Nullable
+		private UUID messageGroupId;
+
+		@Nullable
+		private UUID messageDeduplicationId;
+
+		@Override
+		public SqsSendOptions.Fifo<T> messageGroupId(UUID messageGroupId) {
+			this.messageGroupId = messageGroupId;
+			return this;
+		}
+
+		@Override
+		public SqsSendOptions.Fifo<T> messageDeduplicationId(UUID messageDeduplicationId) {
+			this.messageDeduplicationId = messageDeduplicationId;
+			return this;
+		}
+
+	}
+
+	private static abstract class AbstractSqsReceiveOptionsImpl<T, O extends SqsReceiveOptions<T, O>> implements SqsReceiveOptions<T, O> {
+
+		protected final Map<String, Object> additionalHeaders = new HashMap<>();
+
+		@Nullable
+		protected String queue;
+
+		@Nullable
+		protected Duration pollTimeout;
+
+		@Nullable
+		protected Duration visibilityTimeout;
+
+		@Nullable
+		protected Class<T> payloadClass;
+
+		@Nullable
+		protected Integer maxNumberOfMessages;
+
+		@Override
+		public O queue(String queue) {
+			Assert.notNull(queue, "queue must not be null");
+			this.queue = queue;
+			return self();
+		}
+
+		@Override
+		public O pollTimeout(Duration pollTimeout) {
+			Assert.notNull(pollTimeout, "pollTimeout must not be null");
+			this.pollTimeout = pollTimeout;
+			return self();
+		}
+
+		@Override
+		public O payloadClass(Class<T> payloadClass) {
+			Assert.notNull(payloadClass, "payloadClass must not be null");
+			this.payloadClass = payloadClass;
+			return self();
+		}
+
+		@Override
+		public O visibilityTimeout(Duration visibilityTimeout) {
+			Assert.notNull(visibilityTimeout, "visibilityTimeout must not be null");
+			this.visibilityTimeout = visibilityTimeout;
+			return self();
+		}
+
+		@Override
+		public O maxNumberOfMessages(Integer maxNumberOfMessages) {
+			Assert.notNull(maxNumberOfMessages, "maxNumberOfMessages must not be null");
+			Assert.isTrue(maxNumberOfMessages > 0 && maxNumberOfMessages <= 10,
+				"maxNumberOfMessages must be between 0 and 10");
+			this.maxNumberOfMessages = maxNumberOfMessages;
+			return self();
+		}
+
+		@Override
+		public O additionalHeader(String name, Object value) {
+			Assert.notNull(name, "name must not be null");
+			Assert.notNull(value, "value must not be null");
+			this.additionalHeaders.put(name, value);
+			return self();
+		}
+
+		@Override
+		public O additionalHeaders(Map<String, Object> additionalHeaders) {
+			Assert.notNull(additionalHeaders, "additionalHeaders must not be null");
+			this.additionalHeaders.putAll(additionalHeaders);
+			return self();
+		}
+
+		@SuppressWarnings("unchecked")
+		private O self() {
+			return (O) this;
+		}
+
+	}
+
+	private static class ReceiveStandardOptionsImpl<T> extends AbstractSqsReceiveOptionsImpl<T, SqsReceiveOptions.Standard<T>> implements SqsReceiveOptions.Standard<T> {
+	}
+
+	private static class ReceiveFifoOptionsImpl<T> extends AbstractSqsReceiveOptionsImpl<T, SqsReceiveOptions.Fifo<T>> implements SqsReceiveOptions.Fifo<T> {
+
+		@Nullable
+		private UUID receiveRequestAttemptId;
+
+		@Override
+		public Fifo<T> receiveRequestAttemptId(UUID receiveRequestAttemptId) {
+			this.receiveRequestAttemptId = receiveRequestAttemptId;
+			return this;
+		}
+
+	}
+
+	private class TemplateAcknowledgementCallback<T> implements AcknowledgementCallback<T> {
+
+		@Override
+		public CompletableFuture<Void> onAcknowledge(org.springframework.messaging.Message<T> message) {
+			return deleteMessages(MessageHeaderUtils.getHeaderAsString(message, SqsHeaders.SQS_QUEUE_NAME_HEADER),
+				Collections.singletonList(MessageHeaderUtils.getHeaderAsString(message, SqsHeaders.SQS_RECEIPT_HANDLE_HEADER)));
+		}
+
+		@Override
+		public CompletableFuture<Void> onAcknowledge(Collection<org.springframework.messaging.Message<T>> messages) {
+			return messages.isEmpty() ? CompletableFuture.completedFuture(null) :
+				deleteMessages(MessageHeaderUtils.getHeaderAsString(messages.iterator().next(), SqsHeaders.SQS_QUEUE_NAME_HEADER),
+					messages.stream()
+						.map(msg -> MessageHeaderUtils.getHeaderAsString(msg, SqsHeaders.SQS_RECEIPT_HANDLE_HEADER))
+						.collect(Collectors.toList()));
+		}
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
@@ -536,6 +536,12 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		}
 
 		@Override
+		public SqsTemplateOptions defaultQueue(String defaultQueue) {
+			super.defaultEndpointName(defaultQueue);
+			return this;
+		}
+
+		@Override
 		public SqsTemplateOptions queueNotFoundStrategy(QueueNotFoundStrategy queueNotFoundStrategy) {
 			Assert.notNull(queueNotFoundStrategy, "queueNotFoundStrategy cannot be null");
 			this.queueNotFoundStrategy = queueNotFoundStrategy;

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
@@ -548,30 +548,36 @@ public class SqsTemplate<T> extends AbstractMessagingTemplate<T, Message, SendMe
 
 		@Override
 		public O queue(String queue) {
+			Assert.hasText(queue, "queue must have text");
 			this.queue = queue;
 			return self();
 		}
 
 		@Override
 		public O payload(T payload) {
+			Assert.notNull(payload, "payload must not be null");
 			this.payload = payload;
 			return self();
 		}
 
 		@Override
 		public O header(String headerName, Object headerValue) {
+			Assert.hasText(headerName, "headerName must have text");
+			Assert.notNull(headerValue, "headerValue must not be null");
 			this.headers.put(headerName, headerValue);
 			return self();
 		}
 
 		@Override
 		public O headers(Map<String, Object> headers) {
+			Assert.notNull(headers, "headers must not be null");
 			this.headers.putAll(headers);
 			return self();
 		}
 
 		@Override
 		public O delay(Duration delay) {
+			Assert.notNull(delay, "delay must not be null");
 			this.delay = delay;
 			return self();
 		}
@@ -595,12 +601,14 @@ public class SqsTemplate<T> extends AbstractMessagingTemplate<T, Message, SendMe
 
 		@Override
 		public SqsSendOptions.Fifo<T> messageGroupId(UUID messageGroupId) {
+			Assert.notNull(messageGroupId, "messageGroupId must not be null");
 			this.messageGroupId = messageGroupId;
 			return this;
 		}
 
 		@Override
 		public SqsSendOptions.Fifo<T> messageDeduplicationId(UUID messageDeduplicationId) {
+			Assert.notNull(messageDeduplicationId, "messageDeduplicationId must not be null");
 			this.messageDeduplicationId = messageDeduplicationId;
 			return this;
 		}
@@ -695,6 +703,7 @@ public class SqsTemplate<T> extends AbstractMessagingTemplate<T, Message, SendMe
 
 		@Override
 		public Fifo<T> receiveRequestAttemptId(UUID receiveRequestAttemptId) {
+			Assert.notNull(receiveRequestAttemptId, "receiveRequestAttemptId must not be null");
 			this.receiveRequestAttemptId = receiveRequestAttemptId;
 			return this;
 		}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateBuilder.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateBuilder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.operations;
+
+import io.awspring.cloud.sqs.support.converter.MessagingMessageConverter;
+import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
+import java.util.function.Consumer;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+/**
+ * Builder interface for creating a {@link SqsTemplate} instance.
+ *
+ * @param <T> the payload type.
+ */
+public interface SqsTemplateBuilder<T> {
+
+	/**
+	 * Set the {@link SqsAsyncClient} to be used by the {@link SqsTemplate}.
+	 *
+	 * @param sqsAsyncClient the instance.
+	 * @return the builder.
+	 */
+	SqsTemplateBuilder<T> sqsAsyncClient(SqsAsyncClient sqsAsyncClient);
+
+	/**
+	 * Set the {@link MessagingMessageConverter} to be used by the template.
+	 *
+	 * @param messageConverter the converter.
+	 * @return the builder.
+	 */
+	SqsTemplateBuilder<T> messageConverter(MessagingMessageConverter<Message> messageConverter);
+
+	/**
+	 * Configure the default message converter.
+	 *
+	 * @param messageConverterConfigurer a {@link SqsMessagingMessageConverter} consumer.
+	 * @return the builder.
+	 */
+	SqsTemplateBuilder<T> configureDefaultConverter(Consumer<SqsMessagingMessageConverter> messageConverterConfigurer);
+
+	/**
+	 * Configure options for the template.
+	 *
+	 * @param options a {@link SqsTemplateOptions} consumer.
+	 * @return the builder.
+	 */
+	SqsTemplateBuilder<T> configure(Consumer<SqsTemplateOptions<T>> options);
+
+	/**
+	 * Create the template with the provided options, exposing both sync and async methods.
+	 *
+	 * @return the {@link SqsTemplate} instance.
+	 */
+	SqsTemplate<T> build();
+
+	/**
+	 * Create the template with the provided options, exposing only the async methods contained in the
+	 * {@link SqsAsyncOperations} interface.
+	 *
+	 * @return the {@link SqsTemplate} instance.
+	 */
+	SqsAsyncOperations<T> buildAsyncTemplate();
+
+	/**
+	 * Create the template with the provided options, exposing only the sync methods contained in the
+	 * {@link SqsOperations} interface.
+	 *
+	 * @return the {@link SqsTemplate} instance.
+	 */
+	SqsOperations<T> buildSyncTemplate();
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateBuilder.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateBuilder.java
@@ -24,9 +24,8 @@ import software.amazon.awssdk.services.sqs.model.Message;
 /**
  * Builder interface for creating a {@link SqsTemplate} instance.
  *
- * @param <T> the payload type.
  */
-public interface SqsTemplateBuilder<T> {
+public interface SqsTemplateBuilder {
 
 	/**
 	 * Set the {@link SqsAsyncClient} to be used by the {@link SqsTemplate}.
@@ -34,7 +33,7 @@ public interface SqsTemplateBuilder<T> {
 	 * @param sqsAsyncClient the instance.
 	 * @return the builder.
 	 */
-	SqsTemplateBuilder<T> sqsAsyncClient(SqsAsyncClient sqsAsyncClient);
+	SqsTemplateBuilder sqsAsyncClient(SqsAsyncClient sqsAsyncClient);
 
 	/**
 	 * Set the {@link MessagingMessageConverter} to be used by the template.
@@ -42,7 +41,7 @@ public interface SqsTemplateBuilder<T> {
 	 * @param messageConverter the converter.
 	 * @return the builder.
 	 */
-	SqsTemplateBuilder<T> messageConverter(MessagingMessageConverter<Message> messageConverter);
+	SqsTemplateBuilder messageConverter(MessagingMessageConverter<Message> messageConverter);
 
 	/**
 	 * Configure the default message converter.
@@ -50,7 +49,7 @@ public interface SqsTemplateBuilder<T> {
 	 * @param messageConverterConfigurer a {@link SqsMessagingMessageConverter} consumer.
 	 * @return the builder.
 	 */
-	SqsTemplateBuilder<T> configureDefaultConverter(Consumer<SqsMessagingMessageConverter> messageConverterConfigurer);
+	SqsTemplateBuilder configureDefaultConverter(Consumer<SqsMessagingMessageConverter> messageConverterConfigurer);
 
 	/**
 	 * Configure options for the template.
@@ -58,14 +57,14 @@ public interface SqsTemplateBuilder<T> {
 	 * @param options a {@link SqsTemplateOptions} consumer.
 	 * @return the builder.
 	 */
-	SqsTemplateBuilder<T> configure(Consumer<SqsTemplateOptions<T>> options);
+	SqsTemplateBuilder configure(Consumer<SqsTemplateOptions> options);
 
 	/**
 	 * Create the template with the provided options, exposing both sync and async methods.
 	 *
 	 * @return the {@link SqsTemplate} instance.
 	 */
-	SqsTemplate<T> build();
+	SqsTemplate build();
 
 	/**
 	 * Create the template with the provided options, exposing only the async methods contained in the
@@ -73,7 +72,7 @@ public interface SqsTemplateBuilder<T> {
 	 *
 	 * @return the {@link SqsTemplate} instance.
 	 */
-	SqsAsyncOperations<T> buildAsyncTemplate();
+	SqsAsyncOperations buildAsyncTemplate();
 
 	/**
 	 * Create the template with the provided options, exposing only the sync methods contained in the
@@ -81,6 +80,6 @@ public interface SqsTemplateBuilder<T> {
 	 *
 	 * @return the {@link SqsTemplate} instance.
 	 */
-	SqsOperations<T> buildSyncTemplate();
+	SqsOperations buildSyncTemplate();
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
@@ -59,7 +59,6 @@ public interface SqsTemplateOptions extends MessagingTemplateOptions<SqsTemplate
 	 * @param messageSystemAttributeNames the names.
 	 * @return the options instance.
 	 */
-	SqsTemplateOptions messageSystemAttributeNames(
-			Collection<MessageSystemAttributeName> messageSystemAttributeNames);
+	SqsTemplateOptions messageSystemAttributeNames(Collection<MessageSystemAttributeName> messageSystemAttributeNames);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
@@ -26,7 +26,6 @@ import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
  */
 public interface SqsTemplateOptions extends MessagingTemplateOptions<SqsTemplateOptions> {
 
-
 	/**
 	 * Set the default queue for this template. Default is blank.
 	 *

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
@@ -26,6 +26,15 @@ import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
  */
 public interface SqsTemplateOptions extends MessagingTemplateOptions<SqsTemplateOptions> {
 
+
+	/**
+	 * Set the default queue for this template. Default is blank.
+	 *
+	 * @param defaultQueue the default queue.
+	 * @return the options instance.
+	 */
+	SqsTemplateOptions defaultQueue(String defaultQueue);
+
 	/**
 	 * The {@link QueueNotFoundStrategy} for this template.
 	 *

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
@@ -23,9 +23,8 @@ import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 /**
  * Sqs specific options for the {@link SqsTemplate}.
  *
- * @param <T> the payload type.
  */
-public interface SqsTemplateOptions<T> extends MessagingTemplateOptions<T, SqsTemplateOptions<T>> {
+public interface SqsTemplateOptions extends MessagingTemplateOptions<SqsTemplateOptions> {
 
 	/**
 	 * The {@link QueueNotFoundStrategy} for this template.
@@ -33,7 +32,7 @@ public interface SqsTemplateOptions<T> extends MessagingTemplateOptions<T, SqsTe
 	 * @param queueNotFoundStrategy the strategy.
 	 * @return the options instance.
 	 */
-	SqsTemplateOptions<T> queueNotFoundStrategy(QueueNotFoundStrategy queueNotFoundStrategy);
+	SqsTemplateOptions queueNotFoundStrategy(QueueNotFoundStrategy queueNotFoundStrategy);
 
 	/**
 	 * The queue attribute names that will be retrieved by this template and added as headers to received messages.
@@ -42,7 +41,7 @@ public interface SqsTemplateOptions<T> extends MessagingTemplateOptions<T, SqsTe
 	 * @param queueAttributeNames the names.
 	 * @return the options instance.
 	 */
-	SqsTemplateOptions<T> queueAttributeNames(Collection<QueueAttributeName> queueAttributeNames);
+	SqsTemplateOptions queueAttributeNames(Collection<QueueAttributeName> queueAttributeNames);
 
 	/**
 	 * The message attributes to be retrieved with the message and added as headers to received messages. Default is
@@ -51,7 +50,7 @@ public interface SqsTemplateOptions<T> extends MessagingTemplateOptions<T, SqsTe
 	 * @param messageAttributeNames the names.
 	 * @return the options instance.
 	 */
-	SqsTemplateOptions<T> messageAttributeNames(Collection<String> messageAttributeNames);
+	SqsTemplateOptions messageAttributeNames(Collection<String> messageAttributeNames);
 
 	/**
 	 * The message system attributes to be retrieved with the message and added as headers to received messages. Default
@@ -60,7 +59,7 @@ public interface SqsTemplateOptions<T> extends MessagingTemplateOptions<T, SqsTe
 	 * @param messageSystemAttributeNames the names.
 	 * @return the options instance.
 	 */
-	SqsTemplateOptions<T> messageSystemAttributeNames(
+	SqsTemplateOptions messageSystemAttributeNames(
 			Collection<MessageSystemAttributeName> messageSystemAttributeNames);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.operations;
+
+import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
+import java.util.Collection;
+import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
+
+/**
+ * Sqs specific options for the {@link SqsTemplate}.
+ *
+ * @param <T> the payload type.
+ */
+public interface SqsTemplateOptions<T> extends MessagingTemplateOptions<T, SqsTemplateOptions<T>> {
+
+	/**
+	 * The {@link QueueNotFoundStrategy} for this template.
+	 *
+	 * @param queueNotFoundStrategy the strategy.
+	 * @return the options instance.
+	 */
+	SqsTemplateOptions<T> queueNotFoundStrategy(QueueNotFoundStrategy queueNotFoundStrategy);
+
+	/**
+	 * The queue attribute names that will be retrieved by this template and added as headers to received messages.
+	 * Default is none.
+	 *
+	 * @param queueAttributeNames the names.
+	 * @return the options instance.
+	 */
+	SqsTemplateOptions<T> queueAttributeNames(Collection<QueueAttributeName> queueAttributeNames);
+
+	/**
+	 * The message attributes to be retrieved with the message and added as headers to received messages. Default is
+	 * ALL.
+	 *
+	 * @param messageAttributeNames the names.
+	 * @return the options instance.
+	 */
+	SqsTemplateOptions<T> messageAttributeNames(Collection<String> messageAttributeNames);
+
+	/**
+	 * The message system attributes to be retrieved with the message and added as headers to received messages. Default
+	 * is ALL.
+	 *
+	 * @param messageSystemAttributeNames the names.
+	 * @return the options instance.
+	 */
+	SqsTemplateOptions<T> messageSystemAttributeNames(
+			Collection<MessageSystemAttributeName> messageSystemAttributeNames);
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateParameters.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateParameters.java
@@ -1,0 +1,17 @@
+package io.awspring.cloud.sqs.operations;
+
+/**
+ * SQS parameters added to {@link SendResult} objects as additional information.
+ *
+ * @author Tomaz Fernandes
+ * @since 3.0
+ */
+public class SqsTemplateParameters {
+
+	public static final String SEQUENCE_NUMBER_PARAMETER_NAME = "sequenceNumber";
+
+	public static final String SENDER_FAULT_PARAMETER_NAME = "senderFault";
+
+	public static final String CODE_PARAMETER_NAME = "code";
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateParameters.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateParameters.java
@@ -1,17 +1,42 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.operations;
 
 /**
- * SQS parameters added to {@link SendResult} objects as additional information.
+ * SQS parameters added to {@link SendResult} objects as additional information. These are returned by the SQS endpoints
+ * and stored as returned. See the AWS documentation for more information.
  *
  * @author Tomaz Fernandes
  * @since 3.0
  */
 public class SqsTemplateParameters {
 
+	/**
+	 * Sequence number generated for SQS FIFO.
+	 */
 	public static final String SEQUENCE_NUMBER_PARAMETER_NAME = "sequenceNumber";
 
+	/**
+	 * Whether the messaging operation failed due to a problem with the request.
+	 */
 	public static final String SENDER_FAULT_PARAMETER_NAME = "senderFault";
 
-	public static final String CODE_PARAMETER_NAME = "code";
+	/**
+	 * A code representing the error.
+	 */
+	public static final String ERROR_CODE_PARAMETER_NAME = "code";
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/TemplateAcknowledgementMode.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/TemplateAcknowledgementMode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.operations;
 
 import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement;
@@ -12,9 +27,9 @@ import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement;
 public enum TemplateAcknowledgementMode {
 
 	/**
-	 * Don't acknowledge messages automatically. The message or messages can be
-	 * acknowledged with {@link io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement#acknowledge}
-	 * or {@link Acknowledgement#acknowledgeAsync()}
+	 * Don't acknowledge messages automatically. The message or messages can be acknowledged with
+	 * {@link io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement#acknowledge} or
+	 * {@link Acknowledgement#acknowledgeAsync()}
 	 */
 	DO_NOT_ACKNOWLEDGE,
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/TemplateAcknowledgementMode.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/TemplateAcknowledgementMode.java
@@ -1,0 +1,12 @@
+package io.awspring.cloud.sqs.operations;
+
+/**
+ *
+ */
+public enum TemplateAcknowledgementMode {
+
+	DO_NOT_ACKNOWLEDGE,
+
+	ACKNOWLEDGE_ON_RECEIVE
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/TemplateAcknowledgementMode.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/TemplateAcknowledgementMode.java
@@ -5,6 +5,9 @@ import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement;
 /**
  * Acknowledgement modes to be used by a {@link org.springframework.messaging.core.MessageReceivingOperations}
  * implementation.
+ *
+ * @author Tomaz Fernandes
+ * @since 3.0
  */
 public enum TemplateAcknowledgementMode {
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/TemplateAcknowledgementMode.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/TemplateAcknowledgementMode.java
@@ -1,12 +1,23 @@
 package io.awspring.cloud.sqs.operations;
 
+import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement;
+
 /**
- *
+ * Acknowledgement modes to be used by a {@link org.springframework.messaging.core.MessageReceivingOperations}
+ * implementation.
  */
 public enum TemplateAcknowledgementMode {
 
+	/**
+	 * Don't acknowledge messages automatically. The message or messages can be
+	 * acknowledged with {@link io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement#acknowledge}
+	 * or {@link Acknowledgement#acknowledgeAsync()}
+	 */
 	DO_NOT_ACKNOWLEDGE,
 
+	/**
+	 * Acknowledge received messages automatically.
+	 */
 	ACKNOWLEDGE_ON_RECEIVE
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/package-info.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/package-info.java
@@ -13,19 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.awspring.cloud.sqs.support.converter;
-
-import org.springframework.messaging.MessageHeaders;
 
 /**
- * A {@link HeaderMapper} specialization that supports receiving a {@link MessageConversionContext} for mapping context
- * dependent headers.
- * @author Tomaz Fernandes
- * @since 3.0
- * @see ContextAwareMessagingMessageConverter
+ * Components for converting source messages to Spring messaging messages.
  */
-public interface ContextAwareHeaderMapper<S> extends HeaderMapper<S> {
-
-	MessageHeaders createContextHeaders(S source, MessageConversionContext context);
-
-}
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package io.awspring.cloud.sqs.operations;

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
@@ -189,7 +189,7 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 	}
 
 	@Override
-	public S fromMessagingMessage(Message<?> message) {
+	public S fromMessagingMessage(Message<?> message, @Nullable MessageConversionContext context) {
 		MessageHeaders headers = getMessageHeaders(message);
 		S messageWithHeaders = this.headerMapper.fromHeaders(headers);
 		Object payload = Objects.requireNonNull(this.payloadMessageConverter.toMessage(message.getPayload(), message.getHeaders()),

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
@@ -176,8 +176,10 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 
 	@Nullable
 	private Class<?> getTargetType(Message<?> messagingMessage, @Nullable MessageConversionContext context) {
-		return context != null && context.getPayloadClass() != null ? context.getPayloadClass()
-				: this.payloadTypeMapper.apply(messagingMessage);
+		Class<?> classFromTypeMapper = this.payloadTypeMapper.apply(messagingMessage);
+		return classFromTypeMapper == null && context != null && context.getPayloadClass() != null
+			? context.getPayloadClass()
+			: classFromTypeMapper;
 	}
 
 	protected abstract Object getPayloadToDeserialize(S message);

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
@@ -18,7 +18,6 @@ package io.awspring.cloud.sqs.support.converter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.sqs.MessageHeaderUtils;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -56,7 +55,8 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 
 	private Function<Message<?>, Class<?>> payloadTypeMapper;
 
-	private Function<Message<?>, String> payloadTypeHeaderFunction = message -> message.getPayload().getClass().getName();
+	private Function<Message<?>, String> payloadTypeHeaderFunction = message -> message.getPayload().getClass()
+			.getName();
 
 	protected AbstractMessagingMessageConverter() {
 		this.payloadMessageConverter = createDefaultCompositeMessageConverter();
@@ -91,20 +91,21 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 	 */
 	public void setObjectMapper(ObjectMapper objectMapper) {
 		Assert.notNull(objectMapper, "messageConverter cannot be null");
-		MappingJackson2MessageConverter converter = getMappingJackson2MessageConverter()
-			.orElseThrow(() -> new IllegalStateException("%s can only be set in %s instances, or %s containing one."
-				.formatted(ObjectMapper.class.getSimpleName(), MappingJackson2MessageConverter.class.getSimpleName(),
-					CompositeMessageConverter.class.getSimpleName())));
+		MappingJackson2MessageConverter converter = getMappingJackson2MessageConverter().orElseThrow(
+				() -> new IllegalStateException("%s can only be set in %s instances, or %s containing one.".formatted(
+						ObjectMapper.class.getSimpleName(), MappingJackson2MessageConverter.class.getSimpleName(),
+						CompositeMessageConverter.class.getSimpleName())));
 		converter.setObjectMapper(objectMapper);
 	}
 
 	private Optional<MappingJackson2MessageConverter> getMappingJackson2MessageConverter() {
 		return this.payloadMessageConverter instanceof CompositeMessageConverter compositeConverter
-			? compositeConverter.getConverters().stream().filter(converter -> converter instanceof MappingJackson2MessageConverter)
-				.map(MappingJackson2MessageConverter.class::cast).findFirst()
-			: this.payloadMessageConverter instanceof MappingJackson2MessageConverter converter
-				? Optional.of(converter)
-				: Optional.empty();
+				? compositeConverter.getConverters().stream()
+						.filter(converter -> converter instanceof MappingJackson2MessageConverter)
+						.map(MappingJackson2MessageConverter.class::cast).findFirst()
+				: this.payloadMessageConverter instanceof MappingJackson2MessageConverter converter
+						? Optional.of(converter)
+						: Optional.empty();
 	}
 
 	/**
@@ -163,18 +164,20 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 		return ((ContextAwareHeaderMapper<S>) this.headerMapper).createContextHeaders(message, context);
 	}
 
-	private Object convertPayload(S message, MessageHeaders messageHeaders, @Nullable MessageConversionContext context) {
+	private Object convertPayload(S message, MessageHeaders messageHeaders,
+			@Nullable MessageConversionContext context) {
 		Message<?> messagingMessage = MessageBuilder.createMessage(getPayloadToDeserialize(message), messageHeaders);
 		Class<?> targetType = getTargetType(messagingMessage, context);
-		return targetType != null ? Objects.requireNonNull(this.payloadMessageConverter.fromMessage(messagingMessage, targetType),
-			"payloadMessageConverter returned null payload")
+		return targetType != null
+				? Objects.requireNonNull(this.payloadMessageConverter.fromMessage(messagingMessage, targetType),
+						"payloadMessageConverter returned null payload")
 				: messagingMessage.getPayload();
 	}
 
 	@Nullable
 	private Class<?> getTargetType(Message<?> messagingMessage, @Nullable MessageConversionContext context) {
-		return context != null && context.getPayloadClass() != null
-			? context.getPayloadClass() : this.payloadTypeMapper.apply(messagingMessage);
+		return context != null && context.getPayloadClass() != null ? context.getPayloadClass()
+				: this.payloadTypeMapper.apply(messagingMessage);
 	}
 
 	protected abstract Object getPayloadToDeserialize(S message);
@@ -202,16 +205,18 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 	public S fromMessagingMessage(Message<?> message, @Nullable MessageConversionContext context) {
 		MessageHeaders headers = getMessageHeaders(message);
 		S messageWithHeaders = this.headerMapper.fromHeaders(headers);
-		Object payload = Objects.requireNonNull(this.payloadMessageConverter.toMessage(message.getPayload(), message.getHeaders()),
-			() -> "payloadMessageConverter returned null message for message " + message).getPayload();
+		Object payload = Objects
+				.requireNonNull(this.payloadMessageConverter.toMessage(message.getPayload(), message.getHeaders()),
+						() -> "payloadMessageConverter returned null message for message " + message)
+				.getPayload();
 		return doConvertMessage(messageWithHeaders, payload);
 	}
 
 	private MessageHeaders getMessageHeaders(Message<?> message) {
 		String typeHeaderName = this.payloadTypeHeaderFunction.apply(message);
- 		return typeHeaderName != null
-			? MessageHeaderUtils.addHeader(message.getHeaders(), this.typeHeader, typeHeaderName)
-			: message.getHeaders();
+		return typeHeaderName != null
+				? MessageHeaderUtils.addHeader(message.getHeaders(), this.typeHeader, typeHeaderName)
+				: message.getHeaders();
 	}
 
 	protected abstract S doConvertMessage(S messageWithHeaders, Object payload);

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
@@ -156,7 +156,7 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 	private MessageHeaders createMessageHeaders(S message, @Nullable MessageConversionContext context) {
 		MessageHeaders messageHeaders = this.headerMapper.toHeaders(message);
 		return context != null && this.headerMapper instanceof ContextAwareHeaderMapper
-				? MessageHeaderUtils.addHeaders(messageHeaders, getContextHeaders(message, context))
+				? MessageHeaderUtils.addHeadersIfAbsent(messageHeaders, getContextHeaders(message, context))
 				: messageHeaders;
 	}
 
@@ -178,8 +178,8 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 	private Class<?> getTargetType(Message<?> messagingMessage, @Nullable MessageConversionContext context) {
 		Class<?> classFromTypeMapper = this.payloadTypeMapper.apply(messagingMessage);
 		return classFromTypeMapper == null && context != null && context.getPayloadClass() != null
-			? context.getPayloadClass()
-			: classFromTypeMapper;
+				? context.getPayloadClass()
+				: classFromTypeMapper;
 	}
 
 	protected abstract Object getPayloadToDeserialize(S message);
@@ -217,7 +217,7 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 	private MessageHeaders getMessageHeaders(Message<?> message) {
 		String typeHeaderName = this.payloadTypeHeaderFunction.apply(message);
 		return typeHeaderName != null
-				? MessageHeaderUtils.addHeader(message.getHeaders(), this.typeHeader, typeHeaderName)
+				? MessageHeaderUtils.addHeaderIfAbsent(message.getHeaders(), this.typeHeader, typeHeaderName)
 				: message.getHeaders();
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AcknowledgementAwareMessageConversionContext.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AcknowledgementAwareMessageConversionContext.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.sqs.support.converter;
 
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementCallback;
+import org.springframework.lang.Nullable;
 
 /**
  * {@link MessageConversionContext} specialization that enables setting an {@link AcknowledgementCallback} to be used
@@ -27,6 +28,7 @@ public interface AcknowledgementAwareMessageConversionContext extends MessageCon
 
 	void setAcknowledgementCallback(AcknowledgementCallback<?> acknowledgementCallback);
 
+	@Nullable
 	AcknowledgementCallback<?> getAcknowledgementCallback();
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/ContextAwareMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/ContextAwareMessagingMessageConverter.java
@@ -53,7 +53,6 @@ public interface ContextAwareMessagingMessageConverter<S> extends MessagingMessa
 	 */
 	S fromMessagingMessage(Message<?> message, @Nullable MessageConversionContext context);
 
-
 	/**
 	 * An optional context to be used in the conversion process.
 	 * @return the context.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/ContextAwareMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/ContextAwareMessagingMessageConverter.java
@@ -34,6 +34,7 @@ public interface ContextAwareMessagingMessageConverter<S> extends MessagingMessa
 
 	Message<?> toMessagingMessage(S source, @Nullable MessageConversionContext context);
 
+	@Nullable
 	MessageConversionContext createMessageConversionContext();
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/ContextAwareMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/ContextAwareMessagingMessageConverter.java
@@ -32,8 +32,32 @@ public interface ContextAwareMessagingMessageConverter<S> extends MessagingMessa
 		return toMessagingMessage(source, null);
 	}
 
+	@Override
+	default S fromMessagingMessage(Message<?> message) {
+		return fromMessagingMessage(message, null);
+	}
+
+	/**
+	 * Convert a source message from a specific messaging system to a {@link Message} with an optional context.
+	 * @param source the source message.
+	 * @param context an optional context with information to be used in the conversion process.
+	 * @return the converted message.
+	 */
 	Message<?> toMessagingMessage(S source, @Nullable MessageConversionContext context);
 
+	/**
+	 * Convert a {@link Message} to a message from a specific messaging system.
+	 * @param message the message from which to convert.
+	 * @param context an optional context with information to be used in the conversion process.
+	 * @return the system specific message.
+	 */
+	S fromMessagingMessage(Message<?> message, @Nullable MessageConversionContext context);
+
+
+	/**
+	 * An optional context to be used in the conversion process.
+	 * @return the context.
+	 */
 	@Nullable
 	MessageConversionContext createMessageConversionContext();
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/HeaderMapper.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/HeaderMapper.java
@@ -1,16 +1,43 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.support.converter;
 
 import org.springframework.messaging.MessageHeaders;
 
 /**
+ * Mapper interface to map from and to {@link MessageHeaders} and a given source type.
+ *
  * @author Tomaz Fernandes
  * @since 3.0
- * @param <T>
+ * @param <S> the source message type.
  */
-public interface HeaderMapper<T> {
+public interface HeaderMapper<S> {
 
-	T fromHeaders(MessageHeaders headers);
+	/**
+	 * Map the provided {@link MessageHeaders} into the returning message type.
+	 * @param headers the headers from which to map.
+	 * @return the mapped message instance.
+	 */
+	S fromHeaders(MessageHeaders headers);
 
-	MessageHeaders toHeaders(T source);
+	/**
+	 * Map the provided source into a {@link MessageHeaders} instance.
+	 * @param source the source from which to map.
+	 * @return the mapped {@link MessageHeaders} instance.
+	 */
+	MessageHeaders toHeaders(S source);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/HeaderMapper.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/HeaderMapper.java
@@ -1,0 +1,16 @@
+package io.awspring.cloud.sqs.support.converter;
+
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 3.0
+ * @param <T>
+ */
+public interface HeaderMapper<T> {
+
+	T fromHeaders(MessageHeaders headers);
+
+	MessageHeaders toHeaders(T source);
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessageAttributeDataTypes.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessageAttributeDataTypes.java
@@ -1,0 +1,33 @@
+package io.awspring.cloud.sqs.support.converter;
+
+/**
+ * @author Alain Sahli
+ * @since 1.0
+ */
+public final class MessageAttributeDataTypes {
+
+	private MessageAttributeDataTypes() {
+		// Avoid instantiation
+	}
+
+	/**
+	 * Binary message attribute data type.
+	 */
+	public static final String BINARY = "Binary";
+
+	/**
+	 * Number message attribute data type.
+	 */
+	public static final String NUMBER = "Number";
+
+	/**
+	 * String message attribute data type.
+	 */
+	public static final String STRING = "String";
+
+	/**
+	 * String.Array message attribute data type.
+	 */
+	public static final String STRING_ARRAY = "String.Array";
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessageAttributeDataTypes.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessageAttributeDataTypes.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.support.converter;
 
 /**

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessageConversionContext.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessageConversionContext.java
@@ -26,6 +26,11 @@ import org.springframework.lang.Nullable;
  */
 public interface MessageConversionContext {
 
+	/**
+	 * An optional parameter with the payload class to be used by the
+	 * conversion process.
+	 * @return the payload class.
+	 */
 	@Nullable
 	Class<?> getPayloadClass();
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessageConversionContext.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessageConversionContext.java
@@ -27,8 +27,7 @@ import org.springframework.lang.Nullable;
 public interface MessageConversionContext {
 
 	/**
-	 * An optional parameter with the payload class to be used by the
-	 * conversion process.
+	 * An optional parameter with the payload class to be used by the conversion process.
 	 * @return the payload class.
 	 */
 	@Nullable

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessageConversionContext.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessageConversionContext.java
@@ -15,6 +15,8 @@
  */
 package io.awspring.cloud.sqs.support.converter;
 
+import org.springframework.lang.Nullable;
+
 /**
  * Marker interface for a message conversion context.
  * @author Tomaz Fernandes
@@ -23,5 +25,8 @@ package io.awspring.cloud.sqs.support.converter;
  * @see ContextAwareHeaderMapper
  */
 public interface MessageConversionContext {
+
+	@Nullable
+	Class<?> getPayloadClass();
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessagingMessageConverter.java
@@ -24,8 +24,18 @@ import org.springframework.messaging.Message;
  */
 public interface MessagingMessageConverter<S> {
 
+	/**
+	 * Convert a source message from a specific messaging system to a {@link Message}.
+	 * @param source the source message.
+	 * @return the converted message.
+	 */
 	Message<?> toMessagingMessage(S source);
 
+	/**
+	 * Convert a {@link Message} to a message from a specific messaging system.
+	 * @param message the message from which to convert.
+	 * @return the system specific message.
+	 */
 	S fromMessagingMessage(Message<?> message);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessagingMessageHeaders.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessagingMessageHeaders.java
@@ -29,7 +29,7 @@ public class MessagingMessageHeaders extends MessageHeaders {
 
 	/**
 	 * Create an instance with the provided headers.
-	 * @param headers
+	 * @param headers the original headers.
 	 */
 	public MessagingMessageHeaders(@Nullable Map<String, Object> headers) {
 		super(headers);

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
@@ -16,24 +16,39 @@
 package io.awspring.cloud.sqs.support.converter;
 
 import io.awspring.cloud.sqs.ConfigUtils;
+import io.awspring.cloud.sqs.MessageHeaderUtils;
 import io.awspring.cloud.sqs.listener.QueueAttributes;
 import io.awspring.cloud.sqs.listener.QueueMessageVisibility;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
+
+import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
+import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.util.Assert;
+import org.springframework.util.MimeType;
+import org.springframework.util.NumberUtils;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
 
 /**
- * A {@link org.springframework.messaging.support.HeaderMapper} implementation for SQS {@link Message}s. Enables
+ * A {@link HeaderMapper} implementation for SQS {@link Message}s. Enables
  * creating additional SQS related headers from a {@link SqsMessageConversionContext}.
  * @author Tomaz Fernandes
  * @since 3.0
@@ -53,8 +68,83 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 	}
 
 	@Override
-	public void fromHeaders(MessageHeaders headers, Message target) {
-		// We'll probably use this for SqsTemplate later
+	public Message fromHeaders(MessageHeaders headers) {
+		Message.Builder builder = Message.builder();
+		Map<MessageSystemAttributeName, String> attributes = new HashMap<>();
+		if (headers.containsKey(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER)) {
+			attributes.put(MessageSystemAttributeName.MESSAGE_GROUP_ID,
+				headers.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER).toString());
+		}
+		if (headers.containsKey(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER)) {
+			attributes.put(MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID,
+				headers.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER).toString());
+		}
+		Map<String, MessageAttributeValue> messageAttributes = headers
+			.entrySet()
+			.stream()
+			.filter(Predicate.not(entry -> isSkipHeader(entry.getKey())))
+			.collect(Collectors.toMap(Map.Entry::getKey, entry -> getMessageAttributeValue(entry.getKey(), entry.getValue())));
+		if (headers.containsKey(SqsHeaders.SQS_DELAY_HEADER)) {
+			messageAttributes.put(SqsHeaders.SQS_DELAY_HEADER,
+				getNumberMessageAttribute(Objects.requireNonNull(headers.get(SqsHeaders.SQS_DELAY_HEADER, Integer.class),
+					"Delay header value must not be null")));
+		}
+		String messageId = Objects.requireNonNull(headers.getId(), "No ID found for message").toString();
+		return builder.attributes(attributes).messageId(messageId).messageAttributes(messageAttributes).build();
+	}
+
+	private MessageAttributeValue getMessageAttributeValue(String messageHeaderName, @Nullable Object messageHeaderValue) {
+		if (MessageHeaders.CONTENT_TYPE.equals(messageHeaderName) && messageHeaderValue != null) {
+			return getContentTypeMessageAttribute(messageHeaderValue);
+		}
+		else if (MessageHeaders.ID.equals(messageHeaderName) && messageHeaderValue != null) {
+			return getStringMessageAttribute(messageHeaderValue.toString());
+		}
+		else if (messageHeaderValue instanceof String) {
+			return getStringMessageAttribute((String) messageHeaderValue);
+		}
+		else if (messageHeaderValue instanceof Number) {
+			return getNumberMessageAttribute(messageHeaderValue);
+		}
+		else if (messageHeaderValue instanceof ByteBuffer) {
+			return getBinaryMessageAttribute((ByteBuffer) messageHeaderValue);
+		}
+		return getStringMessageAttribute(messageHeaderValue != null ? messageHeaderValue.toString() : "");
+	}
+
+	private boolean isSkipHeader(String headerName) {
+		return SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER.equals(headerName)
+			|| SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER.equals(headerName)
+			|| SqsHeaders.SQS_DELAY_HEADER.equals(headerName);
+	}
+
+	private MessageAttributeValue getBinaryMessageAttribute(ByteBuffer messageHeaderValue) {
+		return MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.BINARY)
+			.binaryValue(SdkBytes.fromByteBuffer(messageHeaderValue)).build();
+	}
+
+	private MessageAttributeValue getContentTypeMessageAttribute(Object messageHeaderValue) {
+		if (messageHeaderValue instanceof MimeType) {
+			return getStringMessageAttribute(messageHeaderValue.toString());
+		}
+		else if (messageHeaderValue instanceof String stringValue) {
+			return getStringMessageAttribute(stringValue);
+		}
+		return getStringMessageAttribute("");
+	}
+
+	private MessageAttributeValue getStringMessageAttribute(String messageHeaderValue) {
+		return MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.STRING)
+			.stringValue(messageHeaderValue).build();
+	}
+
+	private MessageAttributeValue getNumberMessageAttribute(Object messageHeaderValue) {
+		Assert.isTrue(NumberUtils.STANDARD_NUMBER_TYPES.contains(messageHeaderValue.getClass()),
+			"Only standard number types are accepted as message header.");
+		return MessageAttributeValue.builder()
+			.dataType(MessageAttributeDataTypes.NUMBER + "." + messageHeaderValue.getClass().getName())
+			.stringValue(messageHeaderValue.toString())
+			.build();
 	}
 
 	@Override
@@ -64,14 +154,14 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 		accessor.copyHeadersIfAbsent(getMessageSystemAttributesAsHeaders(source));
 		accessor.copyHeadersIfAbsent(getMessageAttributesAsHeaders(source));
 		accessor.copyHeadersIfAbsent(createDefaultHeaders(source));
-		accessor.copyHeadersIfAbsent(createAdditionalHeaders(source, new MessageHeaderAccessor()));
+		accessor.copyHeadersIfAbsent(createAdditionalHeaders(source));
 		MessageHeaders messageHeaders = accessor.toMessageHeaders();
 		logger.trace("Mapped headers {} for message {}", messageHeaders, source.messageId());
 		return new MessagingMessageHeaders(messageHeaders, UUID.fromString(source.messageId()));
 	}
 
-	private MessageHeaders createAdditionalHeaders(Message source, MessageHeaderAccessor accessor) {
-		return this.additionalHeadersFunction.apply(source, accessor);
+	private MessageHeaders createAdditionalHeaders(Message source) {
+		return this.additionalHeadersFunction.apply(source, new MessageHeaderAccessor());
 	}
 
 	private MessageHeaders createDefaultHeaders(Message source) {
@@ -88,7 +178,7 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 			.messageAttributes()
 			.entrySet()
 			.stream()
-			.collect(Collectors.toMap(entry -> SqsHeaders.SQS_MA_HEADER_PREFIX + entry.getKey(), entry -> entry.getValue().stringValue()));
+			.collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().stringValue()));
 	}
 
 	private Map<String, String> getMessageSystemAttributesAsHeaders(Message source) {
@@ -96,7 +186,7 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 			.attributes()
 			.entrySet()
 			.stream()
-			.collect(Collectors.toMap(entry -> SqsHeaders.MessageSystemAttribute.SQS_MSA_HEADER_PREFIX + entry.getKey(), Map.Entry::getValue));
+			.collect(Collectors.toMap(entry -> SqsHeaders.MessageSystemAttributes.SQS_MSA_HEADER_PREFIX + entry.getKey(), Map.Entry::getValue));
 	}
 	// @formatter:on
 
@@ -119,7 +209,7 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 		accessor.setHeader(SqsHeaders.SQS_QUEUE_NAME_HEADER, queueAttributes.getQueueName());
 		accessor.setHeader(SqsHeaders.SQS_QUEUE_URL_HEADER, queueAttributes.getQueueUrl());
 		accessor.setHeader(SqsHeaders.SQS_QUEUE_ATTRIBUTES_HEADER, queueAttributes);
-		accessor.setHeader(SqsHeaders.SQS_VISIBILITY_HEADER,
+		accessor.setHeader(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER,
 				new QueueMessageVisibility(sqsAsyncClient, queueAttributes.getQueueUrl(), source.receiptHandle()));
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
@@ -22,6 +22,7 @@ import io.awspring.cloud.sqs.listener.QueueMessageVisibility;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
 
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -115,7 +116,9 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 	private boolean isSkipHeader(String headerName) {
 		return SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER.equals(headerName)
 			|| SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER.equals(headerName)
-			|| SqsHeaders.SQS_DELAY_HEADER.equals(headerName);
+			|| SqsHeaders.SQS_DELAY_HEADER.equals(headerName)
+			|| MessageHeaders.ID.equals(headerName)
+			|| MessageHeaders.TIMESTAMP.equals(headerName);
 	}
 
 	private MessageAttributeValue getBinaryMessageAttribute(ByteBuffer messageHeaderValue) {

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
@@ -195,12 +195,16 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 	private void addSqsContextHeaders(Message source, SqsMessageConversionContext sqsContext,
 			MessageHeaderAccessor accessor) {
 		QueueAttributes queueAttributes = sqsContext.getQueueAttributes();
+		if (queueAttributes != null) {
+			accessor.setHeader(SqsHeaders.SQS_QUEUE_NAME_HEADER, queueAttributes.getQueueName());
+			accessor.setHeader(SqsHeaders.SQS_QUEUE_URL_HEADER, queueAttributes.getQueueUrl());
+			accessor.setHeader(SqsHeaders.SQS_QUEUE_ATTRIBUTES_HEADER, queueAttributes);
+		}
 		SqsAsyncClient sqsAsyncClient = sqsContext.getSqsAsyncClient();
-		accessor.setHeader(SqsHeaders.SQS_QUEUE_NAME_HEADER, queueAttributes.getQueueName());
-		accessor.setHeader(SqsHeaders.SQS_QUEUE_URL_HEADER, queueAttributes.getQueueUrl());
-		accessor.setHeader(SqsHeaders.SQS_QUEUE_ATTRIBUTES_HEADER, queueAttributes);
-		accessor.setHeader(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER,
+		if (sqsAsyncClient != null && queueAttributes != null) {
+			accessor.setHeader(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER,
 				new QueueMessageVisibility(sqsAsyncClient, queueAttributes.getQueueUrl(), source.receiptHandle()));
+		}
 	}
 
 	private void maybeAddAcknowledgementHeader(AcknowledgementAwareMessageConversionContext sqsContext,

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
@@ -45,7 +45,10 @@ import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
 /**
  * A {@link HeaderMapper} implementation for SQS {@link Message}s. Enables creating additional SQS related headers from
  * a {@link SqsMessageConversionContext}.
+ *
  * @author Tomaz Fernandes
+ * @author Alain Sahli
+ * @author Maciej Walkowiak
  * @since 3.0
  * @see SqsMessagingMessageConverter
  */

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
@@ -203,7 +203,7 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 		SqsAsyncClient sqsAsyncClient = sqsContext.getSqsAsyncClient();
 		if (sqsAsyncClient != null && queueAttributes != null) {
 			accessor.setHeader(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER,
-				new QueueMessageVisibility(sqsAsyncClient, queueAttributes.getQueueUrl(), source.receiptHandle()));
+					new QueueMessageVisibility(sqsAsyncClient, queueAttributes.getQueueUrl(), source.receiptHandle()));
 		}
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
@@ -19,7 +19,6 @@ import io.awspring.cloud.sqs.ConfigUtils;
 import io.awspring.cloud.sqs.listener.QueueAttributes;
 import io.awspring.cloud.sqs.listener.QueueMessageVisibility;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
-
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.HashMap;
@@ -28,7 +27,6 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.lang.Nullable;
@@ -44,8 +42,8 @@ import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
 
 /**
- * A {@link HeaderMapper} implementation for SQS {@link Message}s. Enables
- * creating additional SQS related headers from a {@link SqsMessageConversionContext}.
+ * A {@link HeaderMapper} implementation for SQS {@link Message}s. Enables creating additional SQS related headers from
+ * a {@link SqsMessageConversionContext}.
  * @author Tomaz Fernandes
  * @since 3.0
  * @see SqsMessagingMessageConverter
@@ -69,27 +67,25 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 		Map<MessageSystemAttributeName, String> attributes = new HashMap<>();
 		if (headers.containsKey(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER)) {
 			attributes.put(MessageSystemAttributeName.MESSAGE_GROUP_ID,
-				headers.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER).toString());
+					headers.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER).toString());
 		}
 		if (headers.containsKey(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER)) {
 			attributes.put(MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID,
-				headers.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER).toString());
+					headers.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER).toString());
 		}
-		Map<String, MessageAttributeValue> messageAttributes = headers
-			.entrySet()
-			.stream()
-			.filter(entry -> !isSkipHeader(entry.getKey()))
-			.collect(Collectors.toMap(Map.Entry::getKey, entry -> getMessageAttributeValue(entry.getKey(), entry.getValue())));
+		Map<String, MessageAttributeValue> messageAttributes = headers.entrySet().stream()
+				.filter(entry -> !isSkipHeader(entry.getKey())).collect(Collectors.toMap(Map.Entry::getKey,
+						entry -> getMessageAttributeValue(entry.getKey(), entry.getValue())));
 		if (headers.containsKey(SqsHeaders.SQS_DELAY_HEADER)) {
-			messageAttributes.put(SqsHeaders.SQS_DELAY_HEADER,
-				getNumberMessageAttribute(Objects.requireNonNull(headers.get(SqsHeaders.SQS_DELAY_HEADER, Integer.class),
-					"Delay header value must not be null")));
+			messageAttributes.put(SqsHeaders.SQS_DELAY_HEADER, getNumberMessageAttribute(Objects.requireNonNull(
+					headers.get(SqsHeaders.SQS_DELAY_HEADER, Integer.class), "Delay header value must not be null")));
 		}
 		String messageId = Objects.requireNonNull(headers.getId(), "No ID found for message").toString();
 		return builder.attributes(attributes).messageId(messageId).messageAttributes(messageAttributes).build();
 	}
 
-	private MessageAttributeValue getMessageAttributeValue(String messageHeaderName, @Nullable Object messageHeaderValue) {
+	private MessageAttributeValue getMessageAttributeValue(String messageHeaderName,
+			@Nullable Object messageHeaderValue) {
 		if (MessageHeaders.CONTENT_TYPE.equals(messageHeaderName) && messageHeaderValue != null) {
 			return getContentTypeMessageAttribute(messageHeaderValue);
 		}
@@ -107,15 +103,14 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 
 	private boolean isSkipHeader(String headerName) {
 		return SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER.equals(headerName)
-			|| SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER.equals(headerName)
-			|| SqsHeaders.SQS_DELAY_HEADER.equals(headerName)
-			|| MessageHeaders.ID.equals(headerName)
-			|| MessageHeaders.TIMESTAMP.equals(headerName);
+				|| SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER.equals(headerName)
+				|| SqsHeaders.SQS_DELAY_HEADER.equals(headerName) || MessageHeaders.ID.equals(headerName)
+				|| MessageHeaders.TIMESTAMP.equals(headerName);
 	}
 
 	private MessageAttributeValue getBinaryMessageAttribute(ByteBuffer messageHeaderValue) {
 		return MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.BINARY)
-			.binaryValue(SdkBytes.fromByteBuffer(messageHeaderValue)).build();
+				.binaryValue(SdkBytes.fromByteBuffer(messageHeaderValue)).build();
 	}
 
 	private MessageAttributeValue getContentTypeMessageAttribute(Object messageHeaderValue) {
@@ -130,16 +125,15 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 
 	private MessageAttributeValue getStringMessageAttribute(String messageHeaderValue) {
 		return MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.STRING)
-			.stringValue(messageHeaderValue).build();
+				.stringValue(messageHeaderValue).build();
 	}
 
 	private MessageAttributeValue getNumberMessageAttribute(Object messageHeaderValue) {
 		Assert.isTrue(NumberUtils.STANDARD_NUMBER_TYPES.contains(messageHeaderValue.getClass()),
-			"Only standard number types are accepted as message header.");
+				"Only standard number types are accepted as message header.");
 		return MessageAttributeValue.builder()
-			.dataType(MessageAttributeDataTypes.NUMBER + "." + messageHeaderValue.getClass().getName())
-			.stringValue(messageHeaderValue.toString())
-			.build();
+				.dataType(MessageAttributeDataTypes.NUMBER + "." + messageHeaderValue.getClass().getName())
+				.stringValue(messageHeaderValue.toString()).build();
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.sqs.support.converter;
 
 import io.awspring.cloud.sqs.ConfigUtils;
+import io.awspring.cloud.sqs.MessagingHeaders;
 import io.awspring.cloud.sqs.listener.QueueAttributes;
 import io.awspring.cloud.sqs.listener.QueueMessageVisibility;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
@@ -205,7 +206,7 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 	private void maybeAddAcknowledgementHeader(AcknowledgementAwareMessageConversionContext sqsContext,
 			MessageHeaderAccessor accessor) {
 		ConfigUtils.INSTANCE.acceptIfNotNull(sqsContext.getAcknowledgementCallback(),
-				callback -> accessor.setHeader(SqsHeaders.SQS_ACKNOWLEDGMENT_CALLBACK_HEADER, callback));
+				callback -> accessor.setHeader(MessagingHeaders.ACKNOWLEDGMENT_CALLBACK_HEADER, callback));
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
@@ -16,24 +16,19 @@
 package io.awspring.cloud.sqs.support.converter;
 
 import io.awspring.cloud.sqs.ConfigUtils;
-import io.awspring.cloud.sqs.MessageHeaderUtils;
 import io.awspring.cloud.sqs.listener.QueueAttributes;
 import io.awspring.cloud.sqs.listener.QueueMessageVisibility;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
 
 import java.nio.ByteBuffer;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.lang.Nullable;
@@ -83,7 +78,7 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 		Map<String, MessageAttributeValue> messageAttributes = headers
 			.entrySet()
 			.stream()
-			.filter(Predicate.not(entry -> isSkipHeader(entry.getKey())))
+			.filter(entry -> !isSkipHeader(entry.getKey()))
 			.collect(Collectors.toMap(Map.Entry::getKey, entry -> getMessageAttributeValue(entry.getKey(), entry.getValue())));
 		if (headers.containsKey(SqsHeaders.SQS_DELAY_HEADER)) {
 			messageAttributes.put(SqsHeaders.SQS_DELAY_HEADER,
@@ -97,9 +92,6 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 	private MessageAttributeValue getMessageAttributeValue(String messageHeaderName, @Nullable Object messageHeaderValue) {
 		if (MessageHeaders.CONTENT_TYPE.equals(messageHeaderName) && messageHeaderValue != null) {
 			return getContentTypeMessageAttribute(messageHeaderValue);
-		}
-		else if (MessageHeaders.ID.equals(messageHeaderName) && messageHeaderValue != null) {
-			return getStringMessageAttribute(messageHeaderValue.toString());
 		}
 		else if (messageHeaderValue instanceof String) {
 			return getStringMessageAttribute((String) messageHeaderValue);

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessageConversionContext.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessageConversionContext.java
@@ -19,11 +19,13 @@ import io.awspring.cloud.sqs.listener.QueueAttributes;
 import io.awspring.cloud.sqs.listener.QueueAttributesAware;
 import io.awspring.cloud.sqs.listener.SqsAsyncClientAware;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementCallback;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.MessageHeaders;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 /**
  * {@link MessageConversionContext} implementation that contains SQS related properties for mapping additional
- * {@link org.springframework.messaging.MessageHeaders}. Also contains a {@link AcknowledgementCallback} to be used for
+ * {@link MessageHeaders}. Also contains a {@link AcknowledgementCallback} to be used for
  * mapping acknowledgement related headers.
  * @author Tomaz Fernandes
  * @since 3.0
@@ -33,11 +35,17 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 public class SqsMessageConversionContext
 		implements AcknowledgementAwareMessageConversionContext, SqsAsyncClientAware, QueueAttributesAware {
 
+	@Nullable
 	private QueueAttributes queueAttributes;
 
+	@Nullable
 	private SqsAsyncClient sqsAsyncClient;
 
+	@Nullable
 	private AcknowledgementCallback<?> acknowledgementCallback;
+
+	@Nullable
+	private Class<?> payloadClass;
 
 	@Override
 	public void setQueueAttributes(QueueAttributes queueAttributes) {
@@ -54,17 +62,28 @@ public class SqsMessageConversionContext
 		this.acknowledgementCallback = acknowledgementCallback;
 	}
 
+	public void setPayloadClass(Class<?> payloadClass) {
+		this.payloadClass = payloadClass;
+	}
+
+	@Nullable
 	public SqsAsyncClient getSqsAsyncClient() {
 		return this.sqsAsyncClient;
 	}
 
+	@Nullable
 	public QueueAttributes getQueueAttributes() {
 		return this.queueAttributes;
 	}
 
+	@Nullable
 	@Override
 	public AcknowledgementCallback<?> getAcknowledgementCallback() {
 		return this.acknowledgementCallback;
 	}
 
+	@Nullable
+	public Class<?> getPayloadClass() {
+		return this.payloadClass;
+	}
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessageConversionContext.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessageConversionContext.java
@@ -25,8 +25,8 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 /**
  * {@link MessageConversionContext} implementation that contains SQS related properties for mapping additional
- * {@link MessageHeaders}. Also contains a {@link AcknowledgementCallback} to be used for
- * mapping acknowledgement related headers.
+ * {@link MessageHeaders}. Also contains a {@link AcknowledgementCallback} to be used for mapping acknowledgement
+ * related headers.
  * @author Tomaz Fernandes
  * @since 3.0
  * @see SqsHeaderMapper

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverter.java
@@ -47,7 +47,7 @@ public class SqsMessagingMessageConverter
 
 	@Override
 	protected software.amazon.awssdk.services.sqs.model.Message doConvertMessage(
-		software.amazon.awssdk.services.sqs.model.Message messageWithHeaders, Object payload) {
+			software.amazon.awssdk.services.sqs.model.Message messageWithHeaders, Object payload) {
 		Assert.isInstanceOf(String.class, payload, "payload must be instance of String");
 		return messageWithHeaders.toBuilder().body((String) payload).build();
 	}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverter.java
@@ -16,7 +16,7 @@
 package io.awspring.cloud.sqs.support.converter;
 
 import org.springframework.messaging.Message;
-import org.springframework.messaging.support.HeaderMapper;
+import org.springframework.util.Assert;
 
 /**
  * {@link MessagingMessageConverter} implementation for converting SQS
@@ -31,18 +31,25 @@ public class SqsMessagingMessageConverter
 		extends AbstractMessagingMessageConverter<software.amazon.awssdk.services.sqs.model.Message> {
 
 	@Override
-	protected HeaderMapper<software.amazon.awssdk.services.sqs.model.Message> getDefaultHeaderMapper() {
+	protected HeaderMapper<software.amazon.awssdk.services.sqs.model.Message> createDefaultHeaderMapper() {
 		return new SqsHeaderMapper();
 	}
 
 	@Override
-	protected Object getPayloadToConvert(software.amazon.awssdk.services.sqs.model.Message message) {
+	protected Object getPayloadToDeserialize(software.amazon.awssdk.services.sqs.model.Message message) {
 		return message.body();
 	}
 
 	@Override
 	public MessageConversionContext createMessageConversionContext() {
 		return new SqsMessageConversionContext();
+	}
+
+	@Override
+	protected software.amazon.awssdk.services.sqs.model.Message doConvertMessage(
+		software.amazon.awssdk.services.sqs.model.Message messageWithHeaders, Object payload) {
+		Assert.isInstanceOf(String.class, payload, "payload must be instance of String");
+		return messageWithHeaders.toBuilder().body((String) payload).build();
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/AcknowledgmentHandlerMethodArgumentResolver.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/AcknowledgmentHandlerMethodArgumentResolver.java
@@ -16,7 +16,7 @@
 package io.awspring.cloud.sqs.support.resolver;
 
 import io.awspring.cloud.sqs.MessageHeaderUtils;
-import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.MessagingHeaders;
 import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementCallback;
 import java.util.concurrent.CompletableFuture;
@@ -42,7 +42,7 @@ public class AcknowledgmentHandlerMethodArgumentResolver implements HandlerMetho
 	@Override
 	public Object resolveArgument(MethodParameter parameter, Message<?> message) {
 		AcknowledgementCallback<Object> callback = message.getHeaders()
-				.get(SqsHeaders.SQS_ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class);
+				.get(MessagingHeaders.ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class);
 		Assert.notNull(callback, "No acknowledgement found for message " + MessageHeaderUtils.getId(message)
 				+ ". AcknowledgeMode should be MANUAL.");
 		return new Acknowledgement() {

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/BatchAcknowledgmentArgumentResolver.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/BatchAcknowledgmentArgumentResolver.java
@@ -16,7 +16,7 @@
 package io.awspring.cloud.sqs.support.resolver;
 
 import io.awspring.cloud.sqs.MessageHeaderUtils;
-import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.MessagingHeaders;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementCallback;
 import io.awspring.cloud.sqs.listener.acknowledgement.BatchAcknowledgement;
 import java.util.Collection;
@@ -46,7 +46,7 @@ public class BatchAcknowledgmentArgumentResolver implements HandlerMethodArgumen
 		Assert.isInstanceOf(Collection.class, payloadObject, "Payload must be instance of Collection");
 		Collection<Message<Object>> messages = (Collection<Message<Object>>) payloadObject;
 		AcknowledgementCallback<Object> callback = messages.iterator().next().getHeaders()
-				.get(SqsHeaders.SQS_ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class);
+				.get(MessagingHeaders.ACKNOWLEDGMENT_CALLBACK_HEADER, AcknowledgementCallback.class);
 		Assert.notNull(callback, "No acknowledgement found for messages " + MessageHeaderUtils.getId(messages)
 				+ ". AcknowledgeMode should be MANUAL.");
 		return createBatchAcknowledgement(messages, callback);

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/QueueAttributesResolverIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/QueueAttributesResolverIntegrationTests.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.awspring.cloud.sqs.QueueAttributesResolvingException;
 import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration;
 import io.awspring.cloud.sqs.listener.QueueAttributes;
-import io.awspring.cloud.sqs.listener.QueueAttributesResolver;
+import io.awspring.cloud.sqs.QueueAttributesResolver;
 import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/QueueAttributesResolverIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/QueueAttributesResolverIntegrationTests.java
@@ -18,10 +18,10 @@ package io.awspring.cloud.sqs.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.awspring.cloud.sqs.QueueAttributesResolver;
 import io.awspring.cloud.sqs.QueueAttributesResolvingException;
 import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration;
 import io.awspring.cloud.sqs.listener.QueueAttributes;
-import io.awspring.cloud.sqs.QueueAttributesResolver;
 import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsFifoIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsFifoIntegrationTests.java
@@ -378,7 +378,7 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 
 		@SqsListener(queueNames = FIFO_RECEIVES_MESSAGE_IN_ORDER_MANY_GROUPS_QUEUE_NAME, id = "receives-in-order-many-groups")
 		void listen(Message<String> message,
-				@Header(SqsHeaders.MessageSystemAttribute.SQS_MESSAGE_GROUP_ID_HEADER) String groupId) {
+				@Header(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER) String groupId) {
 			logger.trace("Received message {} in listener method from groupId {}", message.getPayload(), groupId);
 			loadSimulator.runLoad();
 			List<String> messageList = receivedMessages.computeIfAbsent(groupId, newGroupId -> new ArrayList<>());
@@ -450,10 +450,10 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 		void listen(List<Message<String>> messages) {
 			String firstMessage = messages.iterator().next().getPayload();// Make sure we got the right type
 			Assert.isTrue(MessageHeaderUtils
-					.getHeader(messages, SqsHeaders.MessageSystemAttribute.SQS_MESSAGE_GROUP_ID_HEADER, String.class)
+					.getHeader(messages, SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, String.class)
 					.stream().distinct().count() == 1, "More than one message group returned in the same batch");
 			String messageGroupId = messages.iterator().next().getHeaders()
-					.get(SqsHeaders.MessageSystemAttribute.SQS_MESSAGE_GROUP_ID_HEADER, String.class);
+					.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, String.class);
 			List<String> values = messages.stream().map(Message::getPayload).collect(toList());
 			logger.trace("Started processing messages {} for group id {}", values, messageGroupId);
 			receivedMessages.computeIfAbsent(messageGroupId, groupId -> Collections.synchronizedList(new ArrayList<>()))
@@ -593,7 +593,7 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 				public void onSuccess(Collection<Message<String>> messages) {
 					if (FIFO_RECEIVES_MESSAGE_IN_ORDER_MANY_GROUPS_QUEUE_NAME.equals(MessageHeaderUtils.getHeaderAsString(messages.iterator().next(), SqsHeaders.SQS_QUEUE_NAME_HEADER))) {
 						messages.stream()
-							.collect(groupingBy(msg -> MessageHeaderUtils.getHeaderAsString(msg, SqsHeaders.MessageSystemAttribute.SQS_MESSAGE_GROUP_ID_HEADER)))
+							.collect(groupingBy(msg -> MessageHeaderUtils.getHeaderAsString(msg, SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER)))
 							.forEach((key, value) -> messagesContainer.acknowledgesFromManyGroups.computeIfAbsent(key,
 								newGroup -> Collections.synchronizedList(new ArrayList<>())).addAll(value.stream().map(Message::getPayload).collect(toList())));
 						messages.forEach(msg -> {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsFifoIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsFifoIntegrationTests.java
@@ -143,8 +143,7 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 				createFifoQueue(client, FIFO_RECEIVES_MESSAGES_IN_ORDER_QUEUE_NAME, getVisibilityAttribute("20")),
 				createFifoQueue(client, FIFO_RECEIVES_MESSAGE_IN_ORDER_MANY_GROUPS_QUEUE_NAME),
 				createFifoQueue(client, FIFO_STOPS_PROCESSING_ON_ERROR_QUEUE_NAME, getVisibilityAttribute("2")),
-				createFifoQueue(client, FIFO_STOPS_PROCESSING_ON_ACK_ERROR_ERROR_QUEUE_NAME,
-						getVisibilityAttribute("2")),
+				createFifoQueue(client, FIFO_STOPS_PROCESSING_ON_ACK_ERROR_ERROR_QUEUE_NAME),
 				createFifoQueue(client, FIFO_RECEIVES_BATCHES_MANY_GROUPS_QUEUE_NAME),
 				createFifoQueue(client, FIFO_MANUALLY_CREATE_CONTAINER_QUEUE_NAME),
 				createFifoQueue(client, FIFO_MANUALLY_CREATE_FACTORY_QUEUE_NAME),
@@ -251,10 +250,16 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 				.containsExactlyElementsOf(values.subList(3, this.settings.messagesPerTest));
 	}
 
+	final AtomicBoolean stopsProcessingOnAckErrorHasThrown = new AtomicBoolean(false);
+
 	@Test
 	void stopsProcessingAfterAckException() throws Exception {
 		latchContainer.stopsProcessingOnAckErrorLatch1 = new CountDownLatch(4);
 		latchContainer.stopsProcessingOnAckErrorLatch2 = new CountDownLatch(this.settings.messagesPerTest - 3);
+		latchContainer.stopsProcessingOnAckErrorHasThrown = new CountDownLatch(1);
+		messagesContainer.stopsProcessingOnAckErrorBeforeThrown.clear();
+		messagesContainer.stopsProcessingOnAckErrorAfterThrown.clear();
+		stopsProcessingOnAckErrorHasThrown.set(false);
 		List<String> values = IntStream.range(0, this.settings.messagesPerTest).mapToObj(String::valueOf)
 				.collect(toList());
 		String messageGroupId = UUID.randomUUID().toString();
@@ -530,6 +535,7 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 		CountDownLatch stopsProcessingOnErrorLatch2;
 		CountDownLatch stopsProcessingOnAckErrorLatch1;
 		CountDownLatch stopsProcessingOnAckErrorLatch2;
+		CountDownLatch stopsProcessingOnAckErrorHasThrown;
 		CountDownLatch receivesBatchManyGroupsLatch;
 
 		LatchContainer(Settings settings) {
@@ -548,6 +554,7 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 			this.stopsProcessingOnAckErrorLatch1 = new CountDownLatch(1);
 			this.stopsProcessingOnAckErrorLatch2 = new CountDownLatch(1);
 			this.receivesBatchManyGroupsLatch = new CountDownLatch(1);
+			this.stopsProcessingOnAckErrorHasThrown = new CountDownLatch(1);
 		}
 
 	}
@@ -622,29 +629,34 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 			factory.setContainerComponentFactories(Collections.singletonList(new FifoSqsComponentFactory<String>() {
 				@Override
 				public AcknowledgementHandler<String> createAcknowledgementHandler(SqsContainerOptions options) {
-					return new OnSuccessAcknowledgementHandler<String>() {
-
-						final AtomicBoolean hasThrown = new AtomicBoolean(false);
+					return new OnSuccessAcknowledgementHandler<>() {
 
 						@Override
 						public CompletableFuture<Void> onSuccess(Message<String> message,
 																 AcknowledgementCallback<String> callback) {
-							if (message.getPayload().equals("3") && hasThrown.compareAndSet(false, true)) {
+							if (message.getPayload().equals("3") && latchContainer.stopsProcessingOnAckErrorHasThrown.getCount() == 1) {
+								latchContainer.stopsProcessingOnAckErrorHasThrown.countDown();
 								messagesContainer.stopsProcessingOnAckErrorBeforeThrown.add(message.getPayload());
 								latchContainer.stopsProcessingOnAckErrorLatch1.countDown();
+								logger.debug("stopsProcessingOnAckErrorLatch1 countdown. Remaining: {}",
+									latchContainer.stopsProcessingOnAckErrorLatch1.getCount());
 								return CompletableFutures.failedFuture(new RuntimeException("Expected acking error"));
 							}
 							return super.onSuccess(message, callback).whenComplete((v, t) -> handleResult(message));
 						}
 
 						private void handleResult(Message<String> message) {
-							if (!hasThrown.get()) {
+							if (latchContainer.stopsProcessingOnAckErrorHasThrown.getCount() == 1) {
 								messagesContainer.stopsProcessingOnAckErrorBeforeThrown.add(message.getPayload());
 								latchContainer.stopsProcessingOnAckErrorLatch1.countDown();
+								logger.debug("stopsProcessingOnAckErrorLatch1 countdown. Remaining: {}",
+									latchContainer.stopsProcessingOnAckErrorLatch1.getCount());
 							}
 							else {
 								messagesContainer.stopsProcessingOnAckErrorAfterThrown.add(message.getPayload());
 								latchContainer.stopsProcessingOnAckErrorLatch2.countDown();
+								logger.debug("stopsProcessingOnAckErrorLatch2 countdown. Remaining: {}",
+									latchContainer.stopsProcessingOnAckErrorLatch2.getCount());
 							}
 						}
 					};

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
@@ -1,0 +1,213 @@
+package io.awspring.cloud.sqs.integration;
+
+import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement;
+import io.awspring.cloud.sqs.operations.SqsOperations;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import io.awspring.cloud.sqs.operations.TemplateAcknowledgementMode;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 3.0
+ */
+@SpringBootTest
+public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
+
+	private static final String SENDS_AND_RECEIVES_MESSAGE_QUEUE_NAME = "send-receive-message-queue";
+
+	private static final String SENDS_AND_RECEIVES_RECORD_QUEUE_NAME = "send-receive-record-queue";
+
+	private static final String SENDS_AND_RECEIVES_WITH_HEADERS_QUEUE_NAME = "send-receive-with-headers-queue";
+
+	private static final String SENDS_AND_RECEIVES_MANUAL_ACK_QUEUE_NAME = "send-receive-manual-ack-record-queue";
+
+	private static final String SENDS_AND_RECEIVES_BATCH_QUEUE_NAME = "send-receive-batch-queue";
+
+	private static final String RECORD_WITHOUT_TYPE_HEADER_QUEUE_NAME = "record-without-type-header-queue";
+
+	private static final String EMPTY_QUEUE_NAME = "empty-message-queue";
+
+	private static final String SENDS_AND_RECEIVES_MESSAGE_FIFO_QUEUE_NAME = "send-receive-message-queue.fifo";
+
+	@Autowired
+	private SqsAsyncClient asyncClient;
+
+	@BeforeAll
+	static void beforeTests() {
+		SqsAsyncClient client = createAsyncClient();
+		CompletableFuture.allOf(
+			createQueue(client, SENDS_AND_RECEIVES_MESSAGE_QUEUE_NAME),
+			createQueue(client, SENDS_AND_RECEIVES_RECORD_QUEUE_NAME),
+			createQueue(client, SENDS_AND_RECEIVES_BATCH_QUEUE_NAME),
+			createQueue(client, SENDS_AND_RECEIVES_WITH_HEADERS_QUEUE_NAME),
+			createQueue(client, RECORD_WITHOUT_TYPE_HEADER_QUEUE_NAME),
+			createQueue(client, SENDS_AND_RECEIVES_MANUAL_ACK_QUEUE_NAME),
+			createQueue(client, EMPTY_QUEUE_NAME),
+			createFifoQueue(client, SENDS_AND_RECEIVES_MESSAGE_FIFO_QUEUE_NAME))
+			.join();
+	}
+
+	@Test
+	void shouldSendAndReceiveStringMessage() {
+		SqsTemplate<Object> template = SqsTemplate
+			.newTemplate(this.asyncClient);
+		String testBody = "Hello world!";
+		UUID messageId = template.send(to -> to
+			.queue(SENDS_AND_RECEIVES_MESSAGE_QUEUE_NAME)
+			.payload(testBody));
+		assertThat(messageId).isNotNull();
+		Optional<Message<Object>> receivedMessage = template.receive(from -> from
+			.queue(SENDS_AND_RECEIVES_MESSAGE_QUEUE_NAME));
+		assertThat(receivedMessage).isPresent().get().extracting(Message::getPayload).isEqualTo(testBody);
+	}
+
+	@Test
+	void shouldSendAndReceiveRecordMessageAndAcknowledge() {
+		SqsTemplate<SampleRecord> template = SqsTemplate.newTemplate(this.asyncClient);
+		SampleRecord testRecord = new SampleRecord("Hello world!", "From SQS!");
+		UUID messageId = template.send(SENDS_AND_RECEIVES_RECORD_QUEUE_NAME, testRecord);
+		assertThat(messageId).isNotNull();
+		Optional<Message<SampleRecord>> receivedMessage = template.receive(from -> from
+			.queue(SENDS_AND_RECEIVES_RECORD_QUEUE_NAME));
+		assertThat(receivedMessage).isPresent().get().extracting(Message::getPayload).isEqualTo(testRecord);
+		Optional<Message<SampleRecord>> receivedMessage2 = template.receive(from -> from
+			.queue(SENDS_AND_RECEIVES_RECORD_QUEUE_NAME).pollTimeout(Duration.ofSeconds(1)));
+		assertThat(receivedMessage2).isEmpty();
+	}
+
+	@Test
+	void shouldSendAndReceiveMessageWithHeaders() {
+		SqsTemplate<SampleRecord> template = SqsTemplate.newTemplate(this.asyncClient);
+		SampleRecord testRecord = new SampleRecord("Hello world!", "From SQS!");
+		String myCustomHeader = "MyCustomHeader";
+		String myCustomValue = "MyCustomValue";
+		String myCustomHeader2 = "MyCustomHeader2";
+		String myCustomValue2 = "MyCustomValue2";
+		template.send(to -> to
+			.queue(SENDS_AND_RECEIVES_WITH_HEADERS_QUEUE_NAME)
+			.payload(testRecord)
+			.header(myCustomHeader, myCustomValue)
+			.headers(Map.of(myCustomHeader2, myCustomValue2))
+		);
+		Optional<Message<SampleRecord>> receivedMessage = template.receive(from -> from
+			.queue(SENDS_AND_RECEIVES_WITH_HEADERS_QUEUE_NAME));
+		assertThat(receivedMessage).isPresent().get().extracting(Message::getHeaders)
+			.asInstanceOf(InstanceOfAssertFactories.MAP)
+			.containsKeys(myCustomHeader, myCustomHeader2)
+			.containsValues(myCustomValue, myCustomValue2);
+	}
+
+	@Test
+	void shouldSendAndReceiveWithManualAcknowledgement() {
+		SqsTemplate<SampleRecord> template = SqsTemplate.<SampleRecord>builder()
+			.sqsAsyncClient(this.asyncClient)
+			.configure(options -> options.acknowledgementMode(TemplateAcknowledgementMode.DO_NOT_ACKNOWLEDGE)
+				.endpointName(SENDS_AND_RECEIVES_MANUAL_ACK_QUEUE_NAME))
+			.build();
+		SampleRecord testRecord = new SampleRecord("Hello world!", "From SQS!");
+		template.send(to -> to.payload(testRecord));
+		Optional<Message<SampleRecord>> receivedMessage = template.receive(from -> from
+			.visibilityTimeout(Duration.ofSeconds(1)));
+
+		assertThat(receivedMessage).isPresent().get().extracting(Message::getPayload).isEqualTo(testRecord);
+
+		Optional<Message<SampleRecord>> receivedMessage2 = template.receive(from -> from
+			.visibilityTimeout(Duration.ofSeconds(1)));
+		assertThat(receivedMessage).isPresent().get().extracting(Message::getPayload).isEqualTo(testRecord);
+		Message<SampleRecord> message = receivedMessage2.get();
+		Acknowledgement.acknowledge(message);
+		Optional<Message<SampleRecord>> receivedMessage3 = template.receive(from -> from
+			.pollTimeout(Duration.ofSeconds(1)));
+		assertThat(receivedMessage3).isEmpty();
+	}
+
+	@Test
+	void shouldSendAndReceiveBatch() {
+		SqsTemplate<SampleRecord> template = SqsTemplate.newTemplate(this.asyncClient);
+		List<Message<SampleRecord>> messagesToSend = IntStream
+			.range(0, 5)
+			.mapToObj(index -> new SampleRecord("Hello world - " + index, "From SQS!"))
+			.map(record -> MessageBuilder.withPayload(record).build())
+			.toList();
+		template.send(SENDS_AND_RECEIVES_BATCH_QUEUE_NAME, messagesToSend);
+		Collection<SampleRecord> receivedMessages = template
+			.receiveMany(from -> from
+				.queue(SENDS_AND_RECEIVES_BATCH_QUEUE_NAME)
+				.pollTimeout(Duration.ofSeconds(10))
+				.maxNumberOfMessages(10))
+			.stream()
+			.map(Message::getPayload)
+			.toList();
+		assertThat(receivedMessages)
+			.hasSize(5)
+			.containsExactlyElementsOf(messagesToSend.stream().map(Message::getPayload).toList());
+	}
+
+	@Test
+	void shouldSendAndReceiveMessageFifo() {
+		String testBody = "Hello world!";
+		SqsOperations<Object> template = SqsTemplate.newTemplate(this.asyncClient);
+		template.sendFifo(to -> to
+			.queue(SENDS_AND_RECEIVES_MESSAGE_FIFO_QUEUE_NAME)
+			.payload(testBody));
+		Optional<Message<Object>> receivedMessage = template
+			.receiveFifo(from -> from.queue(SENDS_AND_RECEIVES_MESSAGE_FIFO_QUEUE_NAME));
+		assertThat(receivedMessage).isPresent().get().extracting(Message::getPayload).isEqualTo(testBody);
+	}
+
+	@Test
+	void shouldSendAndReceiveRecordMessageWithoutPayloadInfoHeader() {
+		SqsTemplate<SampleRecord> template = SqsTemplate
+			.<SampleRecord>builder()
+			.sqsAsyncClient(this.asyncClient)
+			.defaultMessageConverter(converter -> converter.setPayloadTypeHeaderValueFunction(msg -> null))
+			.build();
+		SampleRecord testRecord = new SampleRecord("Hello world!", "From SQS!");
+		UUID messageId = template.send(RECORD_WITHOUT_TYPE_HEADER_QUEUE_NAME, testRecord);
+		assertThat(messageId).isNotNull();
+		Optional<Message<SampleRecord>> receivedMessage = template.receive(from -> from
+			.queue(RECORD_WITHOUT_TYPE_HEADER_QUEUE_NAME)
+			.payloadClass(SampleRecord.class));
+		assertThat(receivedMessage).isPresent().get().extracting(Message::getPayload).isEqualTo(testRecord);
+	}
+
+	@Test
+	void shouldReceiveEmptyMessage() {
+		Optional<Message<Object>> receivedMessage = SqsTemplate
+			.newTemplate(this.asyncClient)
+			.receive(from -> from.queue(EMPTY_QUEUE_NAME).pollTimeout(Duration.ofSeconds(1)));
+		assertThat(receivedMessage).isEmpty();
+	}
+
+	private record SampleRecord(String propertyOne, String propertyTwo) {}
+
+	@Configuration
+	static class SQSConfiguration {
+
+		@Bean
+		SqsAsyncClient client() {
+			return createAsyncClient();
+		}
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
@@ -158,7 +158,7 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 	void shouldSendAndReceiveWithManualAcknowledgement() {
 		SqsTemplate template = SqsTemplate.builder().sqsAsyncClient(this.asyncClient)
 				.configure(options -> options.acknowledgementMode(TemplateAcknowledgementMode.MANUAL)
-						.defaultEndpointName(SENDS_AND_RECEIVES_MANUAL_ACK_QUEUE_NAME))
+						.defaultQueue(SENDS_AND_RECEIVES_MANUAL_ACK_QUEUE_NAME))
 				.build();
 		SampleRecord testRecord = new SampleRecord("Hello world!", "From SQS!");
 		template.send(to -> to.payload(testRecord));

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
@@ -92,7 +92,7 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void shouldSendAndReceiveStringMessage() {
-		SqsTemplate<Object> template = SqsTemplate.newTemplate(this.asyncClient);
+		SqsTemplate template = SqsTemplate.newTemplate(this.asyncClient);
 		String testBody = "Hello world!";
 		SendResult<Object> result = template
 				.send(to -> to.queue(SENDS_AND_RECEIVES_MESSAGE_QUEUE_NAME).payload(testBody));
@@ -104,7 +104,7 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void shouldSendAndReceiveRecordMessageAndAcknowledge() {
-		SqsTemplate<SampleRecord> template = SqsTemplate.newTemplate(this.asyncClient);
+		SqsTemplate template = SqsTemplate.newTemplate(this.asyncClient);
 		SampleRecord testRecord = new SampleRecord("Hello world!", "From SQS!");
 		SendResult<SampleRecord> result = template.send(SENDS_AND_RECEIVES_RECORD_QUEUE_NAME, testRecord);
 		assertThat(result).isNotNull();
@@ -118,7 +118,7 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void shouldSendMessageWithDelay() {
-		SqsTemplate<SampleRecord> template = SqsTemplate.newTemplate(this.asyncClient);
+		SqsTemplate template = SqsTemplate.newTemplate(this.asyncClient);
 		SampleRecord testRecord = new SampleRecord("Hello world!", "From SQS!");
 		StopWatch stopWatch = new StopWatch();
 		stopWatch.start();
@@ -134,7 +134,7 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void shouldSendAndReceiveMessageWithHeaders() {
-		SqsOperations<SampleRecord> template = SqsTemplate.newTemplate(this.asyncClient);
+		SqsOperations template = SqsTemplate.newTemplate(this.asyncClient);
 		SampleRecord testRecord = new SampleRecord("Hello world!", "From SQS!");
 		String myCustomHeader = "MyCustomHeader";
 		String myCustomValue = "MyCustomValue";
@@ -155,7 +155,7 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void shouldSendAndReceiveWithManualAcknowledgement() {
-		SqsTemplate<SampleRecord> template = SqsTemplate.<SampleRecord> builder().sqsAsyncClient(this.asyncClient)
+		SqsTemplate template = SqsTemplate.builder().sqsAsyncClient(this.asyncClient)
 				.configure(options -> options.acknowledgementMode(TemplateAcknowledgementMode.MANUAL)
 						.defaultEndpointName(SENDS_AND_RECEIVES_MANUAL_ACK_QUEUE_NAME))
 				.build();
@@ -176,7 +176,7 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void shouldSendAndReceiveBatch() {
-		SqsOperations<SampleRecord> template = SqsTemplate.<SampleRecord> builder().sqsAsyncClient(this.asyncClient)
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(this.asyncClient)
 				.configure(options -> options.acknowledgementMode(TemplateAcknowledgementMode.MANUAL))
 				.buildSyncTemplate();
 		List<Message<SampleRecord>> messagesToSend = IntStream.range(0, 5)
@@ -198,7 +198,7 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void shouldSendAndReceiveMessageFifo() {
 		String testBody = "Hello world!";
-		SqsOperations<Object> template = SqsTemplate.newTemplate(this.asyncClient);
+		SqsOperations template = SqsTemplate.newTemplate(this.asyncClient);
 		SendResult<Object> result = template
 				.sendFifo(to -> to.queue(SENDS_AND_RECEIVES_MESSAGE_FIFO_QUEUE_NAME).payload(testBody));
 		Optional<Message<Object>> receivedMessage = template
@@ -221,7 +221,7 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void shouldSendAndReceiveBatchFifo() {
 		int batchSize = 5;
-		SqsTemplate<SampleRecord> template = SqsTemplate.newTemplate(this.asyncClient);
+		SqsTemplate template = SqsTemplate.newTemplate(this.asyncClient);
 		List<Message<SampleRecord>> messagesToSend = IntStream.range(0, batchSize)
 				.mapToObj(index -> new SampleRecord("Hello world - " + index, "From SQS!"))
 				.map(record -> MessageBuilder.withPayload(record).build()).toList();
@@ -268,7 +268,7 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void shouldSendAndReceiveRecordMessageWithoutPayloadInfoHeader() {
-		SqsTemplate<SampleRecord> template = SqsTemplate.<SampleRecord> builder().sqsAsyncClient(this.asyncClient)
+		SqsTemplate template = SqsTemplate.builder().sqsAsyncClient(this.asyncClient)
 				.configureDefaultConverter(converter -> converter.setPayloadTypeHeaderValueFunction(msg -> null))
 				.build();
 		SampleRecord testRecord = new SampleRecord("Hello world!", "From SQS!");

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
@@ -32,7 +32,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Tomaz Fernandes
- * @since 3.0
  */
 @SpringBootTest
 public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
@@ -1,4 +1,21 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.awspring.cloud.sqs.listener.SqsHeaders;
 import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement;
@@ -7,6 +24,14 @@ import io.awspring.cloud.sqs.operations.SqsOperations;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import io.awspring.cloud.sqs.operations.SqsTemplateParameters;
 import io.awspring.cloud.sqs.operations.TemplateAcknowledgementMode;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -18,17 +43,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.StopWatch;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
-
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.IntStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Tomaz Fernandes
@@ -64,32 +78,27 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 	@BeforeAll
 	static void beforeTests() {
 		SqsAsyncClient client = createAsyncClient();
-		CompletableFuture.allOf(
-			createQueue(client, SENDS_AND_RECEIVES_MESSAGE_QUEUE_NAME),
-			createQueue(client, SENDS_AND_RECEIVES_RECORD_QUEUE_NAME),
-			createQueue(client, SENDS_AND_RECEIVES_BATCH_QUEUE_NAME),
-			createQueue(client, SENDS_AND_RECEIVES_WITH_HEADERS_QUEUE_NAME),
-			createQueue(client, RECORD_WITHOUT_TYPE_HEADER_QUEUE_NAME),
-			createQueue(client, RETURNS_ON_PARTIAL_BATCH_QUEUE_NAME),
-			createQueue(client, THROWS_ON_PARTIAL_BATCH_QUEUE_NAME),
-			createQueue(client, SENDS_AND_RECEIVES_MANUAL_ACK_QUEUE_NAME),
-			createQueue(client, EMPTY_QUEUE_NAME),
-			createFifoQueue(client, SENDS_AND_RECEIVES_MESSAGE_FIFO_QUEUE_NAME),
-			createFifoQueue(client, SENDS_AND_RECEIVES_BATCH_FIFO_QUEUE_NAME))
-			.join();
+		CompletableFuture.allOf(createQueue(client, SENDS_AND_RECEIVES_MESSAGE_QUEUE_NAME),
+				createQueue(client, SENDS_AND_RECEIVES_RECORD_QUEUE_NAME),
+				createQueue(client, SENDS_AND_RECEIVES_BATCH_QUEUE_NAME),
+				createQueue(client, SENDS_AND_RECEIVES_WITH_HEADERS_QUEUE_NAME),
+				createQueue(client, RECORD_WITHOUT_TYPE_HEADER_QUEUE_NAME),
+				createQueue(client, RETURNS_ON_PARTIAL_BATCH_QUEUE_NAME),
+				createQueue(client, THROWS_ON_PARTIAL_BATCH_QUEUE_NAME),
+				createQueue(client, SENDS_AND_RECEIVES_MANUAL_ACK_QUEUE_NAME), createQueue(client, EMPTY_QUEUE_NAME),
+				createFifoQueue(client, SENDS_AND_RECEIVES_MESSAGE_FIFO_QUEUE_NAME),
+				createFifoQueue(client, SENDS_AND_RECEIVES_BATCH_FIFO_QUEUE_NAME)).join();
 	}
 
 	@Test
 	void shouldSendAndReceiveStringMessage() {
-		SqsTemplate<Object> template = SqsTemplate
-			.newTemplate(this.asyncClient);
+		SqsTemplate<Object> template = SqsTemplate.newTemplate(this.asyncClient);
 		String testBody = "Hello world!";
-		SendResult<Object> result = template.send(to -> to
-			.queue(SENDS_AND_RECEIVES_MESSAGE_QUEUE_NAME)
-			.payload(testBody));
+		SendResult<Object> result = template
+				.send(to -> to.queue(SENDS_AND_RECEIVES_MESSAGE_QUEUE_NAME).payload(testBody));
 		assertThat(result).isNotNull();
-		Optional<Message<Object>> receivedMessage = template.receive(from -> from
-			.queue(SENDS_AND_RECEIVES_MESSAGE_QUEUE_NAME));
+		Optional<Message<Object>> receivedMessage = template
+				.receive(from -> from.queue(SENDS_AND_RECEIVES_MESSAGE_QUEUE_NAME));
 		assertThat(receivedMessage).isPresent().get().extracting(Message::getPayload).isEqualTo(testBody);
 	}
 
@@ -99,11 +108,11 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 		SampleRecord testRecord = new SampleRecord("Hello world!", "From SQS!");
 		SendResult<SampleRecord> result = template.send(SENDS_AND_RECEIVES_RECORD_QUEUE_NAME, testRecord);
 		assertThat(result).isNotNull();
-		Optional<Message<SampleRecord>> receivedMessage = template.receive(from -> from
-			.queue(SENDS_AND_RECEIVES_RECORD_QUEUE_NAME));
+		Optional<Message<SampleRecord>> receivedMessage = template
+				.receive(from -> from.queue(SENDS_AND_RECEIVES_RECORD_QUEUE_NAME));
 		assertThat(receivedMessage).isPresent().get().extracting(Message::getPayload).isEqualTo(testRecord);
-		Optional<Message<SampleRecord>> receivedMessage2 = template.receive(from -> from
-			.queue(SENDS_AND_RECEIVES_RECORD_QUEUE_NAME).pollTimeout(Duration.ofSeconds(1)));
+		Optional<Message<SampleRecord>> receivedMessage2 = template
+				.receive(from -> from.queue(SENDS_AND_RECEIVES_RECORD_QUEUE_NAME).pollTimeout(Duration.ofSeconds(1)));
 		assertThat(receivedMessage2).isEmpty();
 	}
 
@@ -114,12 +123,10 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 		StopWatch stopWatch = new StopWatch();
 		stopWatch.start();
 		int delaySeconds = 1;
-		SendResult<SampleRecord> result = template.send(to -> to
-			.queue(SENDS_AND_RECEIVES_RECORD_QUEUE_NAME)
-			.delaySeconds(delaySeconds)
-			.payload(testRecord));
-		Optional<Message<SampleRecord>> receivedMessage = template.receive(from -> from
-			.queue(SENDS_AND_RECEIVES_RECORD_QUEUE_NAME));
+		SendResult<SampleRecord> result = template.send(
+				to -> to.queue(SENDS_AND_RECEIVES_RECORD_QUEUE_NAME).delaySeconds(delaySeconds).payload(testRecord));
+		Optional<Message<SampleRecord>> receivedMessage = template
+				.receive(from -> from.queue(SENDS_AND_RECEIVES_RECORD_QUEUE_NAME));
 		stopWatch.stop();
 		assertThat(stopWatch.getTotalTimeSeconds()).isGreaterThanOrEqualTo(1.0);
 		assertThat(result.message().getHeaders().get(SqsHeaders.SQS_DELAY_HEADER)).isEqualTo(delaySeconds);
@@ -135,75 +142,58 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 		String myCustomValue2 = "MyCustomValue2";
 		String myCustomHeader3 = "MyCustomHeader";
 		String myCustomValue3 = "MyCustomValue";
-		template.send(to -> to
-			.queue(SENDS_AND_RECEIVES_WITH_HEADERS_QUEUE_NAME)
-			.payload(testRecord)
-			.header(myCustomHeader, myCustomValue)
-			.headers(Map.of(myCustomHeader2, myCustomValue2))
-		);
-		Optional<Message<SampleRecord>> receivedMessage = template.receive(from -> from
-			.queue(SENDS_AND_RECEIVES_WITH_HEADERS_QUEUE_NAME)
-			.additionalHeaders(Map.of(myCustomHeader3, myCustomValue3)));
+		template.send(to -> to.queue(SENDS_AND_RECEIVES_WITH_HEADERS_QUEUE_NAME).payload(testRecord)
+				.header(myCustomHeader, myCustomValue).headers(Map.of(myCustomHeader2, myCustomValue2)));
+		Optional<Message<SampleRecord>> receivedMessage = template
+				.receive(from -> from.queue(SENDS_AND_RECEIVES_WITH_HEADERS_QUEUE_NAME)
+						.additionalHeaders(Map.of(myCustomHeader3, myCustomValue3)));
 		assertThat(receivedMessage).isPresent().get().extracting(Message::getHeaders)
-			.asInstanceOf(InstanceOfAssertFactories.MAP)
-			.containsKeys(myCustomHeader, myCustomHeader2, myCustomHeader3)
-			.containsValues(myCustomValue, myCustomValue2, myCustomValue3);
+				.asInstanceOf(InstanceOfAssertFactories.MAP)
+				.containsKeys(myCustomHeader, myCustomHeader2, myCustomHeader3)
+				.containsValues(myCustomValue, myCustomValue2, myCustomValue3);
 	}
 
 	@Test
 	void shouldSendAndReceiveWithManualAcknowledgement() {
-		SqsTemplate<SampleRecord> template = SqsTemplate.<SampleRecord>builder()
-			.sqsAsyncClient(this.asyncClient)
-			.configure(options -> options.acknowledgementMode(TemplateAcknowledgementMode.DO_NOT_ACKNOWLEDGE)
-				.defaultEndpointName(SENDS_AND_RECEIVES_MANUAL_ACK_QUEUE_NAME))
-			.build();
+		SqsTemplate<SampleRecord> template = SqsTemplate.<SampleRecord> builder().sqsAsyncClient(this.asyncClient)
+				.configure(options -> options.acknowledgementMode(TemplateAcknowledgementMode.DO_NOT_ACKNOWLEDGE)
+						.defaultEndpointName(SENDS_AND_RECEIVES_MANUAL_ACK_QUEUE_NAME))
+				.build();
 		SampleRecord testRecord = new SampleRecord("Hello world!", "From SQS!");
 		template.send(to -> to.payload(testRecord));
-		Optional<Message<SampleRecord>> receivedMessage = template.receive(from -> from
-			.visibilityTimeout(Duration.ofSeconds(1)));
+		Optional<Message<SampleRecord>> receivedMessage = template
+				.receive(from -> from.visibilityTimeout(Duration.ofSeconds(1)));
 
 		assertThat(receivedMessage).isPresent().get().extracting(Message::getPayload).isEqualTo(testRecord);
 
-		Optional<Message<SampleRecord>> receivedMessage2 = template.receive(from -> from
-			.visibilityTimeout(Duration.ofSeconds(1)));
+		Optional<Message<SampleRecord>> receivedMessage2 = template
+				.receive(from -> from.visibilityTimeout(Duration.ofSeconds(1)));
 		assertThat(receivedMessage).isPresent().get().extracting(Message::getPayload).isEqualTo(testRecord);
 		Message<SampleRecord> message = receivedMessage2.get();
 		Acknowledgement.acknowledge(message);
-		Optional<Message<SampleRecord>> receivedMessage3 = template.receive(from -> from
-			.pollTimeout(Duration.ofSeconds(1)));
+		Optional<Message<SampleRecord>> receivedMessage3 = template
+				.receive(from -> from.pollTimeout(Duration.ofSeconds(1)));
 		assertThat(receivedMessage3).isEmpty();
 	}
 
 	@Test
 	void shouldSendAndReceiveBatch() {
-		SqsOperations<SampleRecord> template = SqsTemplate.<SampleRecord>builder()
-			.sqsAsyncClient(this.asyncClient)
-			.configure(options -> options.acknowledgementMode(TemplateAcknowledgementMode.DO_NOT_ACKNOWLEDGE))
-			.buildSyncTemplate();
-		List<Message<SampleRecord>> messagesToSend = IntStream
-			.range(0, 5)
-			.mapToObj(index -> new SampleRecord("Hello world - " + index, "From SQS!"))
-			.map(record -> MessageBuilder.withPayload(record).build())
-			.toList();
-		SendResult.Batch<SampleRecord> response = template.sendMany(SENDS_AND_RECEIVES_BATCH_QUEUE_NAME, messagesToSend);
+		SqsOperations<SampleRecord> template = SqsTemplate.<SampleRecord> builder().sqsAsyncClient(this.asyncClient)
+				.configure(options -> options.acknowledgementMode(TemplateAcknowledgementMode.DO_NOT_ACKNOWLEDGE))
+				.buildSyncTemplate();
+		List<Message<SampleRecord>> messagesToSend = IntStream.range(0, 5)
+				.mapToObj(index -> new SampleRecord("Hello world - " + index, "From SQS!"))
+				.map(record -> MessageBuilder.withPayload(record).build()).toList();
+		SendResult.Batch<SampleRecord> response = template.sendMany(SENDS_AND_RECEIVES_BATCH_QUEUE_NAME,
+				messagesToSend);
 		Collection<Message<SampleRecord>> receivedMessages = template
-			.receiveMany(from -> from
-				.queue(SENDS_AND_RECEIVES_BATCH_QUEUE_NAME)
-				.pollTimeout(Duration.ofSeconds(10))
-				.maxNumberOfMessages(10)
-				.visibilityTimeout(Duration.ofSeconds(1))
-			);
-		assertThat(receivedMessages.stream()
-			.map(Message::getPayload)
-			.toList())
-			.hasSize(5)
-			.containsExactlyElementsOf(messagesToSend.stream().map(Message::getPayload).toList());
+				.receiveMany(from -> from.queue(SENDS_AND_RECEIVES_BATCH_QUEUE_NAME).pollTimeout(Duration.ofSeconds(10))
+						.maxNumberOfMessages(10).visibilityTimeout(Duration.ofSeconds(1)));
+		assertThat(receivedMessages.stream().map(Message::getPayload).toList()).hasSize(5)
+				.containsExactlyElementsOf(messagesToSend.stream().map(Message::getPayload).toList());
 		Acknowledgement.acknowledge(receivedMessages);
-		Collection<Message<SampleRecord>> noMessages = template
-			.receiveMany(from -> from
-				.queue(SENDS_AND_RECEIVES_BATCH_QUEUE_NAME)
-				.pollTimeout(Duration.ofSeconds(2))
-			);
+		Collection<Message<SampleRecord>> noMessages = template.receiveMany(
+				from -> from.queue(SENDS_AND_RECEIVES_BATCH_QUEUE_NAME).pollTimeout(Duration.ofSeconds(2)));
 		assertThat(noMessages).isEmpty();
 	}
 
@@ -211,19 +201,20 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 	void shouldSendAndReceiveMessageFifo() {
 		String testBody = "Hello world!";
 		SqsOperations<Object> template = SqsTemplate.newTemplate(this.asyncClient);
-		SendResult<Object> result = template.sendFifo(to -> to
-			.queue(SENDS_AND_RECEIVES_MESSAGE_FIFO_QUEUE_NAME)
-			.payload(testBody));
+		SendResult<Object> result = template
+				.sendFifo(to -> to.queue(SENDS_AND_RECEIVES_MESSAGE_FIFO_QUEUE_NAME).payload(testBody));
 		Optional<Message<Object>> receivedMessage = template
-			.receiveFifo(from -> from.queue(SENDS_AND_RECEIVES_MESSAGE_FIFO_QUEUE_NAME));
+				.receiveFifo(from -> from.queue(SENDS_AND_RECEIVES_MESSAGE_FIFO_QUEUE_NAME));
 		assertThat(receivedMessage).isPresent().get().isInstanceOfSatisfying(Message.class, message -> {
 			assertThat(message.getPayload()).isEqualTo(testBody);
 			assertThat(result.additionalInformation().get(SqsTemplateParameters.SEQUENCE_NUMBER_PARAMETER_NAME))
-				.isEqualTo(message.getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_SEQUENCE_NUMBER));
+					.isEqualTo(message.getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_SEQUENCE_NUMBER));
 			assertThat(message.getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER))
-				.isEqualTo(result.message().getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER));
+					.isEqualTo(result.message().getHeaders()
+							.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER));
 			assertThat(message.getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER))
-				.isEqualTo(result.message().getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER));
+					.isEqualTo(result.message().getHeaders()
+							.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER));
 			assertThat(result.messageId()).isEqualTo(message.getHeaders().getId());
 		});
 
@@ -233,73 +224,71 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 	void shouldSendAndReceiveBatchFifo() {
 		int batchSize = 5;
 		SqsTemplate<SampleRecord> template = SqsTemplate.newTemplate(this.asyncClient);
-		List<Message<SampleRecord>> messagesToSend = IntStream
-			.range(0, batchSize)
-			.mapToObj(index -> new SampleRecord("Hello world - " + index, "From SQS!"))
-			.map(record -> MessageBuilder.withPayload(record).build())
-			.toList();
-		SendResult.Batch<SampleRecord> batchSendResult = template.sendManyFifo(SENDS_AND_RECEIVES_BATCH_FIFO_QUEUE_NAME, messagesToSend);
+		List<Message<SampleRecord>> messagesToSend = IntStream.range(0, batchSize)
+				.mapToObj(index -> new SampleRecord("Hello world - " + index, "From SQS!"))
+				.map(record -> MessageBuilder.withPayload(record).build()).toList();
+		SendResult.Batch<SampleRecord> batchSendResult = template.sendManyFifo(SENDS_AND_RECEIVES_BATCH_FIFO_QUEUE_NAME,
+				messagesToSend);
 		List<SendResult<SampleRecord>> successful = new ArrayList<>(batchSendResult.successful());
 		assertThat(batchSendResult.failed()).isEmpty();
 		assertThat(successful).hasSize(batchSize);
-		IntStream.range(0, batchSize)
-				.forEach(index -> {
-					SendResult<SampleRecord> result = successful.get(index);
-					Message<SampleRecord> originalMessage = messagesToSend.get(index);
-					assertThat(result.endpoint()).isEqualTo(SENDS_AND_RECEIVES_BATCH_FIFO_QUEUE_NAME);
-					assertThat(result.message().getPayload()).isEqualTo(originalMessage.getPayload());
-					assertThat(result.message().getHeaders().getId()).isEqualTo(originalMessage.getHeaders().getId());
-					assertThat(result.message().getHeaders())
-						.containsKeys(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER);
-					assertThat(result.additionalInformation().get(SqsTemplateParameters.SEQUENCE_NUMBER_PARAMETER_NAME)).isNotNull();
-				});
-		List<Message<SampleRecord>> receivedMessages = new ArrayList<>(template
-			.receiveManyFifo(from -> from
-				.queue(SENDS_AND_RECEIVES_BATCH_FIFO_QUEUE_NAME)
-				.pollTimeout(Duration.ofSeconds(10))
-				.maxNumberOfMessages(10)));
-		IntStream.range(0, batchSize)
-			.forEach(index -> {
-				SendResult<SampleRecord> result = successful.get(index);
-				Message<SampleRecord> originalMessage = messagesToSend.get(index);
-				Message<SampleRecord> receivedMessage = receivedMessages.get(index);
-				assertThat(receivedMessage.getPayload()).isEqualTo(originalMessage.getPayload());
-				assertThat(receivedMessage.getHeaders().getId()).isEqualTo(result.messageId());
-				assertThat(result.message().getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER))
-					.isEqualTo(receivedMessage.getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER));
-				assertThat(result.message().getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER))
-					.isEqualTo(receivedMessage.getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER));
-				assertThat(result.additionalInformation().get(SqsTemplateParameters.SEQUENCE_NUMBER_PARAMETER_NAME))
-					.isEqualTo(receivedMessage.getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_SEQUENCE_NUMBER));
-			});
+		IntStream.range(0, batchSize).forEach(index -> {
+			SendResult<SampleRecord> result = successful.get(index);
+			Message<SampleRecord> originalMessage = messagesToSend.get(index);
+			assertThat(result.endpoint()).isEqualTo(SENDS_AND_RECEIVES_BATCH_FIFO_QUEUE_NAME);
+			assertThat(result.message().getPayload()).isEqualTo(originalMessage.getPayload());
+			assertThat(result.message().getHeaders().getId()).isEqualTo(originalMessage.getHeaders().getId());
+			assertThat(result.message().getHeaders()).containsKeys(
+					SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER,
+					SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER);
+			assertThat(result.additionalInformation().get(SqsTemplateParameters.SEQUENCE_NUMBER_PARAMETER_NAME))
+					.isNotNull();
+		});
+		List<Message<SampleRecord>> receivedMessages = new ArrayList<>(
+				template.receiveManyFifo(from -> from.queue(SENDS_AND_RECEIVES_BATCH_FIFO_QUEUE_NAME)
+						.pollTimeout(Duration.ofSeconds(10)).maxNumberOfMessages(10)));
+		IntStream.range(0, batchSize).forEach(index -> {
+			SendResult<SampleRecord> result = successful.get(index);
+			Message<SampleRecord> originalMessage = messagesToSend.get(index);
+			Message<SampleRecord> receivedMessage = receivedMessages.get(index);
+			assertThat(receivedMessage.getPayload()).isEqualTo(originalMessage.getPayload());
+			assertThat(receivedMessage.getHeaders().getId()).isEqualTo(result.messageId());
+			assertThat(
+					result.message().getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER))
+							.isEqualTo(receivedMessage.getHeaders()
+									.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER));
+			assertThat(result.message().getHeaders()
+					.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER))
+							.isEqualTo(receivedMessage.getHeaders()
+									.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER));
+			assertThat(result.additionalInformation().get(SqsTemplateParameters.SEQUENCE_NUMBER_PARAMETER_NAME))
+					.isEqualTo(
+							receivedMessage.getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_SEQUENCE_NUMBER));
+		});
 
 	}
 
 	@Test
 	void shouldSendAndReceiveRecordMessageWithoutPayloadInfoHeader() {
-		SqsTemplate<SampleRecord> template = SqsTemplate
-			.<SampleRecord>builder()
-			.sqsAsyncClient(this.asyncClient)
-			.setupDefaultConverter(converter -> converter.setPayloadTypeHeaderValueFunction(msg -> null))
-			.build();
+		SqsTemplate<SampleRecord> template = SqsTemplate.<SampleRecord> builder().sqsAsyncClient(this.asyncClient)
+				.setupDefaultConverter(converter -> converter.setPayloadTypeHeaderValueFunction(msg -> null)).build();
 		SampleRecord testRecord = new SampleRecord("Hello world!", "From SQS!");
 		SendResult<SampleRecord> result = template.send(RECORD_WITHOUT_TYPE_HEADER_QUEUE_NAME, testRecord);
 		assertThat(result).isNotNull();
-		Optional<Message<SampleRecord>> receivedMessage = template.receive(from -> from
-			.queue(RECORD_WITHOUT_TYPE_HEADER_QUEUE_NAME)
-			.payloadClass(SampleRecord.class));
+		Optional<Message<SampleRecord>> receivedMessage = template
+				.receive(from -> from.queue(RECORD_WITHOUT_TYPE_HEADER_QUEUE_NAME).payloadClass(SampleRecord.class));
 		assertThat(receivedMessage).isPresent().get().extracting(Message::getPayload).isEqualTo(testRecord);
 	}
 
 	@Test
 	void shouldReceiveEmptyMessage() {
-		Optional<Message<Object>> receivedMessage = SqsTemplate
-			.newTemplate(this.asyncClient)
-			.receive(from -> from.queue(EMPTY_QUEUE_NAME).pollTimeout(Duration.ofSeconds(1)));
+		Optional<Message<Object>> receivedMessage = SqsTemplate.newTemplate(this.asyncClient)
+				.receive(from -> from.queue(EMPTY_QUEUE_NAME).pollTimeout(Duration.ofSeconds(1)));
 		assertThat(receivedMessage).isEmpty();
 	}
 
-	private record SampleRecord(String propertyOne, String propertyTwo) {}
+	private record SampleRecord(String propertyOne, String propertyTwo) {
+	}
 
 	@Configuration
 	static class SQSConfiguration {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
@@ -212,7 +212,7 @@ class BatchingAcknowledgementProcessorTests {
 	@Test
 	void shouldAcknowledgeOrderedByGroupFromManyMessageGroups() throws Exception {
 		testAcknowledgementOrdering(AcknowledgementOrdering.ORDERED_BY_GROUP, msg -> MessageHeaderUtils
-				.getHeaderAsString(msg, SqsHeaders.MessageSystemAttribute.SQS_MESSAGE_GROUP_ID_HEADER));
+				.getHeaderAsString(msg, SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER));
 	}
 
 	@Test
@@ -232,7 +232,7 @@ class BatchingAcknowledgementProcessorTests {
 				.stream().map(
 						group -> createFifoMessages(messagesPerGroup, group))
 				.collect(Collectors.toMap(msgs -> MessageHeaderUtils.getHeaderAsString(msgs.iterator().next(),
-						SqsHeaders.MessageSystemAttribute.SQS_MESSAGE_GROUP_ID_HEADER), msgs -> msgs));
+						SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER), msgs -> msgs));
 		CountDownLatch ackLatch = new CountDownLatch(numberOfMessages);
 		Map<String, Collection<String>> acknowledgedMessages = new ConcurrentHashMap<>();
 		AcknowledgementExecutor<String> acknowledgementExecutor = messagesToAck -> {
@@ -242,7 +242,7 @@ class BatchingAcknowledgementProcessorTests {
 				messagesToAck.stream()
 						.collect(
 								groupingBy(msg -> MessageHeaderUtils.getHeaderAsString(msg,
-										SqsHeaders.MessageSystemAttribute.SQS_MESSAGE_GROUP_ID_HEADER)))
+										SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER)))
 						.forEach((key, value) -> acknowledgedMessages
 								.computeIfAbsent(key, newGroup -> Collections.synchronizedList(new ArrayList<>()))
 								.addAll(value.stream().map(Message::getPayload).collect(toList())));
@@ -333,7 +333,7 @@ class BatchingAcknowledgementProcessorTests {
 
 	private Message<String> createFifoMessage(int index, String messageGroup) {
 		return MessageBuilder.withPayload(String.valueOf(index))
-				.setHeader(SqsHeaders.MessageSystemAttribute.SQS_MESSAGE_GROUP_ID_HEADER, messageGroup).build();
+				.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroup).build();
 	}
 
 	private List<Message<String>> createFifoMessages(int numberOfMessages, String messageGroup) {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/ImmediateAcknowledgementProcessorTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/ImmediateAcknowledgementProcessorTests.java
@@ -83,7 +83,7 @@ class ImmediateAcknowledgementProcessorTests {
 		AcknowledgementExecutor<Object> executor = mock(AcknowledgementExecutor.class);
 		Message<Object> message = mock(Message.class);
 		MessageHeaders messageHeaders = new MessageHeaders(Collections.singletonMap(
-				SqsHeaders.MessageSystemAttribute.SQS_MESSAGE_GROUP_ID_HEADER, UUID.randomUUID().toString()));
+				SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, UUID.randomUUID().toString()));
 		given(message.getHeaders()).willReturn(messageHeaders);
 		RuntimeException exception = new RuntimeException("Expected exception from shouldPropagateErrorForOrdered");
 		given(executor.execute(Collections.singletonList(message)))
@@ -95,7 +95,7 @@ class ImmediateAcknowledgementProcessorTests {
 		processor.configure(SqsContainerOptions.builder().acknowledgementOrdering(ordering).build());
 		if (AcknowledgementOrdering.ORDERED_BY_GROUP.equals(ordering)) {
 			processor.setMessageGroupingFunction(msg -> MessageHeaderUtils.getHeaderAsString(msg,
-					SqsHeaders.MessageSystemAttribute.SQS_MESSAGE_GROUP_ID_HEADER));
+					SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER));
 		}
 		processor.start();
 		CompletableFuture<Void> ackResult = processor.doOnAcknowledge(message);

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementExecutorTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementExecutorTests.java
@@ -23,6 +23,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import io.awspring.cloud.sqs.CompletableFutures;
+import io.awspring.cloud.sqs.SqsAcknowledgementException;
 import io.awspring.cloud.sqs.listener.QueueAttributes;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
 import java.util.Collection;
@@ -123,7 +124,7 @@ class SqsAcknowledgementExecutorTests {
 		executor.setQueueAttributes(queueAttributes);
 		assertThatThrownBy(() -> executor.execute(messages).join()).isInstanceOf(CompletionException.class).getCause()
 				.isInstanceOf(SqsAcknowledgementException.class).asInstanceOf(type(SqsAcknowledgementException.class))
-				.extracting(SqsAcknowledgementException::getQueueUrl).isEqualTo(queueUrl);
+				.extracting(SqsAcknowledgementException::getQueue).isEqualTo(queueUrl);
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/sink/MessageGroupingSinkTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/sink/MessageGroupingSinkTests.java
@@ -46,7 +46,7 @@ class MessageGroupingSinkTests {
 
 	@Test
 	void maintainsOrderWithinEachGroup() {
-		String header = SqsHeaders.MessageSystemAttribute.SQS_MESSAGE_GROUP_ID_HEADER;
+		String header = SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER;
 		String firstMessageGroupId = UUID.randomUUID().toString();
 		String secondMessageGroupId = UUID.randomUUID().toString();
 		String thirdMessageGroupId = UUID.randomUUID().toString();

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -1,14 +1,643 @@
 package io.awspring.cloud.sqs.operations;
 
 
+import io.awspring.cloud.sqs.QueueAttributesResolvingException;
+import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.CreateQueueResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlResponse;
+import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
+import software.amazon.awssdk.services.sqs.model.QueueDoesNotExistException;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
 /**
  * @author Tomaz Fernandes
  * @since 3.0
  */
 class SqsTemplateTests {
 
-	void shouldSend() {
+	@Test
+	void shouldSendWithOptions() {
+		String queue = "test-queue";
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		UUID uuid = UUID.randomUUID();
+		String sequenceNumber = "1234";
+		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString()).sequenceNumber(sequenceNumber).build();
+		given(mockClient.sendMessage(any(SendMessageRequest.class))).willReturn(CompletableFuture.completedFuture(response));
 
+		SqsOperations<Object> template = SqsTemplate.newTemplate(mockClient);
+		String payload = "test-payload";
+		String testHeaderName = "testHeaderName";
+		String testHeaderValue = "testHeaderValue";
+		String testHeaderName2 = "testHeaderName2";
+		String testHeaderValue2 = "testHeaderValue2";
+		Integer delaySeconds = 5;
+		SendResult<Object> result = template.send(to -> to
+			.delaySeconds(delaySeconds)
+			.queue(queue)
+			.payload(payload)
+			.header(testHeaderName, testHeaderValue)
+			.headers(Map.of(testHeaderName2, testHeaderValue2)));
+		assertThat(result.endpoint()).isEqualTo(queue);
+		assertThat(result.message().getHeaders())
+			.containsKeys(testHeaderName, testHeaderName2)
+			.containsValues(testHeaderValue, testHeaderValue2);
+		assertThat(result.message().getPayload()).isEqualTo(payload);
+		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+		then(mockClient).should().sendMessage(captor.capture());
+		SendMessageRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.delaySeconds()).isEqualTo(delaySeconds);
+		assertThat(capturedRequest.queueUrl()).isEqualTo(queue);
+		assertThat(capturedRequest.messageBody()).isEqualTo(payload);
+		assertThat(capturedRequest.messageAttributes())
+			.containsKeys(testHeaderName, testHeaderName2);
+	}
+
+	@Test
+	void shouldSendFifoWithOptions() {
+		String queue = "test-queue";
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		UUID uuid = UUID.randomUUID();
+		String sequenceNumber = "1234";
+		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString()).sequenceNumber(sequenceNumber).build();
+		given(mockClient.sendMessage(any(SendMessageRequest.class))).willReturn(CompletableFuture.completedFuture(response));
+
+		UUID messageGroupId = UUID.randomUUID();
+		UUID messageDeduplicationId = UUID.randomUUID();
+
+		SqsOperations<Object> template = SqsTemplate.newTemplate(mockClient);
+		String payload = "test-payload";
+		SendResult<Object> result = template.sendFifo(to -> to
+			.queue(queue)
+			.messageGroupId(messageGroupId)
+			.messageDeduplicationId(messageDeduplicationId)
+			.payload(payload));
+		assertThat(result.endpoint()).isEqualTo(queue);
+		assertThat(result.message().getHeaders())
+			.containsAllEntriesOf(Map.of(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, messageDeduplicationId.toString(),
+				SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId.toString()));
+		assertThat(result.message().getPayload()).isEqualTo(payload);
+		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+		then(mockClient).should().sendMessage(captor.capture());
+		SendMessageRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.queueUrl()).isEqualTo(queue);
+		assertThat(capturedRequest.messageBody()).isEqualTo(payload);
+	}
+
+	@Test
+	void shouldSendWithDefaultEndpoint() {
+		String queue = "test-queue";
+		String payload = "test-payload";
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		UUID uuid = UUID.randomUUID();
+		String sequenceNumber = "1234";
+		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString()).sequenceNumber(sequenceNumber).build();
+		given(mockClient.sendMessage(any(SendMessageRequest.class))).willReturn(CompletableFuture.completedFuture(response));
+		SqsOperations<Object> template = SqsTemplate
+			.builder()
+			.sqsAsyncClient(mockClient)
+			.configure(options -> options.defaultEndpointName(queue))
+			.buildSyncTemplate();
+		SendResult<Object> result = template.send(payload);
+		assertThat(result.endpoint()).isEqualTo(queue);
+		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+		then(mockClient).should().sendMessage(captor.capture());
+		SendMessageRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.queueUrl()).isEqualTo(queue);
+	}
+
+	@Test
+	void shouldSendWithQueueAndPayload() {
+		String queue = "test-queue";
+		String payload = "test-payload";
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		UUID uuid = UUID.randomUUID();
+		String sequenceNumber = "1234";
+		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString()).sequenceNumber(sequenceNumber).build();
+		given(mockClient.sendMessage(any(SendMessageRequest.class))).willReturn(CompletableFuture.completedFuture(response));
+		SqsOperations<Object> template = SqsTemplate.newSyncTemplate(mockClient);
+		SendResult<Object> result = template.send(queue, payload);
+		assertThat(result.endpoint()).isEqualTo(queue);
+		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+		then(mockClient).should().sendMessage(captor.capture());
+		SendMessageRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.queueUrl()).isEqualTo(queue);
+		assertThat(capturedRequest.messageBody()).isEqualTo(payload);
+	}
+
+	@Test
+	void shouldSendWithQueueAndMessageAndHeaders() {
+		String queue = "test-queue";
+		String payload = "test-payload";
+		String headerName = "headerName";
+		String headerValue = "headerValue";
+		Message<String> message = MessageBuilder.withPayload(payload).setHeader(headerName, headerValue).build();
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		UUID uuid = UUID.randomUUID();
+		String sequenceNumber = "1234";
+		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString()).sequenceNumber(sequenceNumber).build();
+		given(mockClient.sendMessage(any(SendMessageRequest.class))).willReturn(CompletableFuture.completedFuture(response));
+		SqsOperations<String> template = SqsTemplate.newSyncTemplate(mockClient);
+		SendResult<String> result = template.send(queue, message);
+		assertThat(result.endpoint()).isEqualTo(queue);
+		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+		then(mockClient).should().sendMessage(captor.capture());
+		SendMessageRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.queueUrl()).isEqualTo(queue);
+		assertThat(capturedRequest.messageBody()).isEqualTo(payload);
+		assertThat(capturedRequest.messageAttributes().get(headerName).stringValue()).isEqualTo(headerValue);
+	}
+
+	@Test
+	void shouldSendBatch() {
+		String queue = "test-queue";
+		String payload1 = "test-payload-1";
+		String payload2 = "test-payload-2";
+		String headerName1 = "headerName";
+		String headerValue1 = "headerValue";
+		String headerName2 = "headerName2";
+		String headerValue2 = "headerValue2";
+		Message<String> message1 = MessageBuilder.withPayload(payload1).setHeader(headerName1, headerValue1).build();
+		Message<String> message2 = MessageBuilder.withPayload(payload2).setHeader(headerName2, headerValue2).build();
+		List<Message<String>> messages = List.of(message1, message2);
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		SendMessageBatchResponse response = SendMessageBatchResponse.builder()
+			.successful(builder -> builder.id(message1.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()),
+				builder -> builder.id(message2.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()))
+			.build();
+		given(mockClient.sendMessageBatch(any(SendMessageBatchRequest.class))).willReturn(CompletableFuture.completedFuture(response));
+		SqsOperations<String> template = SqsTemplate.newSyncTemplate(mockClient);
+		SendResult.Batch<String> results = template.sendMany(queue, messages);
+		assertThat(results.successful()).hasSize(2);
+		Iterator<SendResult<String>> iterator = results.successful().iterator();
+		SendResult<String> firstResult = iterator.next();
+		SendResult<String> secondResult = iterator.next();
+		assertThat(firstResult.endpoint()).isEqualTo(queue);
+		assertThat(firstResult.message().getPayload()).isEqualTo(payload1);
+		assertThat(secondResult.endpoint()).isEqualTo(queue);
+		assertThat(secondResult.message().getPayload()).isEqualTo(payload2);
+		ArgumentCaptor<SendMessageBatchRequest> captor = ArgumentCaptor.forClass(SendMessageBatchRequest.class);
+		then(mockClient).should().sendMessageBatch(captor.capture());
+		SendMessageBatchRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.queueUrl()).isEqualTo(queue);
+		Iterator<SendMessageBatchRequestEntry> requestIterator = capturedRequest.entries().iterator();
+		SendMessageBatchRequestEntry firstEntry = requestIterator.next();
+		SendMessageBatchRequestEntry secondEntry = requestIterator.next();
+		assertThat(firstEntry.messageBody()).isEqualTo(payload1);
+		assertThat(firstEntry.messageAttributes().get(headerName1).stringValue()).isEqualTo(headerValue1);
+		assertThat(secondEntry.messageBody()).isEqualTo(payload2);
+		assertThat(secondEntry.messageAttributes().get(headerName2).stringValue()).isEqualTo(headerValue2);
+	}
+
+	@Test
+	void shouldAddFailedToTheBatchResult() {
+		String queue = "test-queue";
+		String payload1 = "test-payload-1";
+		String payload2 = "test-payload-2";
+		Message<String> message1 = MessageBuilder.withPayload(payload1).build();
+		Message<String> message2 = MessageBuilder.withPayload(payload2).build();
+		List<Message<String>> messages = List.of(message1, message2);
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		String testErrorMessage = "test error message";
+		String code = "BC01";
+		boolean senderFault = true;
+		SendMessageBatchResponse response = SendMessageBatchResponse.builder()
+			.successful(builder -> builder.id(message1.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()))
+			.failed(builder -> builder.id(message2.getHeaders().getId().toString()).message(testErrorMessage).code(code).senderFault(senderFault))
+			.build();
+		given(mockClient.sendMessageBatch(any(SendMessageBatchRequest.class))).willReturn(CompletableFuture.completedFuture(response));
+		SqsOperations<String> template = SqsTemplate.<String>builder().configure(options -> options.sendBatchFailureStrategy(SendBatchFailureStrategy.RETURN_RESULT))
+			.sqsAsyncClient(mockClient).buildSyncTemplate();
+		SendResult.Batch<String> results = template.sendMany(queue, messages);
+		assertThat(results.successful()).isNotEmpty();
+		assertThat(results.failed()).isNotEmpty();
+		SendResult<String> successfulResult = results.successful().iterator().next();
+		assertThat(successfulResult.endpoint()).isEqualTo(queue);
+		assertThat(successfulResult.message().getPayload()).isEqualTo(payload1);
+		SendResult.Failed<String> failedResult = results.failed().iterator().next();
+		assertThat(failedResult.errorMessage()).isEqualTo(testErrorMessage);
+		assertThat(failedResult.message().getPayload()).isEqualTo(payload2);
+		assertThat(failedResult.additionalInformation().get(SqsTemplateParameters.CODE_PARAMETER_NAME)).isEqualTo(code);
+		assertThat(failedResult.additionalInformation().get(SqsTemplateParameters.SENDER_FAULT_PARAMETER_NAME)).isEqualTo(senderFault);
+	}
+
+	@Test
+	void shouldThrowIfHasFailedMessagesInBatchByDefault() {
+		String queue = "test-queue";
+		String payload1 = "test-payload-1";
+		String payload2 = "test-payload-2";
+		Message<String> message1 = MessageBuilder.withPayload(payload1).build();
+		Message<String> message2 = MessageBuilder.withPayload(payload2).build();
+		List<Message<String>> messages = List.of(message1, message2);
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		String testErrorMessage = "test error message";
+		String code = "BC01";
+		boolean senderFault = true;
+		SendMessageBatchResponse response = SendMessageBatchResponse.builder()
+			.successful(builder -> builder.id(message1.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()))
+			.failed(builder -> builder.id(message2.getHeaders().getId().toString()).message(testErrorMessage).code(code).senderFault(senderFault))
+			.build();
+		given(mockClient.sendMessageBatch(any(SendMessageBatchRequest.class))).willReturn(CompletableFuture.completedFuture(response));
+		SqsOperations<String> template = SqsTemplate.newSyncTemplate(mockClient);
+		assertThatThrownBy(() -> template.sendMany(queue, messages))
+			.isInstanceOf(SendBatchOperationFailedException.class)
+			.isInstanceOfSatisfying(SendBatchOperationFailedException.class, ex -> {
+				assertThat(ex.getFailedMessages().iterator().next().getPayload()).isEqualTo(payload2);
+				assertThat(ex.getEndpoint()).isEqualTo(queue);
+				SendResult.Batch<String> sendBatchResult = ex.getSendBatchResult(String.class);
+				SendResult<String> successful = sendBatchResult.successful().iterator().next();
+				assertThat(successful.message().getPayload()).isEqualTo(payload1);
+				assertThat(successful.endpoint()).isEqualTo(queue);
+				SendResult.Failed<String> failedResult = sendBatchResult.failed().iterator().next();
+				assertThat(failedResult.errorMessage()).isEqualTo(testErrorMessage);
+				assertThat(failedResult.message().getPayload()).isEqualTo(payload2);
+				assertThat(failedResult.additionalInformation().get(SqsTemplateParameters.CODE_PARAMETER_NAME)).isEqualTo(code);
+				assertThat(failedResult.additionalInformation().get(SqsTemplateParameters.SENDER_FAULT_PARAMETER_NAME)).isEqualTo(senderFault);
+			});
+	}
+
+	@Test
+	void shouldCreateByDefaultIfQueueNotFound() {
+		String queue = "test-queue";
+		String payload = "test-payload";
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.failedFuture(QueueDoesNotExistException.builder().message("test queue not found").build()));
+		given(mockClient.createQueue(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(CreateQueueResponse.builder().queueUrl(queue).build()));
+		UUID uuid = UUID.randomUUID();
+		String sequenceNumber = "1234";
+		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString()).sequenceNumber(sequenceNumber).build();
+		given(mockClient.sendMessage(any(SendMessageRequest.class))).willReturn(CompletableFuture.completedFuture(response));
+		SqsOperations<Object> template = SqsTemplate.newSyncTemplate(mockClient);
+		SendResult<Object> result = template.send(to -> to.queue(queue).payload(payload));
+		assertThat(result.endpoint()).isEqualTo(queue);
+		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+		then(mockClient).should().sendMessage(captor.capture());
+		SendMessageRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.queueUrl()).isEqualTo(queue);
+	}
+
+	@Test
+	void shouldThrowIfQueueNotFound() {
+		String queue = "test-queue";
+		String payload = "test-payload";
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.failedFuture(QueueDoesNotExistException.builder().message("test queue not found").build()));
+		UUID uuid = UUID.randomUUID();
+		String sequenceNumber = "1234";
+		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString()).sequenceNumber(sequenceNumber).build();
+		given(mockClient.sendMessage(any(SendMessageRequest.class))).willReturn(CompletableFuture.completedFuture(response));
+		SqsOperations<Object> template = SqsTemplate.builder()
+			.sqsAsyncClient(mockClient)
+			.configure(options -> options.queueNotFoundStrategy(QueueNotFoundStrategy.FAIL))
+			.buildSyncTemplate();
+		assertThatThrownBy(() -> template.send(to -> to.queue(queue).payload(payload)))
+			.isInstanceOf(CompletionException.class)
+			.cause()
+			.isInstanceOf(MessagingOperationFailedException.class)
+			.cause()
+			.isInstanceOf(CompletionException.class)
+			.cause()
+			.isInstanceOf(QueueAttributesResolvingException.class)
+			.cause()
+			.isInstanceOf(QueueDoesNotExistException.class);
+	}
+
+	@Test
+	void shouldReceiveEmpty() {
+		String queue = "test-queue";
+		String payload = "test-payload";
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse
+			.builder()
+			.build();
+		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class))).willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+		SqsOperations<Object> template = SqsTemplate
+			.builder()
+			.sqsAsyncClient(mockClient)
+			.configure(options -> options.defaultEndpointName(queue))
+			.buildSyncTemplate();
+		Optional<Message<Object>> receivedMessage = template.receive();
+		assertThat(receivedMessage).isEmpty();
+	}
+
+	@Test
+	void shouldReceiveFromDefaultEndpoint() {
+		String queue = "test-queue";
+		String payload = "test-payload";
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse
+			.builder()
+			.messages(builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
+			.build();
+		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class))).willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse
+			.builder().successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).willReturn(CompletableFuture.completedFuture(deleteResponse));
+		SqsOperations<Object> template = SqsTemplate
+			.builder()
+			.sqsAsyncClient(mockClient)
+			.configure(options -> options.defaultEndpointName(queue))
+			.buildSyncTemplate();
+		Optional<Message<Object>> receivedMessage = template.receive();
+		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
+	}
+
+	@Test
+	void shouldReceiveAndNotAcknowledge() {
+		String queue = "test-queue";
+		String payload = "test-payload";
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse
+			.builder()
+			.messages(builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
+			.build();
+		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class))).willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+		SqsOperations<Object> template = SqsTemplate
+			.builder()
+			.sqsAsyncClient(mockClient)
+			.configure(options -> options.defaultEndpointName(queue)
+				.acknowledgementMode(TemplateAcknowledgementMode.DO_NOT_ACKNOWLEDGE))
+			.buildSyncTemplate();
+		Optional<Message<Object>> receivedMessage = template.receive();
+		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
+		then(mockClient).should(never()).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
+	}
+
+	@Test
+	void shouldReceiveFromDefaultSettings() {
+		String queue = "test-queue";
+		String payload = "test-payload";
+		String headerName1 = "headerName";
+		String headerValue1 = "headerValue";
+		String headerName2 = "headerName2";
+		String headerValue2 = "headerValue2";
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse
+			.builder()
+			.messages(builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
+			.build();
+		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class))).willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse
+			.builder().successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).willReturn(CompletableFuture.completedFuture(deleteResponse));
+		SqsOperations<String> template = SqsTemplate
+			.<String>builder()
+			.sqsAsyncClient(mockClient)
+			.configure(options -> options.defaultEndpointName(queue)
+				.defaultPollTimeout(Duration.ofSeconds(1))
+				.additionalHeaderForReceive(headerName1, headerValue1)
+				.additionalHeadersForReceive(Map.of(headerName2, headerValue2)))
+			.buildSyncTemplate();
+		Optional<Message<String>> receivedMessage = template.receive(null, null, null, null);
+		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> {
+			assertThat(message.getPayload()).isEqualTo(payload);
+			assertThat(message.getHeaders()).containsEntry(headerName1, headerValue1);
+			assertThat(message.getHeaders()).containsEntry(headerName2, headerValue2);
+		});
+		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
+		then(mockClient).should().receiveMessage(captor.capture());
+		ReceiveMessageRequest request = captor.getValue();
+		assertThat(request.maxNumberOfMessages()).isEqualTo(1);
+		assertThat(request.queueUrl()).isEqualTo(queue);
+	}
+
+	@Test
+	void shouldReceiveFromOptions() {
+		String queue = "test-queue";
+		String payload = "test-payload";
+		String headerName1 = "headerName";
+		String headerValue1 = "headerValue";
+		String headerName2 = "headerName2";
+		String headerValue2 = "headerValue2";
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse
+			.builder()
+			.messages(builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
+			.build();
+		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class))).willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse
+			.builder().successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).willReturn(CompletableFuture.completedFuture(deleteResponse));
+		SqsOperations<String> template = SqsTemplate.newSyncTemplate(mockClient);
+		Optional<Message<String>> receivedMessage = template.receive(from -> from
+				.queue(queue)
+				.pollTimeout(Duration.ofSeconds(1))
+				.visibilityTimeout(Duration.ofSeconds(5))
+				.additionalHeader(headerName1, headerValue1)
+				.additionalHeaders(Map.of(headerName2, headerValue2)));
+		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> {
+			assertThat(message.getPayload()).isEqualTo(payload);
+			assertThat(message.getHeaders()).containsEntry(headerName1, headerValue1);
+			assertThat(message.getHeaders()).containsEntry(headerName2, headerValue2);
+		});
+		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
+		then(mockClient).should().receiveMessage(captor.capture());
+		ReceiveMessageRequest request = captor.getValue();
+		assertThat(request.maxNumberOfMessages()).isEqualTo(1);
+		assertThat(request.visibilityTimeout()).isEqualTo(5);
+		assertThat(request.waitTimeSeconds()).isEqualTo(1);
+	}
+
+	@Test
+	void shouldReceiveFifoWithGivenAttemptId() {
+		String queue = "test-queue";
+		String payload = "test-payload";
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		String messageGroupId = UUID.randomUUID().toString();
+		String deduplicationId = UUID.randomUUID().toString();
+		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse
+			.builder()
+			.messages(builder -> builder.messageId(UUID.randomUUID().toString())
+				.attributes(Map.of(MessageSystemAttributeName.MESSAGE_GROUP_ID, messageGroupId,
+					MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID, deduplicationId))
+				.receiptHandle("test-receipt-handle").body(payload).build())
+			.build();
+		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class))).willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse
+			.builder().successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).willReturn(CompletableFuture.completedFuture(deleteResponse));
+		SqsOperations<String> template = SqsTemplate.newSyncTemplate(mockClient);
+		UUID attemptId = UUID.randomUUID();
+		Optional<Message<String>> receivedMessage = template.receiveFifo(from -> from
+				.queue(queue).receiveRequestAttemptId(attemptId));
+		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> {
+			assertThat(message.getPayload()).isEqualTo(payload);
+			assertThat(message.getHeaders()).containsEntry(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId);
+			assertThat(message.getHeaders()).containsEntry(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, deduplicationId);
+		});
+		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
+		then(mockClient).should().receiveMessage(captor.capture());
+		ReceiveMessageRequest request = captor.getValue();
+		assertThat(request.receiveRequestAttemptId()).isEqualTo(attemptId.toString());
+		assertThat(request.maxNumberOfMessages()).isEqualTo(1);
+	}
+
+	@Test
+	void shouldReceiveBatchWithDefaultValues() {
+		String queue = "test-queue";
+		String payload = "test-payload";
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse
+			.builder()
+			.messages(builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
+			.build();
+		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class))).willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse
+			.builder().successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).willReturn(CompletableFuture.completedFuture(deleteResponse));
+		SqsOperations<Object> template = SqsTemplate
+			.builder()
+			.sqsAsyncClient(mockClient)
+			.configure(options -> options.defaultEndpointName(queue)
+				.defaultPollTimeout(Duration.ofSeconds(5))
+				.defaultMaxNumberOfMessages(6))
+			.buildSyncTemplate();
+		Collection<Message<Object>> receivedMessages = template.receiveMany();
+		assertThat(receivedMessages).hasSize(5);
+
+		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
+		then(mockClient).should().receiveMessage(captor.capture());
+		ReceiveMessageRequest request = captor.getValue();
+		assertThat(request.visibilityTimeout()).isNull();
+		assertThat(request.queueUrl()).isEqualTo(queue);
+		assertThat(request.maxNumberOfMessages()).isEqualTo(6);
+		assertThat(request.waitTimeSeconds()).isEqualTo(5);
+	}
+
+	@Test
+	void shouldReceiveBatchWithOptions() {
+		String queue = "test-queue";
+		String payload = "test-payload";
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse
+			.builder()
+			.messages(builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
+			.build();
+		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class))).willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse
+			.builder().successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).willReturn(CompletableFuture.completedFuture(deleteResponse));
+		SqsOperations<Object> template = SqsTemplate.newSyncTemplate(mockClient);
+		Collection<Message<Object>> receivedMessages = template.receiveMany(from -> from
+			.queue(queue)
+			.maxNumberOfMessages(6)
+			.visibilityTimeout(Duration.ofSeconds(3))
+			.pollTimeout(Duration.ofSeconds(5))
+		);
+		assertThat(receivedMessages).hasSize(5);
+
+		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
+		then(mockClient).should().receiveMessage(captor.capture());
+		ReceiveMessageRequest request = captor.getValue();
+		assertThat(request.visibilityTimeout()).isEqualTo(3);
+		assertThat(request.queueUrl()).isEqualTo(queue);
+		assertThat(request.maxNumberOfMessages()).isEqualTo(6);
+		assertThat(request.waitTimeSeconds()).isEqualTo(5);
+	}
+
+	@Test
+	void shouldReceiveBatchFifo() {
+		String queue = "test-queue";
+		String payload = "test-payload";
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse
+			.builder()
+			.messages(builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
+			.build();
+		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class))).willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse
+			.builder().successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).willReturn(CompletableFuture.completedFuture(deleteResponse));
+		SqsOperations<Object> template = SqsTemplate.newSyncTemplate(mockClient);
+		UUID attemptId = UUID.randomUUID();
+		Collection<Message<Object>> receivedMessages = template.receiveManyFifo(from -> from
+			.queue(queue)
+			.receiveRequestAttemptId(attemptId)
+		);
+		assertThat(receivedMessages).hasSize(5);
+		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
+		then(mockClient).should().receiveMessage(captor.capture());
+		ReceiveMessageRequest request = captor.getValue();
+		assertThat(request.receiveRequestAttemptId()).isEqualTo(attemptId.toString());
+		assertThat(request.queueUrl()).isEqualTo(queue);
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -444,8 +444,9 @@ class SqsTemplateTests {
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
-		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
-				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payloadString).build())
+		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
+				.messages(builder -> builder.messageId(UUID.randomUUID().toString())
+						.receiptHandle("test-receipt-handle").body(payloadString).build())
 				.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
@@ -455,7 +456,7 @@ class SqsTemplateTests {
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations<Object> template = SqsTemplate.newSyncTemplate(mockClient);
 		Optional<Message<Object>> receivedMessage = template
-			.receive(from -> from.queue(queue).payloadClass(SampleRecord.class));
+				.receive(from -> from.queue(queue).payloadClass(SampleRecord.class));
 		assertThat(receivedMessage).isPresent()
 				.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
 	}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -67,6 +67,7 @@ import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 /**
  * @author Tomaz Fernandes
  */
+@SuppressWarnings("unchecked")
 class SqsTemplateTests {
 
 	@Test
@@ -74,7 +75,8 @@ class SqsTemplateTests {
 		String queue = "test-queue";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
@@ -108,7 +110,8 @@ class SqsTemplateTests {
 		String queue = "test-queue";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
@@ -141,7 +144,8 @@ class SqsTemplateTests {
 		String queue = "test-queue.fifo";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
@@ -175,7 +179,8 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
@@ -183,7 +188,7 @@ class SqsTemplateTests {
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(response));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-				.configure(options -> options.defaultEndpointName(queue)).buildSyncTemplate();
+				.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
 		SendResult<String> result = template.send(payload);
 		assertThat(result.endpoint()).isEqualTo(queue);
 		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
@@ -198,11 +203,12 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
 				.willReturn(CompletableFuture.failedFuture(new RuntimeException("Expected send error")));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-				.configure(options -> options.defaultEndpointName(queue)).buildSyncTemplate();
+				.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
 		assertThatThrownBy(() -> template.send(payload)).isInstanceOf(MessagingOperationFailedException.class)
 				.isInstanceOfSatisfying(MessagingOperationFailedException.class, ex -> {
 					assertThat(ex.getEndpoint()).isEqualTo(queue);
@@ -218,7 +224,8 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
@@ -244,7 +251,8 @@ class SqsTemplateTests {
 		Message<String> message = MessageBuilder.withPayload(payload).setHeader(headerName, headerValue).build();
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
@@ -276,7 +284,8 @@ class SqsTemplateTests {
 		List<Message<String>> messages = List.of(message1, message2);
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		SendMessageBatchResponse response = SendMessageBatchResponse.builder().successful(
 				builder -> builder.id(message1.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()),
 				builder -> builder.id(message2.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()))
@@ -316,7 +325,8 @@ class SqsTemplateTests {
 		List<Message<String>> messages = List.of(message1, message2);
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		String testErrorMessage = "test error message";
 		String code = "BC01";
 		boolean senderFault = true;
@@ -355,7 +365,8 @@ class SqsTemplateTests {
 		List<Message<String>> messages = List.of(message1, message2);
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		String testErrorMessage = "test error message";
 		String code = "BC01";
 		boolean senderFault = true;
@@ -438,12 +449,13 @@ class SqsTemplateTests {
 		String queue = "test-queue";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-				.configure(options -> options.defaultEndpointName(queue)).buildSyncTemplate();
+				.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
 		Optional<Message<?>> receivedMessage = template.receive();
 		assertThat(receivedMessage).isEmpty();
 	}
@@ -454,7 +466,8 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
 				.build();
@@ -465,7 +478,7 @@ class SqsTemplateTests {
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-				.configure(options -> options.defaultEndpointName(queue)).buildSyncTemplate();
+				.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
 		Optional<Message<?>> receivedMessage = template.receive();
 		assertThat(receivedMessage).isPresent()
 				.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
@@ -478,7 +491,8 @@ class SqsTemplateTests {
 		String payloadString = new ObjectMapper().writeValueAsString(payload);
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
 				.messages(builder -> builder.messageId(UUID.randomUUID().toString())
 						.receiptHandle("test-receipt-handle").body(payloadString).build())
@@ -503,7 +517,8 @@ class SqsTemplateTests {
 		String payloadString = new ObjectMapper().writeValueAsString(payload);
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
 				.messages(builder -> builder.messageId(UUID.randomUUID().toString())
 						.receiptHandle("test-receipt-handle").body(payloadString).build())
@@ -528,13 +543,15 @@ class SqsTemplateTests {
 	record SampleRecord(String firstProperty, String secondProperty) {
 	}
 
+	@SuppressWarnings("rawtypes")
 	@Test
 	void shouldUseCustomConverter() {
 		String queue = "test-queue";
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		ContextAwareMessagingMessageConverter<software.amazon.awssdk.services.sqs.model.Message> converter = mock(
 				ContextAwareMessagingMessageConverter.class);
 		String receiptHandle = "test-receipt-handle";
@@ -551,7 +568,7 @@ class SqsTemplateTests {
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient).messageConverter(converter)
-				.configure(options -> options.defaultEndpointName(queue)).buildSyncTemplate();
+				.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
 		Optional<Message<String>> receivedMessage = template.receive(queue, String.class);
 		assertThat(receivedMessage).isPresent()
 				.hasValueSatisfying(msg -> assertThat(msg.getPayload()).isEqualTo(payload));
@@ -564,13 +581,15 @@ class SqsTemplateTests {
 		String receiptHandle = "test-receipt-handle";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle(receiptHandle).body(payload).build()).build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
-		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient).configure(
-				options -> options.defaultEndpointName(queue).acknowledgementMode(TemplateAcknowledgementMode.MANUAL))
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
+				.configure(
+						options -> options.defaultQueue(queue).acknowledgementMode(TemplateAcknowledgementMode.MANUAL))
 				.buildSyncTemplate();
 		Optional<Message<?>> receivedMessage = template.receive();
 		assertThat(receivedMessage).isPresent()
@@ -584,7 +603,8 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
 				.build();
@@ -610,7 +630,8 @@ class SqsTemplateTests {
 		String payload2 = "test-payload-2";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		String messageId1 = UUID.randomUUID().toString();
 		String messageId2 = UUID.randomUUID().toString();
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(
@@ -645,7 +666,8 @@ class SqsTemplateTests {
 		String headerValue2 = "headerValue2";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
 				.build();
@@ -663,7 +685,7 @@ class SqsTemplateTests {
 		MessageSystemAttributeName systemAttribute = MessageSystemAttributeName.MESSAGE_GROUP_ID;
 		QueueAttributeName queueAttribute = QueueAttributeName.QUEUE_ARN;
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-				.configure(options -> options.defaultEndpointName(queue).defaultPollTimeout(Duration.ofSeconds(1))
+				.configure(options -> options.defaultQueue(queue).defaultPollTimeout(Duration.ofSeconds(1))
 						.messageAttributeNames(Collections.singletonList(testMessageAttributes))
 						.messageSystemAttributeNames(Collections.singletonList(systemAttribute))
 						.queueAttributeNames(Collections.singletonList(queueAttribute))
@@ -708,7 +730,8 @@ class SqsTemplateTests {
 		String headerValue2 = "headerValue2";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
 				.build();
@@ -742,7 +765,8 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		String messageGroupId = UUID.randomUUID().toString();
 		String deduplicationId = UUID.randomUUID().toString();
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
@@ -781,7 +805,8 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		String messageGroupId = UUID.randomUUID().toString();
 		String deduplicationId = UUID.randomUUID().toString();
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
@@ -818,7 +843,8 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
 				.messages(
 						builder -> builder.messageId(UUID.randomUUID().toString())
@@ -839,7 +865,7 @@ class SqsTemplateTests {
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient).configure(options -> options
-				.defaultEndpointName(queue).defaultPollTimeout(Duration.ofSeconds(5)).defaultMaxNumberOfMessages(6))
+				.defaultQueue(queue).defaultPollTimeout(Duration.ofSeconds(5)).defaultMaxNumberOfMessages(6))
 				.buildSyncTemplate();
 		Collection<Message<?>> receivedMessages = template.receiveMany();
 		assertThat(receivedMessages).hasSize(5);
@@ -858,7 +884,8 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
 				.messages(
 						builder -> builder.messageId(UUID.randomUUID().toString())
@@ -905,7 +932,8 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
 				.messages(
 						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
@@ -945,7 +973,8 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
 				.messages(
 						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -882,12 +882,12 @@ class SqsTemplateTests {
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		int defaultPollTimeout = 5;
 		int defaultMaxNumberOfMessages = 6;
-		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
+		SqsAsyncOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
 				.configure(options -> options.defaultQueue(queue)
 						.defaultPollTimeout(Duration.ofSeconds(defaultPollTimeout))
 						.defaultMaxNumberOfMessages(defaultMaxNumberOfMessages))
-				.buildSyncTemplate();
-		Collection<Message<String>> receivedMessages = template.receiveMany(queue, String.class);
+				.buildAsyncTemplate();
+		Collection<Message<String>> receivedMessages = template.receiveManyAsync(queue, String.class).join();
 		assertThat(receivedMessages).hasSize(5);
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
 		then(mockClient).should().receiveMessage(captor.capture());

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -74,7 +74,7 @@ class SqsTemplateTests {
 		String queue = "test-queue";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
@@ -108,7 +108,7 @@ class SqsTemplateTests {
 		String queue = "test-queue";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
@@ -141,7 +141,7 @@ class SqsTemplateTests {
 		String queue = "test-queue.fifo";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
@@ -175,7 +175,7 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
@@ -198,7 +198,7 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
 				.willReturn(CompletableFuture.failedFuture(new RuntimeException("Expected send error")));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
@@ -218,7 +218,7 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
@@ -244,7 +244,7 @@ class SqsTemplateTests {
 		Message<String> message = MessageBuilder.withPayload(payload).setHeader(headerName, headerValue).build();
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
@@ -276,7 +276,7 @@ class SqsTemplateTests {
 		List<Message<String>> messages = List.of(message1, message2);
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		SendMessageBatchResponse response = SendMessageBatchResponse.builder().successful(
 				builder -> builder.id(message1.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()),
 				builder -> builder.id(message2.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()))
@@ -316,7 +316,7 @@ class SqsTemplateTests {
 		List<Message<String>> messages = List.of(message1, message2);
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		String testErrorMessage = "test error message";
 		String code = "BC01";
 		boolean senderFault = true;
@@ -355,7 +355,7 @@ class SqsTemplateTests {
 		List<Message<String>> messages = List.of(message1, message2);
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		String testErrorMessage = "test error message";
 		String code = "BC01";
 		boolean senderFault = true;
@@ -393,7 +393,7 @@ class SqsTemplateTests {
 		String queue = "test-queue";
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture
 				.failedFuture(QueueDoesNotExistException.builder().message("test queue not found").build()));
 		given(mockClient.createQueue(any(Consumer.class)))
 				.willReturn(CompletableFuture.completedFuture(CreateQueueResponse.builder().queueUrl(queue).build()));
@@ -417,7 +417,7 @@ class SqsTemplateTests {
 		String queue = "test-queue";
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture
 				.failedFuture(QueueDoesNotExistException.builder().message("test queue not found").build()));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
@@ -438,7 +438,7 @@ class SqsTemplateTests {
 		String queue = "test-queue";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
@@ -454,7 +454,7 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
 				.build();
@@ -478,7 +478,7 @@ class SqsTemplateTests {
 		String payloadString = new ObjectMapper().writeValueAsString(payload);
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
 				.messages(builder -> builder.messageId(UUID.randomUUID().toString())
 						.receiptHandle("test-receipt-handle").body(payloadString).build())
@@ -503,7 +503,7 @@ class SqsTemplateTests {
 		String payloadString = new ObjectMapper().writeValueAsString(payload);
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
 				.messages(builder -> builder.messageId(UUID.randomUUID().toString())
 						.receiptHandle("test-receipt-handle").body(payloadString).build())
@@ -534,7 +534,7 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		ContextAwareMessagingMessageConverter<software.amazon.awssdk.services.sqs.model.Message> converter = mock(
 				ContextAwareMessagingMessageConverter.class);
 		String receiptHandle = "test-receipt-handle";
@@ -564,7 +564,7 @@ class SqsTemplateTests {
 		String receiptHandle = "test-receipt-handle";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle(receiptHandle).body(payload).build()).build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
@@ -584,7 +584,7 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
 				.build();
@@ -610,7 +610,7 @@ class SqsTemplateTests {
 		String payload2 = "test-payload-2";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		String messageId1 = UUID.randomUUID().toString();
 		String messageId2 = UUID.randomUUID().toString();
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(
@@ -645,7 +645,7 @@ class SqsTemplateTests {
 		String headerValue2 = "headerValue2";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
 				.build();
@@ -683,11 +683,9 @@ class SqsTemplateTests {
 		assertThat(request.queueUrl()).isEqualTo(queue);
 		assertThat(request.messageAttributeNames()).containsExactly(testMessageAttributes);
 		assertThat(request.attributeNamesAsStrings().get(0)).isEqualTo(systemAttribute.name());
-		ArgumentCaptor<Consumer<GetQueueUrlRequest.Builder>> queueCaptor = ArgumentCaptor.forClass(Consumer.class);
+		ArgumentCaptor<GetQueueUrlRequest> queueCaptor = ArgumentCaptor.forClass(GetQueueUrlRequest.class);
 		then(mockClient).should().getQueueUrl(queueCaptor.capture());
-		GetQueueUrlRequest.Builder getUrlBuilder = GetQueueUrlRequest.builder();
-		queueCaptor.getValue().accept(getUrlBuilder);
-		GetQueueUrlRequest capturedUrlRequest = getUrlBuilder.build();
+		GetQueueUrlRequest capturedUrlRequest = queueCaptor.getValue();
 		assertThat(capturedUrlRequest.queueName()).isEqualTo(queue);
 		ArgumentCaptor<Consumer<GetQueueAttributesRequest.Builder>> queueAttributesCaptor = ArgumentCaptor
 				.forClass(Consumer.class);
@@ -710,7 +708,7 @@ class SqsTemplateTests {
 		String headerValue2 = "headerValue2";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
 				.build();
@@ -744,7 +742,7 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		String messageGroupId = UUID.randomUUID().toString();
 		String deduplicationId = UUID.randomUUID().toString();
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
@@ -783,7 +781,7 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		String messageGroupId = UUID.randomUUID().toString();
 		String deduplicationId = UUID.randomUUID().toString();
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
@@ -820,7 +818,7 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
 				.messages(
 						builder -> builder.messageId(UUID.randomUUID().toString())
@@ -860,7 +858,7 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
 				.messages(
 						builder -> builder.messageId(UUID.randomUUID().toString())
@@ -907,7 +905,7 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
 				.messages(
 						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
@@ -947,7 +945,7 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
-		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
 				.messages(
 						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -80,14 +80,14 @@ class SqsTemplateTests {
 				.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(response));
-		SqsOperations<Object> template = SqsTemplate.newTemplate(mockClient);
+		SqsOperations template = SqsTemplate.newTemplate(mockClient);
 		String payload = "test-payload";
 		String testHeaderName = "testHeaderName";
 		String testHeaderValue = "testHeaderValue";
 		String testHeaderName2 = "testHeaderName2";
 		String testHeaderValue2 = "testHeaderValue2";
 		Integer delaySeconds = 5;
-		SendResult<Object> result = template.send(to -> to.delaySeconds(delaySeconds).queue(queue).payload(payload)
+		SendResult<String> result = template.send(to -> to.delaySeconds(delaySeconds).queue(queue).payload(payload)
 				.header(testHeaderName, testHeaderValue).headers(Map.of(testHeaderName2, testHeaderValue2)));
 		assertThat(result.endpoint()).isEqualTo(queue);
 		assertThat(result.message().getHeaders()).containsKeys(testHeaderName, testHeaderName2)
@@ -116,9 +116,9 @@ class SqsTemplateTests {
 				.willReturn(CompletableFuture.completedFuture(response));
 		UUID messageGroupId = UUID.randomUUID();
 		UUID messageDeduplicationId = UUID.randomUUID();
-		SqsOperations<Object> template = SqsTemplate.newTemplate(mockClient);
+		SqsOperations template = SqsTemplate.newTemplate(mockClient);
 		String payload = "test-payload";
-		SendResult<Object> result = template.sendFifo(to -> to.queue(queue).messageGroupId(messageGroupId)
+		SendResult<String> result = template.sendFifo(to -> to.queue(queue).messageGroupId(messageGroupId)
 				.messageDeduplicationId(messageDeduplicationId).payload(payload));
 		assertThat(result.endpoint()).isEqualTo(queue);
 		assertThat(result.message().getHeaders())
@@ -146,9 +146,9 @@ class SqsTemplateTests {
 				.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(response));
-		SqsOperations<Object> template = SqsTemplate.builder().sqsAsyncClient(mockClient)
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
 				.configure(options -> options.defaultEndpointName(queue)).buildSyncTemplate();
-		SendResult<Object> result = template.send(payload);
+		SendResult<String> result = template.send(payload);
 		assertThat(result.endpoint()).isEqualTo(queue);
 		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
 		then(mockClient).should().sendMessage(captor.capture());
@@ -165,7 +165,7 @@ class SqsTemplateTests {
 		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
 				.willReturn(CompletableFuture.failedFuture(new RuntimeException("Expected send error")));
-		SqsOperations<Object> template = SqsTemplate.builder().sqsAsyncClient(mockClient)
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
 				.configure(options -> options.defaultEndpointName(queue)).buildSyncTemplate();
 		assertThatThrownBy(() -> template.send(payload)).isInstanceOf(MessagingOperationFailedException.class)
 				.isInstanceOfSatisfying(MessagingOperationFailedException.class, ex -> {
@@ -189,8 +189,8 @@ class SqsTemplateTests {
 				.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(response));
-		SqsOperations<Object> template = SqsTemplate.newSyncTemplate(mockClient);
-		SendResult<Object> result = template.send(queue, payload);
+		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
+		SendResult<String> result = template.send(queue, payload);
 		assertThat(result.endpoint()).isEqualTo(queue);
 		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
 		then(mockClient).should().sendMessage(captor.capture());
@@ -215,7 +215,7 @@ class SqsTemplateTests {
 				.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(response));
-		SqsOperations<String> template = SqsTemplate.newSyncTemplate(mockClient);
+		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		SendResult<String> result = template.send(queue, message);
 		assertThat(result.endpoint()).isEqualTo(queue);
 		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
@@ -247,7 +247,7 @@ class SqsTemplateTests {
 				.build();
 		given(mockClient.sendMessageBatch(any(SendMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(response));
-		SqsOperations<String> template = SqsTemplate.newSyncTemplate(mockClient);
+		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		SendResult.Batch<String> results = template.sendMany(queue, messages);
 		assertThat(results.successful()).hasSize(2);
 		Iterator<SendResult<String>> iterator = results.successful().iterator();
@@ -291,7 +291,7 @@ class SqsTemplateTests {
 				.build();
 		given(mockClient.sendMessageBatch(any(SendMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(response));
-		SqsOperations<String> template = SqsTemplate.<String> builder().configure(
+		SqsOperations template = SqsTemplate.builder().configure(
 				options -> options.sendBatchFailureHandlingStrategy(SendBatchFailureHandlingStrategy.DO_NOT_THROW))
 				.sqsAsyncClient(mockClient).buildSyncTemplate();
 		SendResult.Batch<String> results = template.sendMany(queue, messages);
@@ -330,7 +330,7 @@ class SqsTemplateTests {
 				.build();
 		given(mockClient.sendMessageBatch(any(SendMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(response));
-		SqsOperations<String> template = SqsTemplate.newSyncTemplate(mockClient);
+		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		assertThatThrownBy(() -> template.sendMany(queue, messages))
 				.isInstanceOf(SendBatchOperationFailedException.class)
 				.isInstanceOfSatisfying(SendBatchOperationFailedException.class, ex -> {
@@ -367,8 +367,8 @@ class SqsTemplateTests {
 				.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(response));
-		SqsOperations<Object> template = SqsTemplate.newSyncTemplate(mockClient);
-		SendResult<Object> result = template.send(to -> to.queue(queue).payload(payload));
+		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
+		SendResult<String> result = template.send(to -> to.queue(queue).payload(payload));
 		assertThat(result.endpoint()).isEqualTo(queue);
 		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
 		then(mockClient).should().sendMessage(captor.capture());
@@ -389,7 +389,7 @@ class SqsTemplateTests {
 				.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(response));
-		SqsOperations<Object> template = SqsTemplate.builder().sqsAsyncClient(mockClient)
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
 				.configure(options -> options.queueNotFoundStrategy(QueueNotFoundStrategy.FAIL)).buildSyncTemplate();
 		assertThatThrownBy(() -> template.send(to -> to.queue(queue).payload(payload)))
 				.isInstanceOf(MessagingOperationFailedException.class).cause().isInstanceOf(CompletionException.class)
@@ -400,16 +400,15 @@ class SqsTemplateTests {
 	@Test
 	void shouldReceiveEmpty() {
 		String queue = "test-queue";
-		String payload = "test-payload";
 		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
-		SqsOperations<Object> template = SqsTemplate.builder().sqsAsyncClient(mockClient)
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
 				.configure(options -> options.defaultEndpointName(queue)).buildSyncTemplate();
-		Optional<Message<Object>> receivedMessage = template.receive();
+		Optional<Message<String>> receivedMessage = template.receive();
 		assertThat(receivedMessage).isEmpty();
 	}
 
@@ -429,9 +428,9 @@ class SqsTemplateTests {
 				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
-		SqsOperations<Object> template = SqsTemplate.builder().sqsAsyncClient(mockClient)
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
 				.configure(options -> options.defaultEndpointName(queue)).buildSyncTemplate();
-		Optional<Message<Object>> receivedMessage = template.receive();
+		Optional<Message<String>> receivedMessage = template.receive();
 		assertThat(receivedMessage).isPresent()
 				.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
 	}
@@ -454,11 +453,43 @@ class SqsTemplateTests {
 				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
-		SqsOperations<Object> template = SqsTemplate.newSyncTemplate(mockClient);
-		Optional<Message<Object>> receivedMessage = template
+		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
+		Optional<Message<SampleRecord>> receivedMessage = template
 				.receive(from -> from.queue(queue).payloadClass(SampleRecord.class));
 		assertThat(receivedMessage).isPresent()
 				.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
+	}
+
+	@Test
+	void shouldConvertToDefaultClass() throws Exception {
+		String queue = "test-queue";
+		SampleRecord payload = new SampleRecord("first-prop", "second-prop");
+		String payloadString = new ObjectMapper().writeValueAsString(payload);
+		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(Consumer.class))).willReturn(CompletableFuture.completedFuture(urlResponse));
+		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
+				.messages(builder -> builder.messageId(UUID.randomUUID().toString())
+						.receiptHandle("test-receipt-handle").body(payloadString).build())
+				.build();
+		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
+				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(deleteResponse));
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
+			.configure(options -> options.defaultPayloadClass(SampleRecord.class))
+			.buildSyncTemplate();
+		Optional<Message<SampleRecord>> receivedMessage = template
+				.receive(from -> from.queue(queue).payloadClass(SampleRecord.class));
+		assertThat(receivedMessage).isPresent()
+				.hasValueSatisfying(message -> {
+					SampleRecord receivedPayload = message.getPayload();
+					assertThat(receivedPayload).isEqualTo(payload);
+					assertThat(receivedPayload.firstProperty).isEqualTo(payload.firstProperty);
+					assertThat(receivedPayload.secondProperty).isEqualTo(payload.secondProperty);
+				});
 	}
 
 	record SampleRecord(String firstProperty, String secondProperty) {
@@ -486,9 +517,9 @@ class SqsTemplateTests {
 				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
-		SqsOperations<Object> template = SqsTemplate.builder().sqsAsyncClient(mockClient).messageConverter(converter)
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient).messageConverter(converter)
 				.configure(options -> options.defaultEndpointName(queue)).buildSyncTemplate();
-		Optional<Message<Object>> receivedMessage = template.receive();
+		Optional<Message<String>> receivedMessage = template.receive();
 		assertThat(receivedMessage).isPresent()
 				.hasValueSatisfying(msg -> assertThat(msg.getPayload()).isEqualTo(payload));
 	}
@@ -505,10 +536,10 @@ class SqsTemplateTests {
 				.messageId(UUID.randomUUID().toString()).receiptHandle(receiptHandle).body(payload).build()).build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
-		SqsOperations<Object> template = SqsTemplate.builder().sqsAsyncClient(mockClient).configure(
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient).configure(
 				options -> options.defaultEndpointName(queue).acknowledgementMode(TemplateAcknowledgementMode.MANUAL))
 				.buildSyncTemplate();
-		Optional<Message<Object>> receivedMessage = template.receive();
+		Optional<Message<String>> receivedMessage = template.receive();
 		assertThat(receivedMessage).isPresent()
 				.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
 		then(mockClient).should(never()).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
@@ -528,7 +559,7 @@ class SqsTemplateTests {
 				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.failedFuture(new RuntimeException("Expected ack error")));
-		SqsOperations<Object> template = SqsTemplate.newSyncTemplate(mockClient);
+		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		assertThatThrownBy(() -> template.receive(from -> from.queue(queue)))
 				.isInstanceOf(MessagingOperationFailedException.class).cause()
 				.isInstanceOf(SqsAcknowledgementException.class)
@@ -559,7 +590,7 @@ class SqsTemplateTests {
 				.successful(builder -> builder.id(messageId1)).failed(builder -> builder.id(messageId2)).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
-		SqsOperations<Object> template = SqsTemplate.newSyncTemplate(mockClient);
+		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		assertThatThrownBy(() -> template.receive(from -> from.queue(queue)))
 				.isInstanceOf(MessagingOperationFailedException.class).cause()
 				.isInstanceOf(SqsAcknowledgementException.class)
@@ -598,7 +629,7 @@ class SqsTemplateTests {
 		String testMessageAttributes = "test-message-attributes";
 		MessageSystemAttributeName systemAttribute = MessageSystemAttributeName.MESSAGE_GROUP_ID;
 		QueueAttributeName queueAttribute = QueueAttributeName.QUEUE_ARN;
-		SqsOperations<String> template = SqsTemplate.<String> builder().sqsAsyncClient(mockClient)
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
 				.configure(options -> options.defaultEndpointName(queue).defaultPollTimeout(Duration.ofSeconds(1))
 						.messageAttributeNames(Collections.singletonList(testMessageAttributes))
 						.messageSystemAttributeNames(Collections.singletonList(systemAttribute))
@@ -656,7 +687,7 @@ class SqsTemplateTests {
 				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
-		SqsOperations<String> template = SqsTemplate.newSyncTemplate(mockClient);
+		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		Optional<Message<String>> receivedMessage = template.receive(from -> from.queue(queue)
 				.pollTimeout(Duration.ofSeconds(1)).visibilityTimeout(Duration.ofSeconds(5))
 				.additionalHeader(headerName1, headerValue1).additionalHeaders(Map.of(headerName2, headerValue2)));
@@ -694,7 +725,7 @@ class SqsTemplateTests {
 				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
-		SqsOperations<String> template = SqsTemplate.newSyncTemplate(mockClient);
+		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		UUID attemptId = UUID.randomUUID();
 		Optional<Message<String>> receivedMessage = template
 				.receiveFifo(from -> from.queue(queue).receiveRequestAttemptId(attemptId));
@@ -738,10 +769,10 @@ class SqsTemplateTests {
 				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
-		SqsOperations<Object> template = SqsTemplate.builder().sqsAsyncClient(mockClient).configure(options -> options
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient).configure(options -> options
 				.defaultEndpointName(queue).defaultPollTimeout(Duration.ofSeconds(5)).defaultMaxNumberOfMessages(6))
 				.buildSyncTemplate();
-		Collection<Message<Object>> receivedMessages = template.receiveMany();
+		Collection<Message<String>> receivedMessages = template.receiveMany();
 		assertThat(receivedMessages).hasSize(5);
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
 		then(mockClient).should().receiveMessage(captor.capture());
@@ -780,10 +811,10 @@ class SqsTemplateTests {
 				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
-		SqsOperations<Object> template = SqsTemplate.builder().sqsAsyncClient(mockClient).configure(options -> options
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient).configure(options -> options
 				.defaultEndpointName(queue).defaultPollTimeout(Duration.ofSeconds(5)).defaultMaxNumberOfMessages(6))
 				.buildSyncTemplate();
-		Collection<Message<Object>> receivedMessages = template.receiveMany(queue, null, Duration.ofSeconds(5), 6,
+		Collection<Message<String>> receivedMessages = template.receiveMany(queue, null, Duration.ofSeconds(5), 6,
 				Map.of(headerName1, headerValue1));
 		assertThat(receivedMessages).hasSize(5);
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
@@ -825,8 +856,8 @@ class SqsTemplateTests {
 				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
-		SqsOperations<Object> template = SqsTemplate.newSyncTemplate(mockClient);
-		Collection<Message<Object>> receivedMessages = template.receiveMany(from -> from.queue(queue)
+		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
+		Collection<Message<String>> receivedMessages = template.receiveMany(from -> from.queue(queue)
 				.maxNumberOfMessages(6).visibilityTimeout(Duration.ofSeconds(3)).pollTimeout(Duration.ofSeconds(5)));
 		assertThat(receivedMessages).hasSize(5);
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
@@ -864,9 +895,9 @@ class SqsTemplateTests {
 				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
-		SqsOperations<Object> template = SqsTemplate.newSyncTemplate(mockClient);
+		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		UUID attemptId = UUID.randomUUID();
-		Collection<Message<Object>> receivedMessages = template
+		Collection<Message<String>> receivedMessages = template
 				.receiveManyFifo(from -> from.queue(queue).receiveRequestAttemptId(attemptId));
 		assertThat(receivedMessages).hasSize(5);
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -1,0 +1,14 @@
+package io.awspring.cloud.sqs.operations;
+
+
+/**
+ * @author Tomaz Fernandes
+ * @since 3.0
+ */
+class SqsTemplateTests {
+
+	void shouldSend() {
+
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverterTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverterTests.java
@@ -29,7 +29,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.MessageConverter;
-import org.springframework.messaging.support.HeaderMapper;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverterTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverterTests.java
@@ -67,6 +67,23 @@ class SqsMessagingMessageConverterTests {
 		assertThat(resultMessage.getPayload()).isEqualTo(myPojo);
 	}
 
+	@Test
+	void shouldUseHeaderOverPayloadClass() throws Exception {
+		String typeHeader = "myHeader";
+		MyPojo myPojo = new MyPojo();
+		String payload = this.objectMapper.writeValueAsString(myPojo);
+		Message message = Message.builder()
+				.messageAttributes(Collections.singletonMap(typeHeader,
+						MessageAttributeValue.builder().stringValue(MyPojo.class.getName()).build()))
+				.body(payload).messageId(UUID.randomUUID().toString()).build();
+		SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+		SqsMessageConversionContext context = new SqsMessageConversionContext();
+		context.setPayloadClass(String.class);
+		converter.setPayloadTypeHeader(typeHeader);
+		org.springframework.messaging.Message<?> resultMessage = converter.toMessagingMessage(message, context);
+		assertThat(resultMessage.getPayload()).isEqualTo(myPojo);
+	}
+
 	@SuppressWarnings("unchecked")
 	@Test
 	void shouldUseProvidedHeaderMapper() {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/resolver/BatchAcknowledgmentArgumentResolverTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/resolver/BatchAcknowledgmentArgumentResolverTests.java
@@ -21,7 +21,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
-import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.MessagingHeaders;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementCallback;
 import io.awspring.cloud.sqs.listener.acknowledgement.BatchAcknowledgement;
 import java.util.Arrays;
@@ -131,7 +131,7 @@ class BatchAcknowledgmentArgumentResolverTests {
 
 	@NotNull
 	private MessageHeaders getMessageHeaders(AcknowledgementCallback<Object> callback) {
-		return new MessageHeaders(Collections.singletonMap(SqsHeaders.SQS_ACKNOWLEDGMENT_CALLBACK_HEADER, callback));
+		return new MessageHeaders(Collections.singletonMap(MessagingHeaders.ACKNOWLEDGMENT_CALLBACK_HEADER, callback));
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/test/resources/logback.xml
+++ b/spring-cloud-aws-sqs/src/test/resources/logback.xml
@@ -26,7 +26,7 @@
 	<logger name="io.awspring.cloud.sqs.listener.SqsMessageListenerContainer" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.listener.AsyncComponentAdapters" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.listener.SemaphoreBackPressureHandler" level="INFO"/>
-	<logger name="io.awspring.cloud.sqs.listener.QueueAttributesResolver" level="INFO"/>
+	<logger name="io.awspring.cloud.sqs.QueueAttributesResolver" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.listener.source" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.listener.sink" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.listener.sink.AbstractMessageProcessingPipelineSink" level="INFO"/>
@@ -37,6 +37,7 @@
 	<logger name="io.awspring.cloud.sqs.listener.acknowledgement.handler" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.listener.acknowledgement.BatchingAcknowledgementProcessor" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.listener.acknowledgement.SqsAcknowledgementExecutor" level="INFO"/>
+	<logger name="io.awspring.cloud.sqs.operations" level="TRACE"/>
 
 	<logger name="io.awspring.cloud.sqs.integration.BaseSqsIntegrationTest" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.integration.SqsIntegrationTests" level="INFO"/>
@@ -44,6 +45,7 @@
 	<logger name="io.awspring.cloud.sqs.integration.SqsLoadIntegrationTests" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.integration.SqsInterceptorIntegrationTests" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.integration.SqsMessageConversionIntegrationTests" level="INFO"/>
+	<logger name="io.awspring.cloud.sqs.integration.SqsTemplateIntegrationTests" level="TRACE"/>
 
 	<root level="warn">
 		<appender-ref ref="STDOUT"/>


### PR DESCRIPTION
Hey!

I think implementation-wise this is almost done, pending documentation, javadocs and unit tests.

I'd appreciate feedback, specially on the API / interfaces, if possible.

You can check [SqsTemplateIntegrationTests](https://github.com/tomazfernandes/spring-cloud-aws/blob/GH-507/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java) for some examples.

### Instantiation

Basically, there are two ways of instantiating the `SqsTemplate`. The first one is a simple one with default settings:

```java
SqsOperations<Object> template = SqsTemplate.newTemplate(this.asyncClient);
```

and a more elaborate one with a builder:

```java
SqsTemplate<SampleRecord> template = SqsTemplate.<SampleRecord>builder()
			.sqsAsyncClient(this.asyncClient)
			.configure(options -> options
                                .acknowledgementMode(TemplateAcknowledgementMode.DO_NOT_ACKNOWLEDGE)
				.endpointName(SENDS_AND_RECEIVES_MANUAL_ACK_QUEUE_NAME))
			.build();
```

I chose to go with the builder because `Templates` are usually shared between many threads, so immutability will ensure it's thread safe.


### Sending and Receiving

For sending and receiving messages there are `blocking` and `async` interfaces. The most familiar ones would be [MessagingOperations](https://github.com/tomazfernandes/spring-cloud-aws/blob/GH-507/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingOperations.java) and [AsyncMessagingOperations](https://github.com/tomazfernandes/spring-cloud-aws/blob/GH-507/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AsyncMessagingOperations.java).

But the ones I think will be most useful have a more fluent API: [SqsOperations](https://github.com/tomazfernandes/spring-cloud-aws/blob/GH-507/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsOperations.java) and [SqsAsyncOperations](https://github.com/tomazfernandes/spring-cloud-aws/blob/GH-507/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsAsyncOperations.java)

```java
template.send(to -> to
	  .queue(SENDS_AND_RECEIVES_WITH_HEADERS_QUEUE_NAME)
	  .payload(testRecord)
	  .header(myCustomHeader, myCustomValue)
	  .headers(Map.of(myCustomHeader2, myCustomValue2))
);


Optional<Message<SampleRecord>> receivedMessage2 = template.receive(from -> from
	.queue(SENDS_AND_RECEIVES_RECORD_QUEUE_NAME)
        .pollTimeout(Duration.ofSeconds(1)));
```

### Batch

There are variants for sending and receiving batches of messages:

```java
List<Message<SampleRecord>> messagesToSend = IntStream
			.range(0, 5)
			.mapToObj(index -> new SampleRecord("Hello world - " + index, "From SQS!"))
			.map(record -> MessageBuilder.withPayload(record).build())
			.toList();
template.send(SENDS_AND_RECEIVES_BATCH_QUEUE_NAME, messagesToSend);


Collection<Message<SampleRecord>> receivedMessages = template
			.receiveMany(from -> from
				.queue(SENDS_AND_RECEIVES_BATCH_QUEUE_NAME)
				.pollTimeout(Duration.ofSeconds(10))
				.maxNumberOfMessages(10));
```


### FIFO

I've also added specific `FIFO` methods that allow users to specify `messageDeduplicationId` and `messageGroupId` for sending, and `receiveRequestAttemptId` for receiving, adding random UUIDs if none is provided. I'm not sure if maybe it'd be better to simplify this and remove these FIFO methods, leaving all options in the main methods, but seems like this might help users be explicit in this choice.

```java
template.sendFifo(to -> to
	.queue(SENDS_AND_RECEIVES_MESSAGE_FIFO_QUEUE_NAME)
	.messageGroupId(UUID.randomUUID())
	.payload(testBody));

Optional<Message<Object>> receivedMessage = template
	.receiveFifo(from -> from.queue(SENDS_AND_RECEIVES_MESSAGE_FIFO_QUEUE_NAME)
		.receiveRequestAttemptId(UUID.randomUUID()));
```



The `SqsTemplate` API got a bit crowded with all blocking and async methods, so it's probably better to inject `SqsOperations` or `SqsAsyncOperations` instead.

Please let me know if you have any questions or suggestions.

Thanks!