### PR TITLE
Initial support for StsWebIdentityTokenFileCredentialsProvider

### DIFF
--- a/spring-cloud-aws-autoconfigure/pom.xml
+++ b/spring-cloud-aws-autoconfigure/pom.xml
@@ -146,6 +146,11 @@
 			<artifactId>spring-boot-starter-aop</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>sts</artifactId>
+			<optional>true</optional>
+		</dependency>
 
 		<!-- AWS SDK v1 is required by testcontainers-localstack -->
 		<dependency>


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Adds support for StsWebIdentityTokenFileCredentialsProvider, a common use case in EKS.
Note: This is still WIP. I would first like feedback before adding tests, docs etc.

## :bulb: Motivation and Context
The recommended way of authenticating to AWS in EKS is using Service Accounts. See here https://docs.aws.amazon.com/eks/latest/userguide/pod-configuration.html

This PR adds native support for it. Users of spring-cloud-aws now only need to add the STS dependency and set up the required service account.  spring-cloud-aws will then automatically create a StsWebIdentityTokenFileCredentialsProvider. 

The inspiration behind this was https://github.com/awspring/spring-cloud-aws/issues/666


## :green_heart: How did you test it?
This still needs to be tested. I first want to hear initial feedback from the team if this will be a good feature to add. 

## :pencil: Checklist
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
