### PR TITLE
Add option to set a property prefix on Secrets Manager property sources for 2.4.x

### DIFF
--- a/docs/src/main/asciidoc/secrets-manager.adoc
+++ b/docs/src/main/asciidoc/secrets-manager.adoc
@@ -109,6 +109,9 @@ import. The table below provides examples of supported property values and descr
 |`spring.config.import=aws-secretsmanager:secret-key;other-secret-key`
 |Importing secrets by individual keys
 
+|`spring.config.import=aws-secretsmanager:secret-key?prefix=db.`
+|To avoid property keys collisions it is possible to configure property key prefix that gets added to each resolved property from a secret
+
 |`spring.config.import=optional:aws-secretsmanager:secret-key;other-secret-key`
 |When `optional` is used the application will start even if the specified secret is not found.
 

--- a/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourceTest.java
+++ b/spring-cloud-aws-secrets-manager-config/src/test/java/io/awspring/cloud/secretsmanager/AwsSecretsManagerPropertySourceTest.java
@@ -20,7 +20,10 @@ import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.amazonaws.services.secretsmanager.model.ResourceNotFoundException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -30,23 +33,48 @@ import static org.mockito.Mockito.when;
 
 class AwsSecretsManagerPropertySourceTest {
 
-	private AWSSecretsManager client = mock(AWSSecretsManager.class);
+	private AWSSecretsManager client;
 
-	private AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource("/config/myservice",
-			client);
+	private AwsSecretsManagerPropertySource propertySource;
+
+	private ArgumentCaptor<GetSecretValueRequest> secretValueRequestArgumentCaptor;
+
+	@BeforeEach
+	void setUp() {
+		client = mock(AWSSecretsManager.class);
+		secretValueRequestArgumentCaptor = ArgumentCaptor.forClass(GetSecretValueRequest.class);
+		propertySource = new AwsSecretsManagerPropertySource("/config/myservice", client);
+	}
 
 	@Test
 	void shouldParseSecretValue() {
-		GetSecretValueResult secretValueResult = new GetSecretValueResult();
-		secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
+		GetSecretValueResult secretValueResult = new GetSecretValueResult()
+				.withSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
 
-		when(client.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
+		when(client.getSecretValue(secretValueRequestArgumentCaptor.capture())).thenReturn(secretValueResult);
 
 		propertySource.init();
 
+		assertThat(secretValueRequestArgumentCaptor.getValue().getSecretId()).isEqualTo("/config/myservice");
 		assertThat(propertySource.getPropertyNames()).containsExactly("key1", "key2");
 		assertThat(propertySource.getProperty("key1")).isEqualTo("value1");
 		assertThat(propertySource.getProperty("key2")).isEqualTo("value2");
+	}
+
+	@Test
+	void shouldAppendPrefixIfPrefixConfigured() {
+		propertySource = new AwsSecretsManagerPropertySource("/config/myservice2?prefix=service2.", client);
+		GetSecretValueResult secretValueResult = new GetSecretValueResult()
+				.withSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
+
+		when(client.getSecretValue(secretValueRequestArgumentCaptor.capture())).thenReturn(secretValueResult);
+
+		propertySource.init();
+
+		assertThat(secretValueRequestArgumentCaptor.getValue().getSecretId()).isEqualTo("/config/myservice2");
+		assertThat(propertySource.getPropertyNames()).containsExactly("service2.key1", "service2.key2");
+		assertThat(propertySource.getProperty("service2.key1")).isEqualTo("value1");
+		assertThat(propertySource.getProperty("service2.key2")).isEqualTo("value2");
 	}
 
 	@Test
@@ -54,7 +82,18 @@ class AwsSecretsManagerPropertySourceTest {
 		when(client.getSecretValue(any(GetSecretValueRequest.class)))
 				.thenThrow(new ResourceNotFoundException("secret not found"));
 
-		assertThatThrownBy(() -> propertySource.init()).isInstanceOf(ResourceNotFoundException.class);
+		assertThatThrownBy(() -> propertySource.init()).isInstanceOf(ResourceNotFoundException.class)
+				.hasMessageContaining("secret not found");
+	}
+
+	@Test
+	void throwsExceptionWhenSecretIsNotJsonSecret() {
+		GetSecretValueResult secretValueResult = new GetSecretValueResult()
+				.withSecretString("plain text secret string, not json secret");
+		when(client.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
+
+		assertThatThrownBy(() -> propertySource.init()).isInstanceOf(RuntimeException.class)
+				.extracting(Throwable::getCause).isInstanceOf(JsonProcessingException.class);
 	}
 
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Option to add a prefix to property keys configure `spring.config.import` property with `?prefix=` added to the secret name

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When multiple secrets containing JSON properties are imported, and same keys exist in both secret JSONs then value from one secret overwrites the other.
<!--- If it fixes an open issue, please link to the issue here. -->
Similar to #622 this fixes #621 for `2.4.x` version

## :green_heart: How did you test it?
Locally connecting to AWS account with Session token, on spring boot template repo.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
