### PR TITLE
feature: verify the message by AWS SNS signingCertUrl.

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sns/SnsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sns/SnsAutoConfiguration.java
@@ -22,6 +22,7 @@ import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
 import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
+import io.awspring.cloud.sns.core.AwsSignatureVerifier;
 import io.awspring.cloud.sns.core.SnsOperations;
 import io.awspring.cloud.sns.core.SnsTemplate;
 import io.awspring.cloud.sns.core.TopicArnResolver;
@@ -54,10 +55,11 @@ import software.amazon.awssdk.services.sns.SnsClientBuilder;
  * @author Maciej Walkowiak
  * @author Manuel Wessner
  * @author Matej Nedic
+ * @author kazaff
  */
 @AutoConfiguration
 @ConditionalOnClass({ SnsClient.class, SnsTemplate.class })
-@EnableConfigurationProperties({ SnsProperties.class })
+@EnableConfigurationProperties({ SnsProperties.class, VerificationProperties.class })
 @AutoConfigureAfter({ CredentialsProviderAutoConfiguration.class, RegionProviderAutoConfiguration.class })
 @ConditionalOnProperty(name = "spring.cloud.aws.sns.enabled", havingValue = "true", matchIfMissing = true)
 public class SnsAutoConfiguration {
@@ -101,6 +103,13 @@ public class SnsAutoConfiguration {
 			};
 		}
 
