### PR TITLE
Load secret as string if json parse fails

### DIFF
--- a/docs/src/main/asciidoc/secrets-manager.adoc
+++ b/docs/src/main/asciidoc/secrets-manager.adoc
@@ -123,6 +123,15 @@ Spring Boot 2.4 changed the ways files are loaded which means profile loading ha
 Link to Spring Boot reference docs about file specific loading: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-files-profile-specific[Reference Docs]
 Read more on the official https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4[Spring Blog]
 
+==== Using plain text secrets
+
+If a `SecretString` is a plain text, use secret name to retrieve its value.
+For example, we have JDBC url as plain text secret type with name `/secrets/jdbc-url`. Secret value can be retrieved by referencing secret name:
+[source,properties]
+----
+spring.datasource.url=${jdbc-url}
+----
+
 ==== IAM Permissions
 Following IAM permissions are required by Spring Cloud AWS:
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
If secret is not a JSON string, it will take it as string. 
Name of spring property will be secret name last suffix. 
eg. if secret name is `service1/secret1` the property name will be `secret1`.
Similar approach as `3.0.x`

This also inherits behaviour like adding prefix to the property name.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #636

## :green_heart: How did you test it?
Unit test only.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
