### PR TITLE
Basic s3 signed URL implementation

### DIFF
--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Operations.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Operations.java
@@ -16,6 +16,8 @@
 package io.awspring.cloud.s3;
 
 import java.io.InputStream;
+import java.net.URL;
+
 import org.springframework.lang.Nullable;
 import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
 
@@ -103,4 +105,24 @@ public interface S3Operations {
 	 * @return downloaded object represented as {@link S3Resource}
 	 */
 	S3Resource download(String bucketName, String key);
+
+	/**
+	 * Creates a signed URL for retrieving an object from S3.
+	 *
+	 * @param bucketName - the bucket name
+	 * @param key - the object key
+	 * @param durationMinutes - duration that the URL will work
+	 * @return a {@link URL} representing the signed URL
+	 */
+	URL createSignedGetURL(String bucketName, String key, int durationMinutes);
+
+	/**
+	 * Creates a signed URL for putting an object into S3.
+	 *
+	 * @param bucketName - the bucket name
+	 * @param key - the object key
+	 * @param durationMinutes - duration that the URL will work
+	 * @return a {@link URL} representing the signed URL
+	 */
+	URL createSignedPutURL(String bucketName, String key, int durationMinutes);
 }

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Template.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Template.java
@@ -17,11 +17,20 @@ package io.awspring.cloud.s3;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URL;
+import java.time.Duration;
+
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 /**
  * Higher level abstraction over {@link S3Client} providing methods for the most common use cases.
@@ -126,6 +135,36 @@ public class S3Template implements S3Operations {
 		Assert.notNull(key, "key is required");
 
 		return new S3Resource(bucketName, key, s3Client, s3OutputStreamProvider);
+	}
+
+	@Override
+	public URL createSignedGetURL(String bucketName, String key, int durationMinutes){
+		S3Presigner presigner = S3Presigner.builder().build();
+		GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+			.bucket(bucketName)
+			.key(key).build();
+
+		GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+			.getObjectRequest(getObjectRequest)
+			.signatureDuration(Duration.ofMinutes(durationMinutes)).build();
+
+		PresignedGetObjectRequest signedRequest = presigner.presignGetObject(presignRequest);
+		return signedRequest.url();
+	}
+
+	@Override
+	public URL createSignedPutURL(String bucketName, String key, int durationMinutes){
+		S3Presigner presigner = S3Presigner.builder().build();
+		PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+			.bucket(bucketName)
+			.key(key).build();
+
+		PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+			.putObjectRequest(putObjectRequest)
+			.signatureDuration(Duration.ofMinutes(durationMinutes)).build();
+
+		PresignedPutObjectRequest signedRequest = presigner.presignPutObject(presignRequest);
+		return signedRequest.url();
 	}
 
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Added two methods to S3Operations and thus S3Template that simplify creating signed urls for getting/putting objects in S3.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It simplifies the creation of signed URLs for S3 into one function call each.
<!--- If it fixes an open issue, please link to the issue here. -->
#318 

## :green_heart: How did you test it?
So far I've manually tested it by doing ./mvnw install and then importing 3.0.0-SNAPSHOT from my local repository in a fresh spring project. 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
I'm not 100% sure this is what the issue was requesting, so please let me know! I also don't think the way I have the S3 presigner is ideal, but I'm unsure how I should set it up. I imagine it should be configured like the S3Client, but I was unable to figure out how that works exactly and could use some advice. If any of this seems promising, I will go ahead and add tests and what not. 