### PR TITLE
Change SqsSendOptions Ids API to String (#694)

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsSendOptions.java
@@ -16,7 +16,6 @@
 package io.awspring.cloud.sqs.operations;
 
 import java.util.Map;
-import java.util.UUID;
 
 /**
  * Options for sending messages to SQS queues, with a method chaining API.
@@ -63,17 +62,17 @@ public interface SqsSendOptions<T> {
 	SqsSendOptions<T> delaySeconds(Integer delaySeconds);
 
 	/**
-	 * Set the messageGroupId for the message. If none is provided for a FIFO queue, a random one is added.
+	 * Set the messageGroupId for the message. If none is provided for a FIFO queue, a random UUID is generated.
 	 * @param messageGroupId the id.
 	 * @return the options instance.
 	 */
-	SqsSendOptions<T> messageGroupId(UUID messageGroupId);
+	SqsSendOptions<T> messageGroupId(String messageGroupId);
 
 	/**
-	 * Set the messageDeduplicationId for the message. If none is provided for a FIFO queue, a random one is added.
+	 * Set the messageDeduplicationId for the message. If none is provided for a FIFO queue, a random UUID is generated.
 	 * @param messageDeduplicationId the id.
 	 * @return the options instance.
 	 */
-	SqsSendOptions<T> messageDeduplicationId(UUID messageDeduplicationId);
+	SqsSendOptions<T> messageDeduplicationId(String messageDeduplicationId);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
@@ -153,11 +153,10 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		}
 		if (options.messageDeduplicationId != null) {
 			builder.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER,
-					options.messageDeduplicationId.toString());
+					options.messageDeduplicationId);
 		}
 		if (options.messageGroupId != null) {
-			builder.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER,
-					options.messageGroupId.toString());
+			builder.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, options.messageGroupId);
 		}
 		return builder.build();
 	}
@@ -673,10 +672,10 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		protected final Map<String, Object> headers = new HashMap<>();
 
 		@Nullable
-		private UUID messageGroupId;
+		private String messageGroupId;
 
 		@Nullable
-		private UUID messageDeduplicationId;
+		private String messageDeduplicationId;
 
 		@Nullable
 		protected String queue;
@@ -724,15 +723,15 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		}
 
 		@Override
-		public SqsSendOptions<T> messageGroupId(UUID messageGroupId) {
-			Assert.notNull(messageGroupId, "messageGroupId must not be null");
+		public SqsSendOptions<T> messageGroupId(String messageGroupId) {
+			Assert.hasText(messageGroupId, "messageGroupId must have text");
 			this.messageGroupId = messageGroupId;
 			return this;
 		}
 
 		@Override
-		public SqsSendOptions<T> messageDeduplicationId(UUID messageDeduplicationId) {
-			Assert.notNull(messageDeduplicationId, "messageDeduplicationId must not be null");
+		public SqsSendOptions<T> messageDeduplicationId(String messageDeduplicationId) {
+			Assert.hasText(messageDeduplicationId, "messageDeduplicationId must have text");
 			this.messageDeduplicationId = messageDeduplicationId;
 			return this;
 		}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
@@ -71,11 +71,11 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 		Map<MessageSystemAttributeName, String> attributes = new HashMap<>();
 		if (headers.containsKey(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER)) {
 			attributes.put(MessageSystemAttributeName.MESSAGE_GROUP_ID,
-					headers.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER).toString());
+					headers.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, String.class));
 		}
 		if (headers.containsKey(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER)) {
 			attributes.put(MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID,
-					headers.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER).toString());
+					headers.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, String.class));
 		}
 		Map<String, MessageAttributeValue> messageAttributes = headers.entrySet().stream()
 				.filter(entry -> !isSkipHeader(entry.getKey())).collect(Collectors.toMap(Map.Entry::getKey,

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -118,25 +118,24 @@ class SqsTemplateTests {
 				.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
 				.willReturn(CompletableFuture.completedFuture(response));
-		UUID messageGroupId = UUID.randomUUID();
-		UUID messageDeduplicationId = UUID.randomUUID();
+		var messageGroupId = UUID.randomUUID().toString();
+		var messageDeduplicationId = UUID.randomUUID().toString();
 		SqsOperations template = SqsTemplate.newTemplate(mockClient);
 		String payload = "test-payload";
 		SendResult<String> result = template.send(to -> to.queue(queue).messageGroupId(messageGroupId)
 				.messageDeduplicationId(messageDeduplicationId).payload(payload));
 		assertThat(result.endpoint()).isEqualTo(queue);
-		assertThat(result.message().getHeaders())
-				.containsAllEntriesOf(Map.of(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER,
-						messageDeduplicationId.toString(),
-						SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId.toString()));
+		assertThat(result.message().getHeaders()).containsAllEntriesOf(
+				Map.of(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, messageDeduplicationId,
+						SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId));
 		assertThat(result.message().getPayload()).isEqualTo(payload);
 		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
 		then(mockClient).should().sendMessage(captor.capture());
 		SendMessageRequest capturedRequest = captor.getValue();
 		assertThat(capturedRequest.queueUrl()).isEqualTo(queue);
 		assertThat(capturedRequest.messageBody()).isEqualTo(payload);
-		assertThat(capturedRequest.messageGroupId()).isEqualTo(messageGroupId.toString());
-		assertThat(capturedRequest.messageDeduplicationId()).isEqualTo(messageDeduplicationId.toString());
+		assertThat(capturedRequest.messageGroupId()).isEqualTo(messageGroupId);
+		assertThat(capturedRequest.messageDeduplicationId()).isEqualTo(messageDeduplicationId);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #694

Using UUID as the API for messageGroupId and messageDeduplicationId prevents users from adding non-uuid business ids as the key.

Change to String so it matches the AWS SDK API for those settings.
