### PR TITLE
Normalize Maven Variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
 				<sonar.projectKey>awspring_spring-cloud-aws</sonar.projectKey>
 
 				<!-- https://community.sonarsource.com/t/project-quarkusio-quarkus-cant-have-2-modules-with-the-following-key-quarkusio-quarkus/33824/6 -->
-				<sonar.moduleKey>${artifactId}</sonar.moduleKey>
+				<sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
 				<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 			</properties>
 			<build>


### PR DESCRIPTION
Many POMs use variables like ${basedir}. That is the short form of ${project.basedir}. The form without prefix is deprecated: https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#Available_Variables