### PR TITLE
Add support to register beans of type TableSchema. Fixes gh-674

### DIFF
--- a/docs/src/main/asciidoc/dynamodb.adoc
+++ b/docs/src/main/asciidoc/dynamodb.adoc
@@ -69,6 +69,18 @@ To use custom implementation, declare a bean of type `DynamoDbTableNameResolver`
 
 To resolve a table schema for an entity, `DynamoDbTemplate` uses a bean of type `DynamoDbTableSchemaResolver`. The default implementation caches `TableSchema` objects in internal map.
 To use custom implementation, declare a bean of type `DynamoDbTableSchemaResolver` and it will get injected into `DynamoDbTemplate` automatically during auto-configuration.
+To register a custom table schema for a DynamoDB entity a bean of type `TableSchema`  should be created:
+[source, java]
+----
+@Configuration
+public class MyTableSchemaConfiguration {
+
+    @Bean
+    public TableSchema<MyEntity> myEntityTableSchema() {
+        // create and return a TableSchema object for the MyEntity class
+    }
+}
+----
 
 IMPORTANT: Because of classloader related https://github.com/aws/aws-sdk-java-v2/issues/2604[issue] in AWS SDK DynamoDB Enhanced client, to use Spring Cloud AWS DynamoDB module together with Spring Boot DevTools you must create a custom table schema resolver and define schema using `StaticTableSchema`.
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfigurationTest.java
@@ -292,11 +292,6 @@ class DynamoDbAutoConfigurationTest {
 			return null;
 		}
 
-		@Override
-		public <T> void register(TableSchema<T> tableSchema, String tableName) {
-
-		}
-
 	}
 
 	static class CustomDynamoDBDynamoDbTableNameResolver implements DynamoDbTableNameResolver {

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfigurationTest.java
@@ -31,7 +31,6 @@ import java.net.URI;
 import java.time.Duration;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;

--- a/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DefaultDynamoDbTableSchemaResolver.java
+++ b/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DefaultDynamoDbTableSchemaResolver.java
@@ -31,4 +31,9 @@ public class DefaultDynamoDbTableSchemaResolver implements DynamoDbTableSchemaRe
 	public <T> TableSchema<T> resolve(Class<T> clazz, String tableName) {
 		return tableSchemaCache.computeIfAbsent(tableName, entityClassName -> TableSchema.fromBean(clazz));
 	}
+
+	@Override
+	public <T> void register(TableSchema<T> tableSchema, String tableName) {
+		tableSchemaCache.put(tableName, tableSchema);
+	}
 }

--- a/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DynamoDbTableSchemaResolver.java
+++ b/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DynamoDbTableSchemaResolver.java
@@ -35,4 +35,13 @@ public interface DynamoDbTableSchemaResolver {
 	 * @param <T> - type
 	 */
 	<T> TableSchema resolve(Class<T> clazz, String tableName);
+
+	/**
+	 * Register manually a {@link TableSchema}
+	 *
+	 * @param tableSchema - the schema to be registered
+	 * @param tableName - the table name
+	 */
+	<T> void register(TableSchema<T> tableSchema, String tableName);
+
 }

--- a/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DynamoDbTableSchemaResolver.java
+++ b/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DynamoDbTableSchemaResolver.java
@@ -42,6 +42,7 @@ public interface DynamoDbTableSchemaResolver {
 	 * @param tableSchema - the schema to be registered
 	 * @param tableName - the table name
 	 */
-	<T> void register(TableSchema<T> tableSchema, String tableName);
+	default <T> void register(TableSchema<T> tableSchema, String tableName) {
+	}
 
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
The provided solution allows developers to register custom `TableSchema` by defining beans of such type, these beans will be preloaded during the start-up by the DynamoDB autoconfiguration class.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As described in https://github.com/awspring/spring-cloud-aws/issues/674, this simplifies the usage DynamoDB starter by letting people define different types of TableSchema (i.e. `StaticTableSchema` and `ImmutableTableSchema` (which can be useful when `BeanTableSchema` doesn't  fulfill the use-case [i.e. native executables built by GraalVM])

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
