### PR TITLE
Add option to resolve SQS queue by ARN

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -134,7 +134,11 @@ public void queueListener(Person person) {
 ----
 
 In this example a queue listener container is started that polls the SQS `queueName` passed to the `MessageMapping`
-annotation. The incoming messages are converted to the target type and then the annotated method `queueListener` is invoked.
+annotation. The incoming messages are converted to the target type and then the annotated method `queueListener` is invoked. There are multiple options to specify the queue that should be listened to:
+
+ * Using the queue name. Works only for queues within the same account and region your application/sqs client is using.
+ * Using the queue url. This allows access to a queue that is in a different region than your application/sqs client is using.
+ * Using the queue arn. Can be used to listen to queues that are owned by another account, but live within the same region your application/sqs client uses.
 
 In addition to the payload, headers can be injected in the listener methods with the `@Header` or `@Headers`
 annotations. `@Header` is used to inject a specific header value while `@Headers` injects a `Map<String, String>`

--- a/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/support/destination/DynamicQueueUrlDestinationResolver.java
+++ b/spring-cloud-aws-messaging/src/main/java/io/awspring/cloud/messaging/support/destination/DynamicQueueUrlDestinationResolver.java
@@ -26,6 +26,7 @@ import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
 import com.amazonaws.services.sqs.model.GetQueueUrlResult;
 import com.amazonaws.services.sqs.model.QueueDoesNotExistException;
 import io.awspring.cloud.core.env.ResourceIdResolver;
+import io.awspring.cloud.core.naming.AmazonResourceName;
 
 import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.core.DestinationResolver;
@@ -87,7 +88,15 @@ public class DynamicQueueUrlDestinationResolver implements DestinationResolver<S
 		}
 		else {
 			try {
-				GetQueueUrlResult getQueueUrlResult = this.amazonSqs.getQueueUrl(new GetQueueUrlRequest(queueName));
+				GetQueueUrlRequest request = new GetQueueUrlRequest(queueName);
+
+				if (AmazonResourceName.isValidAmazonResourceName(queueName)) {
+					AmazonResourceName resourceName = AmazonResourceName.fromString(name);
+					request.setQueueName(resourceName.getResourceType());
+					request.setQueueOwnerAWSAccountId(resourceName.getAccount());
+				}
+
+				GetQueueUrlResult getQueueUrlResult = this.amazonSqs.getQueueUrl(request);
 				return getQueueUrlResult.getQueueUrl();
 			}
 			catch (QueueDoesNotExistException e) {


### PR DESCRIPTION
Fixes #561

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This PR introduces the option to use the queue ARN to resolve an SQS queue when specifying an SQSListener. This enables the user to listen to queues from other accounts than the account used by the application/sqs client.

**Limitation:** As the used AmazonSQS client is region-specific, queues from other regions cannot be resolved. However, this can still be achieved using the queue url. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See issue #561 
Since it is common to access AWS resources via the ARN, this should also be possible for the SqsListener.

## :green_heart: How did you test it?
I built the project locally and ran the unit tests. In addition, I used a small sample application to check locally that the ARN is resolved correctly when specified as value in the SqsListener annotation. 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
