### PR TITLE
RelativeKey should not include / if no objectName.  

### DIFF
--- a/spring-cloud-aws-core/src/main/java/io/awspring/cloud/core/io/s3/SimpleStorageResource.java
+++ b/spring-cloud-aws-core/src/main/java/io/awspring/cloud/core/io/s3/SimpleStorageResource.java
@@ -58,6 +58,7 @@ import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.WritableResource;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.core.task.support.ExecutorServiceAdapter;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link org.springframework.core.io.Resource} implementation for
@@ -192,7 +193,7 @@ public class SimpleStorageResource extends AbstractResource implements WritableR
 
 	@Override
 	public SimpleStorageResource createRelative(String relativePath) throws IOException {
-		String relativeKey = this.objectName + "/" + relativePath;
+		String relativeKey = StringUtils.hasText(this.objectName) ? this.objectName + "/" + relativePath : relativePath;
 		return new SimpleStorageResource(this.amazonS3, this.bucketName, relativeKey, this.taskExecutor);
 	}
 

--- a/spring-cloud-aws-core/src/test/java/io/awspring/cloud/core/io/s3/SimpleStorageResourceTest.java
+++ b/spring-cloud-aws-core/src/test/java/io/awspring/cloud/core/io/s3/SimpleStorageResourceTest.java
@@ -261,6 +261,22 @@ class SimpleStorageResourceTest {
 	}
 
 	@Test
+	void createRelative_root_returnsRelativeCreatedFile() throws IOException {
+
+		// Arrange
+		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(new ObjectMetadata());
+		SimpleStorageResource simpleStorageResource = new SimpleStorageResource(amazonS3, "bucket", "",
+				new SyncTaskExecutor());
+
+		// Act
+		SimpleStorageResource subObject = simpleStorageResource.createRelative("subObject");
+
+		// Assert
+		assertThat(subObject.getFilename()).isEqualTo("subObject");
+	}
+
+	@Test
 	void writeFile_forNewFile_writesFileContent() throws Exception {
 		// Arrange
 		AmazonS3 amazonS3 = mock(AmazonS3.class);


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Calling `SimpleStorageResouce.createRelative` on a `Resource` that does not contain an `objectName` will create an `objectName` with a `/` in it.  


## :bulb: Motivation and Context
Fixes #648


## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ x] I reviewed submitted code
- [ x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ x] All tests passing
- [x ] No breaking changes


## :crystal_ball: Next steps