+	}
+
+	@ConditionalOnProperty(name = "spring.cloud.aws.sns.verification", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnMissingBean
+	@Bean
+	public AwsSignatureVerifier awsSignatureVerifier(VerificationProperties verificationProperties) {
+		return new AwsSignatureVerifier(verificationProperties.getMaxLifeTimeOfMessage());
 	}
 
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sns/VerificationProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sns/VerificationProperties.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.sns;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.lang.Nullable;
+
+/**
+ * @author kazaff
+ */
+@ConfigurationProperties(prefix = VerificationProperties.CONFIG_PREFIX)
+public class VerificationProperties {
+
+	/**
+	 * Configuration prefix.
+	 */
+	public static final String CONFIG_PREFIX = "spring.cloud.aws.sns.verification";
+
+	@Nullable
+	private String enabled;
+
+	@Nullable
+	private long maxLifeTimeOfMessage;
+
+	@Nullable
+	public String getEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(@Nullable String enabled) {
+		this.enabled = enabled;
+	}
+
+	public long getMaxLifeTimeOfMessage() {
+		return maxLifeTimeOfMessage;
+	}
+
+	public void setMaxLifeTimeOfMessage(long maxLifeTimeOfMessage) {
+		this.maxLifeTimeOfMessage = maxLifeTimeOfMessage;
+	}
+}

--- a/spring-cloud-aws-sns/pom.xml
+++ b/spring-cloud-aws-sns/pom.xml
@@ -75,6 +75,12 @@
 			<artifactId>sqs</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<version>2.9.3</version>
+		</dependency>
+
 		<!-- AWS SDK v1 is required by testcontainers-localstack -->
 		<dependency>
 			<groupId>com.amazonaws</groupId>

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/annotation/handlers/NotificationPayload.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/annotation/handlers/NotificationPayload.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sns.annotation.handlers;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that is used to map SNS message payloads to NotificationPayloads object that is annotated. Used in
+ * Controllers method for handling/receiving SNS notifications.
+ *
+ * @author kazaff
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface NotificationPayload {
+
+}

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/configuration/NotificationHandlerMethodArgumentResolverConfigurationUtils.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/configuration/NotificationHandlerMethodArgumentResolverConfigurationUtils.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.sns.configuration;
 
 import io.awspring.cloud.sns.handlers.NotificationMessageHandlerMethodArgumentResolver;
+import io.awspring.cloud.sns.handlers.NotificationPayloadHandlerMethodArgumentResolver;
 import io.awspring.cloud.sns.handlers.NotificationStatusHandlerMethodArgumentResolver;
 import io.awspring.cloud.sns.handlers.NotificationSubjectHandlerMethodArgumentResolver;
 import org.springframework.util.Assert;
@@ -28,6 +29,8 @@ import software.amazon.awssdk.services.sns.SnsClient;
  *
  * @author Alain Sahli
  * @since 1.0
+ *
+ * @author kazaff
  */
 public final class NotificationHandlerMethodArgumentResolverConfigurationUtils {
 
@@ -41,6 +44,7 @@ public final class NotificationHandlerMethodArgumentResolverConfigurationUtils {
 		composite.addResolver(new NotificationStatusHandlerMethodArgumentResolver(snsClient));
 		composite.addResolver(new NotificationMessageHandlerMethodArgumentResolver());
 		composite.addResolver(new NotificationSubjectHandlerMethodArgumentResolver());
+		composite.addResolver(new NotificationPayloadHandlerMethodArgumentResolver());
 		return composite;
 	}
 

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/AwsSignatureVerifier.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/AwsSignatureVerifier.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sns.core;
+
+import io.awspring.cloud.sns.handlers.NotificationPayloads;
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.Signature;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+
+/**
+ * Check that the request is from SNS (has the well-known header). Checks that the Signing Cert URL is hosted at
+ * amazonaws.com for SNS. Retrieves the signing certificate from the URL. Checks that the signing certificate is valid
+ * (within validity dates). Builds the string-to-sign and verifies it against the signing certificate. Verifies the
+ * signature against that string-to-sign. Checks that the timestamp is no more than {@link maxLifeTimeOfMessage} seconds
+ * prior.
+ *
+ * @author Dino Chiesa (https://github.com/DinoChiesa/Apigee-Java-AWS-SNS-Verifier)
+ * @author kazaff
+ */
+public class AwsSignatureVerifier {
+
+	private long maxLifeTimeOfMessage;
+
+	public AwsSignatureVerifier(long maxLifeTimeOfMessage) {
+		this.maxLifeTimeOfMessage = maxLifeTimeOfMessage;
+	}
+
+	public boolean verify(NotificationPayloads payloads, HttpServletRequest httpServletRequest) {
+
+		if (!isMessageHeaderValid(httpServletRequest)) {
+			return false;
+		}
+
+		if (!isMessageBodyValid(payloads)) {
+			return false;
+		}
+
+		if (maxLifeTimeOfMessage != 0L) {
+			Instant expiry = Instant.parse(payloads.getTimestamp()).plusSeconds(maxLifeTimeOfMessage);
+			Instant now = Instant.now();
+			long secondsRemaining = now.until(expiry, ChronoUnit.SECONDS);
+			if (secondsRemaining <= 0L) {
+				return false;
+			}
+		}
+
+		return isMessageSignatureValid(payloads);
+	}
+
+	private static boolean isMessageHeaderValid(HttpServletRequest httpServletRequest) {
+		String content = httpServletRequest.getHeader("x-amz-sns-message-type");
+		if (content == null || content.equals("")) {
+			return false;
+		}
+
+		content = httpServletRequest.getHeader("x-amz-sns-message-id");
+		if (content == null || content.equals("")) {
+			return false;
+		}
+
+		content = httpServletRequest.getHeader("x-amz-sns-topic-arn");
+		if (content == null || content.equals("")) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private static boolean isMessageBodyValid(NotificationPayloads payloads) {
+		if (payloads.getMessage() == null || payloads.getMessageId() == null || payloads.getTimestamp() == null
+				|| payloads.getTopicArn() == null || payloads.getType() == null || payloads.getSigningCertUrl() == null
+				|| payloads.getSignatureVersion() == null || payloads.getSignature() == null) {
+			return false;
+		}
+		return true;
+	}
+
+	private static boolean isMessageSignatureValid(NotificationPayloads payloads) {
+		try {
+			String certUri = payloads.getSigningCertUrl();
+			verifyCertificateURL(certUri);
+			Signature sig = Signature.getInstance("SHA1withRSA");
+			sig.initVerify(CertCache.getCert(certUri).getPublicKey());
+			sig.update(getMessageBytesToSign(payloads));
+			return sig.verify(Base64.getDecoder().decode(payloads.getSignature()));
+		}
+		catch (Exception e) {
+			throw new SecurityException("Verify failed", e);
+		}
+	}
+
+	private static void verifyCertificateURL(String signingCertUri) {
+		URI certUri = URI.create(signingCertUri);
+		if (!"https".equals(certUri.getScheme())) {
+			throw new SecurityException("SigningCertURL was not using HTTPS: " + certUri.toString());
+		}
+
+		String hostname = certUri.getHost();
+		if (!hostname.startsWith("sns") || !hostname.endsWith("amazonaws.com")) {
+			throw new SecurityException("SigningCertUrl appears to be invalid.");
+		}
+	}
+
+	private static byte[] getMessageBytesToSign(NotificationPayloads payloads) {
+		String type = payloads.getType();
+		if ("Notification".equals(type)) {
+			return StringToSign.forNotification(payloads).getBytes(StandardCharsets.UTF_8);
+		}
+
+		if ("SubscriptionConfirmation".equals(type) || "UnsubscribeConfirmation".equals(type)) {
+			return StringToSign.forSubscription(payloads).getBytes(StandardCharsets.UTF_8);
+		}
+
+		return null;
+	}
+
+	private static class StringToSign {
+		public static String forNotification(NotificationPayloads payloads) {
+			String stringToSign = "Message\n" + payloads.getMessage() + "\n" + "MessageId\n" + payloads.getMessageId()
+					+ "\n";
+			if (payloads.getSubject() != null) {
+				stringToSign += "Subject\n" + payloads.getSubject() + "\n";
+			}
+			stringToSign += "Timestamp\n" + payloads.getTimestamp() + "\n" + "TopicArn\n" + payloads.getTopicArn()
+					+ "\n" + "Type\n" + payloads.getType() + "\n";
+			return stringToSign;
+		}
+
+		public static String forSubscription(NotificationPayloads payloads) {
+			String stringToSign = "Message\n" + payloads.getMessage() + "\n" + "MessageId\n" + payloads.getMessageId()
+					+ "\n" + "SubscribeURL\n" + payloads.getSubscribeUrl() + "\n" + "Timestamp\n"
+					+ payloads.getTimestamp() + "\n" + "Token\n" + payloads.getToken() + "\n" + "TopicArn\n"
+					+ payloads.getTopicArn() + "\n" + "Type\n" + payloads.getType() + "\n";
+			return stringToSign;
+		}
+	}
+}

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/CertCache.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/CertCache.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sns.core;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * fetch and cache the publicKey from signingCertUrl address.
+ *
+ * @author Dino Chiesa (https://github.com/DinoChiesa/Apigee-Java-AWS-SNS-Verifier)
+ * @author kazaff
+ */
+public class CertCache {
+	private CertCache() {
+	} // uncomment if wanted
+
+	private static final Cache<String, X509Certificate> certCache = Caffeine.newBuilder().maximumSize(20)
+			.expireAfterAccess(30, TimeUnit.SECONDS).executor(Runnable::run).recordStats().build();
+
+	public static X509Certificate getCert(String certUri) throws Exception {
+		X509Certificate cert = certCache.getIfPresent(certUri);
+		if (cert == null) {
+			cert = readCertFromUri(certUri);
+			certCache.put(certUri, cert);
+		}
+		cert.checkValidity();
+		return cert;
+	}
+
+	private static X509Certificate readCertFromUri(String certUri) throws Exception {
+		try (InputStream inStream = openFollowRedirects(certUri)) {
+			return (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(inStream);
+		}
+	}
+
+	private static InputStream openFollowRedirects(String uri) throws Exception {
+		URL url = new URL(uri);
+		HttpURLConnection c = (HttpURLConnection) url.openConnection();
+		Set<String> visitedUrls = new HashSet<>();
+		boolean doneRedirecting = false;
+		while (!doneRedirecting) {
+			switch (c.getResponseCode()) {
+			case HttpURLConnection.HTTP_MOVED_PERM:
+			case HttpURLConnection.HTTP_MOVED_TEMP:
+				// Follow redirect if not already visisted
+				String newLocation = c.getHeaderField("Location");
+				if (visitedUrls.contains(newLocation)) {
+					throw new RuntimeException(
+							String.format("Infinite redirect loop detected for URL %s", url.toString()));
+				}
+				visitedUrls.add(newLocation);
+
+				url = new URL(newLocation);
+				c = (HttpURLConnection) url.openConnection();
+				break;
+			default:
+				doneRedirecting = true;
+				break;
+			}
+		}
+
+		return c.getInputStream();
+	}
+}

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/handlers/NotificationPayloadHandlerMethodArgumentResolver.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/handlers/NotificationPayloadHandlerMethodArgumentResolver.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sns.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.awspring.cloud.sns.annotation.handlers.NotificationPayload;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpInputMessage;
+
+/**
+ *
+ * Handles Subscription and Unsubscription events by transforming them to {@link NotificationPayloads} which can be used
+ * to get and verify message.
+ *
+ * @author kazaff
+ */
+public class NotificationPayloadHandlerMethodArgumentResolver
+		extends AbstractNotificationMessageHandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return (parameter.hasParameterAnnotation(NotificationPayload.class)
+				&& NotificationPayloads.class.isAssignableFrom(parameter.getParameterType()));
+	}
+
+	@Override
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	protected Object doResolveArgumentFromNotificationMessage(JsonNode content, HttpInputMessage request,
+			Class<?> parameterType) {
+
+		NotificationPayloads result = new NotificationPayloads();
+		result.setType(content.get("Type").asText());
+		result.setMessageId(content.get("MessageId").asText());
+		result.setTopicArn(content.get("TopicArn").asText());
+		result.setMessage(content.get("Message").asText());
+		result.setTimestamp(content.get("Timestamp").asText());
+		result.setSignatureVersion(content.get("SignatureVersion").asText());
+		result.setSigningCertUrl(content.get("SigningCertURL").asText());
+		result.setSignature(content.get("Signature").asText());
+
+		if (content.get("Token") != null) {
+			result.setToken(content.get("Token").asText());
+		}
+
+		if (content.get("Subject") != null) {
+			result.setSubject(content.get("Subject").asText());
+		}
+
+		if (content.get("SubscribeURL") != null) {
+			result.setSubscribeUrl(content.get("SubscribeURL").asText());
+		}
+
+		if (content.get("UnsubscribeURL") != null) {
+			result.setUnsubscribeUrl(content.get("UnsubscribeURL").asText());
+		}
+
+		return result;
+	}
+
+}

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/handlers/NotificationPayloads.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/handlers/NotificationPayloads.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sns.handlers;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * represent the AWS SNS Message payload data.
+ * @author kazaff
+ */
+public class NotificationPayloads {
+
+	private String type;
+
+	private String messageId;
+
+	@Nullable
+	private String token;
+
+	private String topicArn;
+
+	@Nullable
+	private String subject;
+
+	private String message;
+
+	@Nullable
+	private String subscribeUrl;
+
+	@Nullable
+	private String unsubscribeUrl;
+
+	private String timestamp;
+
+	private String signatureVersion;
+
+	private String signature;
+
+	private String signingCertUrl;
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getMessageId() {
+		return messageId;
+	}
+
+	public void setMessageId(String messageId) {
+		this.messageId = messageId;
+	}
+
+	@Nullable
+	public String getToken() {
+		return token;
+	}
+
+	public void setToken(@Nullable String token) {
+		this.token = token;
+	}
+
+	public String getTopicArn() {
+		return topicArn;
+	}
+
+	public void setTopicArn(String topicArn) {
+		this.topicArn = topicArn;
+	}
+
+	@Nullable
+	public String getSubject() {
+		return subject;
+	}
+
+	public void setSubject(@Nullable String subject) {
+		this.subject = subject;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public void setMessage(String message) {
+		this.message = message;
+	}
+
+	@Nullable
+	public String getSubscribeUrl() {
+		return subscribeUrl;
+	}
+
+	public void setSubscribeUrl(@Nullable String subscribeUrl) {
+		this.subscribeUrl = subscribeUrl;
+	}
+
+	@Nullable
+	public String getUnsubscribeUrl() {
+		return unsubscribeUrl;
+	}
+
+	public void setUnsubscribeUrl(@Nullable String unsubscribeUrl) {
+		this.unsubscribeUrl = unsubscribeUrl;
+	}
+
+	public String getTimestamp() {
+		return timestamp;
+	}
+
+	public void setTimestamp(String timestamp) {
+		this.timestamp = timestamp;
+	}
+
+	public String getSignatureVersion() {
+		return signatureVersion;
+	}
+
+	public void setSignatureVersion(String signatureVersion) {
+		this.signatureVersion = signatureVersion;
+	}
+
+	public String getSignature() {
+		return signature;
+	}
+
+	public void setSignature(String signature) {
+		this.signature = signature;
+	}
+
+	public String getSigningCertUrl() {
+		return signingCertUrl;
+	}
+
+	public void setSigningCertUrl(String signingCertUrl) {
+		this.signingCertUrl = signingCertUrl;
+	}
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Baseed on suggestion from AWS, any SNS message need to be verifed. So this pull request realize the must-do work.
Now when you handle the request from SNS, you can get the whole payload of message and verify it.  

## :bulb: Motivation and Context
As I saied before.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
