### PR TITLE
Add option to set DynamoDB table prefix.

### DIFF
--- a/docs/src/main/asciidoc/dynamodb.adoc
+++ b/docs/src/main/asciidoc/dynamodb.adoc
@@ -62,8 +62,9 @@ dynamoDbTemplate.save(person);
 
 ==== Resolving Table Name
 
-To resolve a table name for an entity, `DynamoDbTemplate` uses a bean of type `DynamoDbTableNameResolver`. The default implementation turns an entity class name into its snake case representation.
-To use custom implementation, declare a bean of type `DynamoDbTableNameResolver` and it will get injected into `DynamoDbTemplate` automatically during auto-configuration.
+To resolve a table name for an entity, `DynamoDbTemplate` uses a bean of type `DynamoDbTableNameResolver`. The default implementation turns an entity class name into its snake case representation with the possibility of using a table name prefix (optional). Specify the `spring.cloud.aws.dynamodb.table-prefix` to provide a table name prefix. The prefix is prepended to the table name. For example, if `spring.cloud.aws.dynamodb.table-prefix` is configured as `foo_` and the entity class is `Person`, then the default implementation resolves the table name as `foo_person`. However if you do not specify `spring.cloud.aws.dynamodb.table-prefix`, the table name will be resolved as `person`.
+
+To use a custom implementation, declare a bean of type `DynamoDbTableNameResolver` and it will get injected into `DynamoDbTemplate` automatically during auto-configuration.
 
 ==== Resolving Table Schema
 
@@ -120,6 +121,7 @@ The Spring Boot Starter for DynamoDb provides the following configuration option
 | `spring.cloud.aws.dynamodb.enabled` | Enables the DynamoDb integration. | No | `true`
 | `spring.cloud.aws.dynamodb.endpoint` | Configures endpoint used by `DynamoDbClient`. | No |
 | `spring.cloud.aws.dynamodb.region` | Configures region used by `DynamoDbClient`. | No |
+| `spring.cloud.aws.dynamodb.table-prefix` | Table name prefix used by the default `DynamoDbTableNameResolver` implementation. | No |
 
 | `spring.cloud.aws.dynamodb.dax.idle-timeout-millis` |Timeout for idle connections with the DAX cluster. | No | `30000`
 | `spring.cloud.aws.dynamodb.dax.url` | DAX cluster endpoint. | Yes |

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfiguration.java
@@ -35,7 +35,6 @@ import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.regions.providers.AwsRegionProvider;
@@ -118,14 +117,14 @@ public class DynamoDbAutoConfiguration {
 
 	@ConditionalOnMissingBean(DynamoDbOperations.class)
 	@Bean
-	public DynamoDbTemplate dynamoDBTemplate(Environment environment, DynamoDbEnhancedClient dynamoDbEnhancedClient,
-			Optional<DynamoDbTableSchemaResolver> tableSchemaResolver,
+	public DynamoDbTemplate dynamoDBTemplate(DynamoDbProperties properties,
+			DynamoDbEnhancedClient dynamoDbEnhancedClient, Optional<DynamoDbTableSchemaResolver> tableSchemaResolver,
 			Optional<DynamoDbTableNameResolver> tableNameResolver) {
 		DynamoDbTableSchemaResolver tableSchemaRes = tableSchemaResolver
 				.orElseGet(DefaultDynamoDbTableSchemaResolver::new);
 
 		DynamoDbTableNameResolver tableNameRes = tableNameResolver
-				.orElseGet(() -> new DefaultDynamoDbTableNameResolver(environment));
+				.orElseGet(() -> new DefaultDynamoDbTableNameResolver(properties.getTablePrefix()));
 		return new DynamoDbTemplate(dynamoDbEnhancedClient, tableSchemaRes, tableNameRes);
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.regions.providers.AwsRegionProvider;
@@ -46,6 +47,7 @@ import software.amazon.dax.ClusterDaxClient;
  * {@link EnableAutoConfiguration Auto-configuration} for DynamoDB integration.
  *
  * @author Matej Nedic
+ * @author Arun Patra
  * @since 3.0.0
  */
 @AutoConfiguration
@@ -116,12 +118,14 @@ public class DynamoDbAutoConfiguration {
 
 	@ConditionalOnMissingBean(DynamoDbOperations.class)
 	@Bean
-	public DynamoDbTemplate dynamoDBTemplate(DynamoDbEnhancedClient dynamoDbEnhancedClient,
+	public DynamoDbTemplate dynamoDBTemplate(Environment environment, DynamoDbEnhancedClient dynamoDbEnhancedClient,
 			Optional<DynamoDbTableSchemaResolver> tableSchemaResolver,
 			Optional<DynamoDbTableNameResolver> tableNameResolver) {
 		DynamoDbTableSchemaResolver tableSchemaRes = tableSchemaResolver
 				.orElseGet(DefaultDynamoDbTableSchemaResolver::new);
-		DynamoDbTableNameResolver tableNameRes = tableNameResolver.orElseGet(DefaultDynamoDbTableNameResolver::new);
+
+		DynamoDbTableNameResolver tableNameRes = tableNameResolver
+				.orElseGet(() -> new DefaultDynamoDbTableNameResolver(environment));
 		return new DynamoDbTemplate(dynamoDbEnhancedClient, tableSchemaRes, tableNameRes);
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,12 @@ package io.awspring.cloud.autoconfigure.dynamodb;
 import io.awspring.cloud.autoconfigure.AwsClientProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.lang.Nullable;
 
 /**
  * Properties related to AWS DynamoDB.
  * @author Matej Nedic
+ * @author Arun Patra
  * @since 3.0.0
  */
 @ConfigurationProperties(prefix = DynamoDbProperties.PREFIX)
@@ -31,11 +33,26 @@ public class DynamoDbProperties extends AwsClientProperties {
 	 * The prefix used for AWS credentials related properties.
 	 */
 	public static final String PREFIX = "spring.cloud.aws.dynamodb";
+
+	/**
+	 * The prefix used to resolve table names.
+	 */
+	@Nullable
+	private String tablePrefix;
+
 	/**
 	 * Properties that are used to configure {@link software.amazon.dax.ClusterDaxClient}.
 	 */
 	@NestedConfigurationProperty
 	private DaxProperties dax = new DaxProperties();
+
+	public String getTablePrefix() {
+		return tablePrefix;
+	}
+
+	public void setTablePrefix(String tablePrefix) {
+		this.tablePrefix = tablePrefix;
+	}
 
 	public DaxProperties getDax() {
 		return dax;

--- a/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DefaultDynamoDbTableNameResolver.java
+++ b/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DefaultDynamoDbTableNameResolver.java
@@ -36,6 +36,10 @@ public class DefaultDynamoDbTableNameResolver implements DynamoDbTableNameResolv
 		this.tablePrefix = tablePrefix;
 	}
 
+	public DefaultDynamoDbTableNameResolver() {
+		this(null);
+	}
+
 	@Override
 	public String resolve(Class clazz) {
 		Assert.notNull(clazz, "clazz is required");

--- a/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DefaultDynamoDbTableNameResolver.java
+++ b/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DefaultDynamoDbTableNameResolver.java
@@ -16,7 +16,7 @@
 package io.awspring.cloud.dynamodb;
 
 import java.util.Locale;
-import org.springframework.core.env.Environment;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -29,19 +29,18 @@ import org.springframework.util.StringUtils;
  */
 public class DefaultDynamoDbTableNameResolver implements DynamoDbTableNameResolver {
 
-	private final Environment environment;
+	@Nullable
+	private final String tablePrefix;
 
-	public DefaultDynamoDbTableNameResolver(Environment environment) {
-		this.environment = environment;
+	public DefaultDynamoDbTableNameResolver(@Nullable String tablePrefix) {
+		this.tablePrefix = tablePrefix;
 	}
 
 	@Override
 	public String resolve(Class clazz) {
 		Assert.notNull(clazz, "clazz is required");
 
-		String prefix = this.environment.getProperty("spring.cloud.aws.dynamodb.table-prefix");
-		String tablePrefix = StringUtils.hasText(prefix) ? prefix : "";
-
-		return tablePrefix.concat(clazz.getSimpleName().replaceAll("(.)(\\p{Lu})", "$1_$2").toLowerCase(Locale.ROOT));
+		String prefix = StringUtils.hasText(tablePrefix) ? tablePrefix : "";
+		return prefix.concat(clazz.getSimpleName().replaceAll("(.)(\\p{Lu})", "$1_$2").toLowerCase(Locale.ROOT));
 	}
 }

--- a/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DefaultDynamoDbTableNameResolver.java
+++ b/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DefaultDynamoDbTableNameResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,32 @@
 package io.awspring.cloud.dynamodb;
 
 import java.util.Locale;
+import org.springframework.core.env.Environment;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Simple implementation of {@link DynamoDbTableNameResolver} that resolves class simple name to table name.
  *
  * @author Matej Nedic
+ * @author Arun Patra
  * @since 3.0
  */
 public class DefaultDynamoDbTableNameResolver implements DynamoDbTableNameResolver {
 
+	private final Environment environment;
+
+	public DefaultDynamoDbTableNameResolver(Environment environment) {
+		this.environment = environment;
+	}
+
 	@Override
 	public String resolve(Class clazz) {
 		Assert.notNull(clazz, "clazz is required");
-		return clazz.getSimpleName().replaceAll("(.)(\\p{Lu})", "$1_$2").toLowerCase(Locale.ROOT);
+
+		String prefix = this.environment.getProperty("spring.cloud.aws.dynamodb.table-prefix");
+		String tablePrefix = StringUtils.hasText(prefix) ? prefix : "";
+
+		return tablePrefix.concat(clazz.getSimpleName().replaceAll("(.)(\\p{Lu})", "$1_$2").toLowerCase(Locale.ROOT));
 	}
 }

--- a/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DynamoDbTemplate.java
+++ b/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DynamoDbTemplate.java
@@ -38,8 +38,8 @@ public class DynamoDbTemplate implements DynamoDbOperations {
 	private final DynamoDbTableNameResolver dynamoDbTableNameResolver;
 
 	public DynamoDbTemplate(Environment environment, DynamoDbEnhancedClient dynamoDbEnhancedClient) {
-		this(dynamoDbEnhancedClient, new DefaultDynamoDbTableSchemaResolver(),
-				new DefaultDynamoDbTableNameResolver(environment));
+		this(dynamoDbEnhancedClient, new DefaultDynamoDbTableSchemaResolver(), new DefaultDynamoDbTableNameResolver(
+				environment.getProperty("spring.cloud.aws.dynamodb.table-prefix")));
 	}
 
 	public DynamoDbTemplate(DynamoDbEnhancedClient dynamoDbEnhancedClient,

--- a/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DynamoDbTemplate.java
+++ b/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DynamoDbTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.dynamodb;
 
+import org.springframework.core.env.Environment;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
@@ -28,6 +29,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
  * Default implementation of {@link DynamoDbOperations}.
  *
  * @author Matej Nedic
+ * @author Arun Patra
  * @since 3.0
  */
 public class DynamoDbTemplate implements DynamoDbOperations {
@@ -35,8 +37,9 @@ public class DynamoDbTemplate implements DynamoDbOperations {
 	private final DynamoDbTableSchemaResolver dynamoDbTableSchemaResolver;
 	private final DynamoDbTableNameResolver dynamoDbTableNameResolver;
 
-	public DynamoDbTemplate(DynamoDbEnhancedClient dynamoDbEnhancedClient) {
-		this(dynamoDbEnhancedClient, new DefaultDynamoDbTableSchemaResolver(), new DefaultDynamoDbTableNameResolver());
+	public DynamoDbTemplate(Environment environment, DynamoDbEnhancedClient dynamoDbEnhancedClient) {
+		this(dynamoDbEnhancedClient, new DefaultDynamoDbTableSchemaResolver(),
+				new DefaultDynamoDbTableNameResolver(environment));
 	}
 
 	public DynamoDbTemplate(DynamoDbEnhancedClient dynamoDbEnhancedClient,

--- a/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DynamoDbTemplate.java
+++ b/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DynamoDbTemplate.java
@@ -15,7 +15,6 @@
  */
 package io.awspring.cloud.dynamodb;
 
-import org.springframework.core.env.Environment;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
@@ -37,9 +36,14 @@ public class DynamoDbTemplate implements DynamoDbOperations {
 	private final DynamoDbTableSchemaResolver dynamoDbTableSchemaResolver;
 	private final DynamoDbTableNameResolver dynamoDbTableNameResolver;
 
-	public DynamoDbTemplate(Environment environment, DynamoDbEnhancedClient dynamoDbEnhancedClient) {
-		this(dynamoDbEnhancedClient, new DefaultDynamoDbTableSchemaResolver(), new DefaultDynamoDbTableNameResolver(
-				environment.getProperty("spring.cloud.aws.dynamodb.table-prefix")));
+	public DynamoDbTemplate(@Nullable String tablePrefix, DynamoDbEnhancedClient dynamoDbEnhancedClient) {
+		this(dynamoDbEnhancedClient, new DefaultDynamoDbTableSchemaResolver(),
+			new DefaultDynamoDbTableNameResolver(tablePrefix));
+	}
+
+	public DynamoDbTemplate(DynamoDbEnhancedClient dynamoDbEnhancedClient) {
+		this(dynamoDbEnhancedClient, new DefaultDynamoDbTableSchemaResolver(),
+			new DefaultDynamoDbTableNameResolver(null));
 	}
 
 	public DynamoDbTemplate(DynamoDbEnhancedClient dynamoDbEnhancedClient,

--- a/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTableNameResolverTest.java
+++ b/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTableNameResolverTest.java
@@ -18,7 +18,6 @@ package io.awspring.cloud.dynamodb;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.mock.env.MockEnvironment;
 
 /**
  * Tests for {@link DynamoDbTableNameResolver}.
@@ -29,10 +28,10 @@ import org.springframework.mock.env.MockEnvironment;
 class DynamoDbTableNameResolverTest {
 
 	private static final DefaultDynamoDbTableNameResolver tableNameResolver = new DefaultDynamoDbTableNameResolver(
-			new MockEnvironment());
+			null);
 
 	private static final DefaultDynamoDbTableNameResolver prefixedTableNameResolver = new DefaultDynamoDbTableNameResolver(
-			new MockEnvironment().withProperty("spring.cloud.aws.dynamodb.table-prefix", "my_prefix_"));
+			"my_prefix_");
 
 	@Test
 	void resolveTableNameSuccessfully() {

--- a/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTableNameResolverTest.java
+++ b/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTableNameResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,21 @@ package io.awspring.cloud.dynamodb;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
 
 /**
  * Tests for {@link DynamoDbTableNameResolver}.
  *
  * @author Matej Nedic
+ * @author Arun Patra
  */
 class DynamoDbTableNameResolverTest {
 
-	private static final DefaultDynamoDbTableNameResolver tableNameResolver = new DefaultDynamoDbTableNameResolver();
+	private static final DefaultDynamoDbTableNameResolver tableNameResolver = new DefaultDynamoDbTableNameResolver(
+			new MockEnvironment());
+
+	private static final DefaultDynamoDbTableNameResolver prefixedTableNameResolver = new DefaultDynamoDbTableNameResolver(
+			new MockEnvironment().withProperty("spring.cloud.aws.dynamodb.table-prefix", "my_prefix_"));
 
 	@Test
 	void resolveTableNameSuccessfully() {
@@ -35,8 +41,20 @@ class DynamoDbTableNameResolverTest {
 	}
 
 	@Test
+	void resolvePrefixedTableNameSuccessfully() {
+		assertThat(prefixedTableNameResolver.resolve(MoreComplexPerson.class))
+				.isEqualTo("my_prefix_more_complex_person");
+		assertThat(prefixedTableNameResolver.resolve(Person.class)).isEqualTo("my_prefix_person");
+	}
+
+	@Test
 	void resolvesTableNameFromRecord() {
 		assertThat(tableNameResolver.resolve(PersonRecord.class)).isEqualTo("person_record");
+	}
+
+	@Test
+	void resolvesPrefixedTableNameFromRecord() {
+		assertThat(prefixedTableNameResolver.resolve(PersonRecord.class)).isEqualTo("my_prefix_person_record");
 	}
 
 	record PersonRecord(String name) {

--- a/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTemplateIntegrationTest.java
+++ b/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTemplateIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,9 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.lang.Nullable;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.util.StringUtils;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -38,11 +41,19 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.*;
 
+/**
+ * Tests for {@link DynamoDbTemplate}.
+ *
+ * @author Matej Nedic
+ * @author Arun Patra
+ */
 @Testcontainers
 public class DynamoDbTemplateIntegrationTest {
 
 	private static DynamoDbTable<PersonEntity> dynamoDbTable;
+	private static DynamoDbTable<PersonEntity> prefixedDynamoDbTable;
 	private static DynamoDbTemplate dynamoDbTemplate;
+	private static DynamoDbTemplate prefixedDynamoDbTemplate;
 	private static final String indexName = "gsiPersonEntityTable";
 	private static final String nameOfGSPK = "gsPk";
 
@@ -58,10 +69,18 @@ public class DynamoDbTemplateIntegrationTest {
 						.create(AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey())))
 				.build();
 		DynamoDbEnhancedClient enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build();
-		dynamoDbTemplate = new DynamoDbTemplate(enhancedClient);
+
+		dynamoDbTemplate = new DynamoDbTemplate(new MockEnvironment(), enhancedClient);
 		dynamoDbTable = DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build().table("person_entity",
 				TableSchema.fromBean(PersonEntity.class));
-		describeAndCreateTable(dynamoDbClient);
+		describeAndCreateTable(dynamoDbClient, null);
+
+		prefixedDynamoDbTemplate = new DynamoDbTemplate(
+				new MockEnvironment().withProperty("spring.cloud.aws.dynamodb.table-prefix", "my_prefix_"),
+				enhancedClient);
+		prefixedDynamoDbTable = DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build()
+				.table("my_prefix_person_entity", TableSchema.fromBean(PersonEntity.class));
+		describeAndCreateTable(dynamoDbClient, "my_prefix_");
 	}
 
 	@Test
@@ -77,8 +96,27 @@ public class DynamoDbTemplateIntegrationTest {
 	}
 
 	@Test
+	void prefixedDynamoDbTemplate_saveAndRead_entitySuccessful() {
+		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
+		prefixedDynamoDbTemplate.save(personEntity);
+
+		PersonEntity personEntity1 = prefixedDynamoDbTemplate
+				.load(Key.builder().partitionValue(personEntity.getUuid().toString()).build(), PersonEntity.class);
+		assertThat(personEntity1).isEqualTo(personEntity);
+
+		cleanUpPrefixedTable(personEntity.getUuid());
+	}
+
+	@Test
 	void dynamoDbTemplate_read_entitySuccessful_returnsNull() {
 		PersonEntity personEntity1 = dynamoDbTemplate
+				.load(Key.builder().partitionValue(UUID.randomUUID().toString()).build(), PersonEntity.class);
+		assertThat(personEntity1).isNull();
+	}
+
+	@Test
+	void prefixedDynamoDbTemplate_read_entitySuccessful_returnsNull() {
+		PersonEntity personEntity1 = prefixedDynamoDbTemplate
 				.load(Key.builder().partitionValue(UUID.randomUUID().toString()).build(), PersonEntity.class);
 		assertThat(personEntity1).isNull();
 	}
@@ -100,6 +138,22 @@ public class DynamoDbTemplateIntegrationTest {
 	}
 
 	@Test
+	void prefixedDynamoDbTemplate_saveUpdateAndRead_entitySuccessful() {
+		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
+		prefixedDynamoDbTemplate.save(personEntity);
+
+		personEntity.setLastName("xxx");
+		prefixedDynamoDbTemplate.update(personEntity);
+
+		PersonEntity personEntity1 = prefixedDynamoDbTemplate
+				.load(Key.builder().partitionValue(personEntity.getUuid().toString()).build(), PersonEntity.class);
+		assertThat(personEntity1).isEqualTo(personEntity);
+
+		// clean up
+		cleanUpPrefixedTable(personEntity.getUuid());
+	}
+
+	@Test
 	void dynamoDbTemplate_saveAndDelete_entitySuccessful() {
 		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
 		dynamoDbTemplate.save(personEntity);
@@ -109,6 +163,18 @@ public class DynamoDbTemplateIntegrationTest {
 				.load(Key.builder().partitionValue(personEntity.getUuid().toString()).build(), PersonEntity.class);
 		assertThat(personEntity1).isEqualTo(null);
 		cleanUp(personEntity.getUuid());
+	}
+
+	@Test
+	void prefixedDynamoDbTemplate_saveAndDelete_entitySuccessful() {
+		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
+		prefixedDynamoDbTemplate.save(personEntity);
+
+		prefixedDynamoDbTemplate.delete(personEntity);
+		PersonEntity personEntity1 = prefixedDynamoDbTemplate
+				.load(Key.builder().partitionValue(personEntity.getUuid().toString()).build(), PersonEntity.class);
+		assertThat(personEntity1).isEqualTo(null);
+		cleanUpPrefixedTable(personEntity.getUuid());
 	}
 
 	@Test
@@ -126,8 +192,28 @@ public class DynamoDbTemplateIntegrationTest {
 	}
 
 	@Test
+	void prefixedDynamoDbTemplate_saveAndDelete_entitySuccessful_forKey() {
+		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
+		prefixedDynamoDbTemplate.save(personEntity);
+
+		prefixedDynamoDbTemplate.delete(Key.builder().partitionValue(personEntity.getUuid().toString()).build(),
+				PersonEntity.class);
+
+		PersonEntity personEntity1 = prefixedDynamoDbTemplate
+				.load(Key.builder().partitionValue(personEntity.getUuid().toString()).build(), PersonEntity.class);
+		assertThat(personEntity1).isEqualTo(null);
+		cleanUpPrefixedTable(personEntity.getUuid());
+	}
+
+	@Test
 	void dynamoDbTemplate_delete_entitySuccessful_forNotEntityInTable() {
 		dynamoDbTemplate.delete(Key.builder().partitionValue(UUID.randomUUID().toString()).build(), PersonEntity.class);
+	}
+
+	@Test
+	void prefixedDynamoDbTemplate_delete_entitySuccessful_forNotEntityInTable() {
+		prefixedDynamoDbTemplate.delete(Key.builder().partitionValue(UUID.randomUUID().toString()).build(),
+				PersonEntity.class);
 	}
 
 	@Test
@@ -151,6 +237,26 @@ public class DynamoDbTemplateIntegrationTest {
 	}
 
 	@Test
+	void prefixedDynamoDbTemplate_queryIndex_returns_singlePagePerson() {
+		PersonEntity personEntity = PersonEntity.Builder.person().withName("foo").withLastName("bar")
+				.withGpk1("thisIsMyKey").withUuid(UUID.randomUUID()).build();
+		prefixedDynamoDbTemplate.save(personEntity);
+
+		QueryEnhancedRequest queryEnhancedRequest = QueryEnhancedRequest.builder()
+				.queryConditional(
+						QueryConditional.keyEqualTo(Key.builder().partitionValue(personEntity.getGsPk()).build()))
+				.build();
+
+		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.query(queryEnhancedRequest, PersonEntity.class,
+				indexName);
+		// items size
+		assertThat(persons.items().stream()).hasSize(1);
+		// page size
+		assertThat(persons.stream()).hasSize(1);
+		cleanUpPrefixedTable(personEntity.getUuid());
+	}
+
+	@Test
 	void dynamoDbTemplate_query_returns_singlePagePerson() {
 		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
 		dynamoDbTemplate.save(personEntity);
@@ -168,6 +274,23 @@ public class DynamoDbTemplateIntegrationTest {
 	}
 
 	@Test
+	void prefixedDynamoDbTemplate_query_returns_singlePagePerson() {
+		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
+		prefixedDynamoDbTemplate.save(personEntity);
+
+		QueryEnhancedRequest queryEnhancedRequest = QueryEnhancedRequest.builder().queryConditional(
+				QueryConditional.keyEqualTo(Key.builder().partitionValue(personEntity.getUuid().toString()).build()))
+				.build();
+
+		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.query(queryEnhancedRequest, PersonEntity.class);
+		// items size
+		assertThat(persons.items().stream()).hasSize(1);
+		// page size
+		assertThat(persons.stream()).hasSize(1);
+		cleanUpPrefixedTable(personEntity.getUuid());
+	}
+
+	@Test
 	void dynamoDbTemplate_query_returns_empty() {
 		QueryEnhancedRequest queryEnhancedRequest = QueryEnhancedRequest.builder()
 				.queryConditional(
@@ -175,6 +298,20 @@ public class DynamoDbTemplateIntegrationTest {
 				.build();
 
 		PageIterable<PersonEntity> persons = dynamoDbTemplate.query(queryEnhancedRequest, PersonEntity.class);
+		// items size
+		assertThat(persons.items().stream()).isEmpty();
+		// page size
+		assertThat(persons.stream()).hasSize(1);
+	}
+
+	@Test
+	void prefixedDynamoDbTemplate_query_returns_empty() {
+		QueryEnhancedRequest queryEnhancedRequest = QueryEnhancedRequest.builder()
+				.queryConditional(
+						QueryConditional.keyEqualTo(Key.builder().partitionValue(UUID.randomUUID().toString()).build()))
+				.build();
+
+		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.query(queryEnhancedRequest, PersonEntity.class);
 		// items size
 		assertThat(persons.items().stream()).isEmpty();
 		// page size
@@ -193,6 +330,17 @@ public class DynamoDbTemplateIntegrationTest {
 	}
 
 	@Test
+	void prefixedDynamoDbTemplate_saveAndScanAll_entitySuccessful() {
+		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
+		prefixedDynamoDbTemplate.save(personEntity);
+
+		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.scanAll(PersonEntity.class);
+		assertThat(persons.items().iterator().next()).isEqualTo(personEntity);
+
+		cleanUpPrefixedTable(personEntity.getUuid());
+	}
+
+	@Test
 	void dynamoDbTemplate_saveAndScanAll_index_entitySuccessful() {
 		PersonEntity personEntity = PersonEntity.Builder.person().withName("foo").withLastName("bar")
 				.withGpk1("partition_key").withUuid(UUID.randomUUID()).build();
@@ -205,8 +353,26 @@ public class DynamoDbTemplateIntegrationTest {
 	}
 
 	@Test
+	void prefixedDynamoDbTemplate_saveAndScanAll_index_entitySuccessful() {
+		PersonEntity personEntity = PersonEntity.Builder.person().withName("foo").withLastName("bar")
+				.withGpk1("partition_key").withUuid(UUID.randomUUID()).build();
+		prefixedDynamoDbTemplate.save(personEntity);
+
+		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.scanAll(PersonEntity.class, indexName);
+		assertThat(persons.items().iterator().next()).isEqualTo(personEntity);
+
+		cleanUpPrefixedTable(personEntity.getUuid());
+	}
+
+	@Test
 	void dynamoDbTemplate_scanAll_returnsEmpty() {
 		PageIterable<PersonEntity> persons = dynamoDbTemplate.scanAll(PersonEntity.class);
+		assertThat(persons.items().stream()).isEmpty();
+	}
+
+	@Test
+	void prefixedDynamoDbTemplate_scanAll_returnsEmpty() {
+		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.scanAll(PersonEntity.class);
 		assertThat(persons.items().stream()).isEmpty();
 	}
 
@@ -220,6 +386,18 @@ public class DynamoDbTemplateIntegrationTest {
 		assertThat(persons.items().stream()).hasSize(2);
 		cleanUp(personEntity1.getUuid());
 		cleanUp(personEntity2.getUuid());
+	}
+
+	@Test
+	void prefixedDynamoDbTemplate_saveAndScanAllReturnsMultiplePersons_entitySuccessful() {
+		PersonEntity personEntity1 = new PersonEntity(UUID.randomUUID(), "foo", "bar");
+		PersonEntity personEntity2 = new PersonEntity(UUID.randomUUID(), "foo", "bar");
+		prefixedDynamoDbTemplate.save(personEntity1);
+		prefixedDynamoDbTemplate.save(personEntity2);
+		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.scanAll(PersonEntity.class);
+		assertThat(persons.items().stream()).hasSize(2);
+		cleanUpPrefixedTable(personEntity1.getUuid());
+		cleanUpPrefixedTable(personEntity2.getUuid());
 	}
 
 	@Test
@@ -242,6 +420,25 @@ public class DynamoDbTemplateIntegrationTest {
 	}
 
 	@Test
+	void prefixedDynamoDbTemplate_saveAndScanForParticular_entitySuccessful() {
+		PersonEntity personEntity1 = new PersonEntity(UUID.randomUUID(), "foo", "bar");
+		PersonEntity personEntity2 = new PersonEntity(UUID.randomUUID(), "foo", "bar");
+		prefixedDynamoDbTemplate.save(personEntity1);
+		prefixedDynamoDbTemplate.save(personEntity2);
+		Expression expression = Expression.builder().expression("#uuidToBeLooked = :myValue")
+				.putExpressionName("#uuidToBeLooked", "uuid")
+				.putExpressionValue(":myValue", AttributeValue.builder().s(personEntity1.getUuid().toString()).build())
+				.build();
+		ScanEnhancedRequest scanEnhancedRequest = ScanEnhancedRequest.builder().limit(2).consistentRead(true)
+				.filterExpression(expression).build();
+		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.scan(scanEnhancedRequest, PersonEntity.class);
+		assertThat(persons.items().stream()).hasSize(1);
+		assertThat(persons.items().iterator().next()).isEqualTo(personEntity1);
+		cleanUpPrefixedTable(personEntity1.getUuid());
+		cleanUpPrefixedTable(personEntity2.getUuid());
+	}
+
+	@Test
 	void dynamoDbTemplate_saveAndScanForParticularIndex_entitySuccessful() {
 		PersonEntity personEntity1 = PersonEntity.Builder.person().withName("foo").withLastName("bar")
 				.withGpk1("my_random_key").withUuid(UUID.randomUUID()).build();
@@ -261,11 +458,36 @@ public class DynamoDbTemplateIntegrationTest {
 		cleanUp(personEntity2.getUuid());
 	}
 
+	@Test
+	void prefixedDynamoDbTemplate_saveAndScanForParticularIndex_entitySuccessful() {
+		PersonEntity personEntity1 = PersonEntity.Builder.person().withName("foo").withLastName("bar")
+				.withGpk1("my_random_key").withUuid(UUID.randomUUID()).build();
+		PersonEntity personEntity2 = PersonEntity.Builder.person().withName("foo").withLastName("bar")
+				.withGpk1("some_other_key").withUuid(UUID.randomUUID()).build();
+		prefixedDynamoDbTemplate.save(personEntity1);
+		prefixedDynamoDbTemplate.save(personEntity2);
+		Expression expression = Expression.builder().expression("#gsPkToBeLooked = :myValue")
+				.putExpressionName("#gsPkToBeLooked", nameOfGSPK)
+				.putExpressionValue(":myValue", AttributeValue.builder().s(personEntity1.getGsPk()).build()).build();
+		ScanEnhancedRequest scanEnhancedRequest = ScanEnhancedRequest.builder().limit(2).filterExpression(expression)
+				.build();
+		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.scan(scanEnhancedRequest, PersonEntity.class,
+				indexName);
+		assertThat(persons.items().stream()).hasSize(1);
+		assertThat(persons.items().iterator().next()).isEqualTo(personEntity1);
+		cleanUpPrefixedTable(personEntity1.getUuid());
+		cleanUpPrefixedTable(personEntity2.getUuid());
+	}
+
 	public static void cleanUp(UUID uuid) {
 		dynamoDbTable.deleteItem(Key.builder().partitionValue(uuid.toString()).build());
 	}
 
-	private static void describeAndCreateTable(DynamoDbClient dynamoDbClient) {
+	public static void cleanUpPrefixedTable(UUID uuid) {
+		prefixedDynamoDbTable.deleteItem(Key.builder().partitionValue(uuid.toString()).build());
+	}
+
+	private static void describeAndCreateTable(DynamoDbClient dynamoDbClient, @Nullable String tablePrefix) {
 		ArrayList<AttributeDefinition> attributeDefinitions = new ArrayList<AttributeDefinition>();
 		attributeDefinitions.add(AttributeDefinition.builder().attributeName("uuid").attributeType("S").build());
 		attributeDefinitions.add(AttributeDefinition.builder().attributeName(nameOfGSPK).attributeType("S").build());
@@ -279,8 +501,8 @@ public class DynamoDbTemplateIntegrationTest {
 						.writeCapacityUnits((long) 1).build())
 				.projection(Projection.builder().projectionType(ProjectionType.ALL).build()).keySchema(indexKeySchema)
 				.build();
-
-		CreateTableRequest createTableRequest = CreateTableRequest.builder().tableName("person_entity")
+		String tableName = StringUtils.hasText(tablePrefix) ? tablePrefix.concat("person_entity") : "person_entity";
+		CreateTableRequest createTableRequest = CreateTableRequest.builder().tableName(tableName)
 				.provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits((long) 10)
 						.writeCapacityUnits((long) 1).build())
 				.attributeDefinitions(attributeDefinitions).keySchema(tableKeySchema)

--- a/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTemplateIntegrationTest.java
+++ b/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTemplateIntegrationTest.java
@@ -22,7 +22,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.lang.Nullable;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.util.StringUtils;
@@ -83,8 +85,10 @@ public class DynamoDbTemplateIntegrationTest {
 		describeAndCreateTable(dynamoDbClient, "my_prefix_");
 	}
 
-	@Test
-	void dynamoDbTemplate_saveAndRead_entitySuccessful() {
+	@ParameterizedTest
+	@MethodSource("argumentSource")
+	void dynamoDbTemplate_saveAndRead_entitySuccessful(DynamoDbTable<PersonEntity> dynamoDbTable,
+			DynamoDbTemplate dynamoDbTemplate) {
 		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
 		dynamoDbTemplate.save(personEntity);
 
@@ -92,37 +96,22 @@ public class DynamoDbTemplateIntegrationTest {
 				.load(Key.builder().partitionValue(personEntity.getUuid().toString()).build(), PersonEntity.class);
 		assertThat(personEntity1).isEqualTo(personEntity);
 
-		cleanUp(personEntity.getUuid());
+		cleanUp(dynamoDbTable, personEntity.getUuid());
 	}
 
-	@Test
-	void prefixedDynamoDbTemplate_saveAndRead_entitySuccessful() {
-		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
-		prefixedDynamoDbTemplate.save(personEntity);
-
-		PersonEntity personEntity1 = prefixedDynamoDbTemplate
-				.load(Key.builder().partitionValue(personEntity.getUuid().toString()).build(), PersonEntity.class);
-		assertThat(personEntity1).isEqualTo(personEntity);
-
-		cleanUpPrefixedTable(personEntity.getUuid());
-	}
-
-	@Test
-	void dynamoDbTemplate_read_entitySuccessful_returnsNull() {
+	@ParameterizedTest
+	@MethodSource("argumentSource")
+	void dynamoDbTemplate_read_entitySuccessful_returnsNull(DynamoDbTable<PersonEntity> dynamoDbTable,
+			DynamoDbTemplate dynamoDbTemplate) {
 		PersonEntity personEntity1 = dynamoDbTemplate
 				.load(Key.builder().partitionValue(UUID.randomUUID().toString()).build(), PersonEntity.class);
 		assertThat(personEntity1).isNull();
 	}
 
-	@Test
-	void prefixedDynamoDbTemplate_read_entitySuccessful_returnsNull() {
-		PersonEntity personEntity1 = prefixedDynamoDbTemplate
-				.load(Key.builder().partitionValue(UUID.randomUUID().toString()).build(), PersonEntity.class);
-		assertThat(personEntity1).isNull();
-	}
-
-	@Test
-	void dynamoDbTemplate_saveUpdateAndRead_entitySuccessful() {
+	@ParameterizedTest
+	@MethodSource("argumentSource")
+	void dynamoDbTemplate_saveUpdateAndRead_entitySuccessful(DynamoDbTable<PersonEntity> dynamoDbTable,
+			DynamoDbTemplate dynamoDbTemplate) {
 		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
 		dynamoDbTemplate.save(personEntity);
 
@@ -134,27 +123,13 @@ public class DynamoDbTemplateIntegrationTest {
 		assertThat(personEntity1).isEqualTo(personEntity);
 
 		// clean up
-		cleanUp(personEntity.getUuid());
+		cleanUp(dynamoDbTable, personEntity.getUuid());
 	}
 
-	@Test
-	void prefixedDynamoDbTemplate_saveUpdateAndRead_entitySuccessful() {
-		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
-		prefixedDynamoDbTemplate.save(personEntity);
-
-		personEntity.setLastName("xxx");
-		prefixedDynamoDbTemplate.update(personEntity);
-
-		PersonEntity personEntity1 = prefixedDynamoDbTemplate
-				.load(Key.builder().partitionValue(personEntity.getUuid().toString()).build(), PersonEntity.class);
-		assertThat(personEntity1).isEqualTo(personEntity);
-
-		// clean up
-		cleanUpPrefixedTable(personEntity.getUuid());
-	}
-
-	@Test
-	void dynamoDbTemplate_saveAndDelete_entitySuccessful() {
+	@ParameterizedTest
+	@MethodSource("argumentSource")
+	void dynamoDbTemplate_saveAndDelete_entitySuccessful(DynamoDbTable<PersonEntity> dynamoDbTable,
+			DynamoDbTemplate dynamoDbTemplate) {
 		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
 		dynamoDbTemplate.save(personEntity);
 
@@ -162,23 +137,13 @@ public class DynamoDbTemplateIntegrationTest {
 		PersonEntity personEntity1 = dynamoDbTemplate
 				.load(Key.builder().partitionValue(personEntity.getUuid().toString()).build(), PersonEntity.class);
 		assertThat(personEntity1).isEqualTo(null);
-		cleanUp(personEntity.getUuid());
+		cleanUp(dynamoDbTable, personEntity.getUuid());
 	}
 
-	@Test
-	void prefixedDynamoDbTemplate_saveAndDelete_entitySuccessful() {
-		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
-		prefixedDynamoDbTemplate.save(personEntity);
-
-		prefixedDynamoDbTemplate.delete(personEntity);
-		PersonEntity personEntity1 = prefixedDynamoDbTemplate
-				.load(Key.builder().partitionValue(personEntity.getUuid().toString()).build(), PersonEntity.class);
-		assertThat(personEntity1).isEqualTo(null);
-		cleanUpPrefixedTable(personEntity.getUuid());
-	}
-
-	@Test
-	void dynamoDbTemplate_saveAndDelete_entitySuccessful_forKey() {
+	@ParameterizedTest
+	@MethodSource("argumentSource")
+	void dynamoDbTemplate_saveAndDelete_entitySuccessful_forKey(DynamoDbTable<PersonEntity> dynamoDbTable,
+			DynamoDbTemplate dynamoDbTemplate) {
 		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
 		dynamoDbTemplate.save(personEntity);
 
@@ -188,36 +153,20 @@ public class DynamoDbTemplateIntegrationTest {
 		PersonEntity personEntity1 = dynamoDbTemplate
 				.load(Key.builder().partitionValue(personEntity.getUuid().toString()).build(), PersonEntity.class);
 		assertThat(personEntity1).isEqualTo(null);
-		cleanUp(personEntity.getUuid());
+		cleanUp(dynamoDbTable, personEntity.getUuid());
 	}
 
-	@Test
-	void prefixedDynamoDbTemplate_saveAndDelete_entitySuccessful_forKey() {
-		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
-		prefixedDynamoDbTemplate.save(personEntity);
-
-		prefixedDynamoDbTemplate.delete(Key.builder().partitionValue(personEntity.getUuid().toString()).build(),
-				PersonEntity.class);
-
-		PersonEntity personEntity1 = prefixedDynamoDbTemplate
-				.load(Key.builder().partitionValue(personEntity.getUuid().toString()).build(), PersonEntity.class);
-		assertThat(personEntity1).isEqualTo(null);
-		cleanUpPrefixedTable(personEntity.getUuid());
-	}
-
-	@Test
-	void dynamoDbTemplate_delete_entitySuccessful_forNotEntityInTable() {
+	@ParameterizedTest
+	@MethodSource("argumentSource")
+	void dynamoDbTemplate_delete_entitySuccessful_forNotEntityInTable(DynamoDbTable<PersonEntity> dynamoDbTable,
+			DynamoDbTemplate dynamoDbTemplate) {
 		dynamoDbTemplate.delete(Key.builder().partitionValue(UUID.randomUUID().toString()).build(), PersonEntity.class);
 	}
 
-	@Test
-	void prefixedDynamoDbTemplate_delete_entitySuccessful_forNotEntityInTable() {
-		prefixedDynamoDbTemplate.delete(Key.builder().partitionValue(UUID.randomUUID().toString()).build(),
-				PersonEntity.class);
-	}
-
-	@Test
-	void dynamoDbTemplate_queryIndex_returns_singlePagePerson() {
+	@ParameterizedTest
+	@MethodSource("argumentSource")
+	void dynamoDbTemplate_queryIndex_returns_singlePagePerson(DynamoDbTable<PersonEntity> dynamoDbTable,
+			DynamoDbTemplate dynamoDbTemplate) {
 		PersonEntity personEntity = PersonEntity.Builder.person().withName("foo").withLastName("bar")
 				.withGpk1("thisIsMyKey").withUuid(UUID.randomUUID()).build();
 		dynamoDbTemplate.save(personEntity);
@@ -233,31 +182,13 @@ public class DynamoDbTemplateIntegrationTest {
 		assertThat(persons.items().stream()).hasSize(1);
 		// page size
 		assertThat(persons.stream()).hasSize(1);
-		cleanUp(personEntity.getUuid());
+		cleanUp(dynamoDbTable, personEntity.getUuid());
 	}
 
-	@Test
-	void prefixedDynamoDbTemplate_queryIndex_returns_singlePagePerson() {
-		PersonEntity personEntity = PersonEntity.Builder.person().withName("foo").withLastName("bar")
-				.withGpk1("thisIsMyKey").withUuid(UUID.randomUUID()).build();
-		prefixedDynamoDbTemplate.save(personEntity);
-
-		QueryEnhancedRequest queryEnhancedRequest = QueryEnhancedRequest.builder()
-				.queryConditional(
-						QueryConditional.keyEqualTo(Key.builder().partitionValue(personEntity.getGsPk()).build()))
-				.build();
-
-		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.query(queryEnhancedRequest, PersonEntity.class,
-				indexName);
-		// items size
-		assertThat(persons.items().stream()).hasSize(1);
-		// page size
-		assertThat(persons.stream()).hasSize(1);
-		cleanUpPrefixedTable(personEntity.getUuid());
-	}
-
-	@Test
-	void dynamoDbTemplate_query_returns_singlePagePerson() {
+	@ParameterizedTest
+	@MethodSource("argumentSource")
+	void dynamoDbTemplate_query_returns_singlePagePerson(DynamoDbTable<PersonEntity> dynamoDbTable,
+			DynamoDbTemplate dynamoDbTemplate) {
 		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
 		dynamoDbTemplate.save(personEntity);
 
@@ -270,28 +201,13 @@ public class DynamoDbTemplateIntegrationTest {
 		assertThat(persons.items().stream()).hasSize(1);
 		// page size
 		assertThat(persons.stream()).hasSize(1);
-		cleanUp(personEntity.getUuid());
+		cleanUp(dynamoDbTable, personEntity.getUuid());
 	}
 
-	@Test
-	void prefixedDynamoDbTemplate_query_returns_singlePagePerson() {
-		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
-		prefixedDynamoDbTemplate.save(personEntity);
-
-		QueryEnhancedRequest queryEnhancedRequest = QueryEnhancedRequest.builder().queryConditional(
-				QueryConditional.keyEqualTo(Key.builder().partitionValue(personEntity.getUuid().toString()).build()))
-				.build();
-
-		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.query(queryEnhancedRequest, PersonEntity.class);
-		// items size
-		assertThat(persons.items().stream()).hasSize(1);
-		// page size
-		assertThat(persons.stream()).hasSize(1);
-		cleanUpPrefixedTable(personEntity.getUuid());
-	}
-
-	@Test
-	void dynamoDbTemplate_query_returns_empty() {
+	@ParameterizedTest
+	@MethodSource("argumentSource")
+	void dynamoDbTemplate_query_returns_empty(DynamoDbTable<PersonEntity> dynamoDbTable,
+			DynamoDbTemplate dynamoDbTemplate) {
 		QueryEnhancedRequest queryEnhancedRequest = QueryEnhancedRequest.builder()
 				.queryConditional(
 						QueryConditional.keyEqualTo(Key.builder().partitionValue(UUID.randomUUID().toString()).build()))
@@ -304,44 +220,23 @@ public class DynamoDbTemplateIntegrationTest {
 		assertThat(persons.stream()).hasSize(1);
 	}
 
-	@Test
-	void prefixedDynamoDbTemplate_query_returns_empty() {
-		QueryEnhancedRequest queryEnhancedRequest = QueryEnhancedRequest.builder()
-				.queryConditional(
-						QueryConditional.keyEqualTo(Key.builder().partitionValue(UUID.randomUUID().toString()).build()))
-				.build();
-
-		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.query(queryEnhancedRequest, PersonEntity.class);
-		// items size
-		assertThat(persons.items().stream()).isEmpty();
-		// page size
-		assertThat(persons.stream()).hasSize(1);
-	}
-
-	@Test
-	void dynamoDbTemplate_saveAndScanAll_entitySuccessful() {
+	@ParameterizedTest
+	@MethodSource("argumentSource")
+	void dynamoDbTemplate_saveAndScanAll_entitySuccessful(DynamoDbTable<PersonEntity> dynamoDbTable,
+			DynamoDbTemplate dynamoDbTemplate) {
 		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
 		dynamoDbTemplate.save(personEntity);
 
 		PageIterable<PersonEntity> persons = dynamoDbTemplate.scanAll(PersonEntity.class);
 		assertThat(persons.items().iterator().next()).isEqualTo(personEntity);
 
-		cleanUp(personEntity.getUuid());
+		cleanUp(dynamoDbTable, personEntity.getUuid());
 	}
 
-	@Test
-	void prefixedDynamoDbTemplate_saveAndScanAll_entitySuccessful() {
-		PersonEntity personEntity = new PersonEntity(UUID.randomUUID(), "foo", "bar");
-		prefixedDynamoDbTemplate.save(personEntity);
-
-		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.scanAll(PersonEntity.class);
-		assertThat(persons.items().iterator().next()).isEqualTo(personEntity);
-
-		cleanUpPrefixedTable(personEntity.getUuid());
-	}
-
-	@Test
-	void dynamoDbTemplate_saveAndScanAll_index_entitySuccessful() {
+	@ParameterizedTest
+	@MethodSource("argumentSource")
+	void dynamoDbTemplate_saveAndScanAll_index_entitySuccessful(DynamoDbTable<PersonEntity> dynamoDbTable,
+			DynamoDbTemplate dynamoDbTemplate) {
 		PersonEntity personEntity = PersonEntity.Builder.person().withName("foo").withLastName("bar")
 				.withGpk1("partition_key").withUuid(UUID.randomUUID()).build();
 		dynamoDbTemplate.save(personEntity);
@@ -349,59 +244,35 @@ public class DynamoDbTemplateIntegrationTest {
 		PageIterable<PersonEntity> persons = dynamoDbTemplate.scanAll(PersonEntity.class, indexName);
 		assertThat(persons.items().iterator().next()).isEqualTo(personEntity);
 
-		cleanUp(personEntity.getUuid());
+		cleanUp(dynamoDbTable, personEntity.getUuid());
 	}
 
-	@Test
-	void prefixedDynamoDbTemplate_saveAndScanAll_index_entitySuccessful() {
-		PersonEntity personEntity = PersonEntity.Builder.person().withName("foo").withLastName("bar")
-				.withGpk1("partition_key").withUuid(UUID.randomUUID()).build();
-		prefixedDynamoDbTemplate.save(personEntity);
-
-		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.scanAll(PersonEntity.class, indexName);
-		assertThat(persons.items().iterator().next()).isEqualTo(personEntity);
-
-		cleanUpPrefixedTable(personEntity.getUuid());
-	}
-
-	@Test
-	void dynamoDbTemplate_scanAll_returnsEmpty() {
+	@ParameterizedTest
+	@MethodSource("argumentSource")
+	void dynamoDbTemplate_scanAll_returnsEmpty(DynamoDbTable<PersonEntity> dynamoDbTable,
+			DynamoDbTemplate dynamoDbTemplate) {
 		PageIterable<PersonEntity> persons = dynamoDbTemplate.scanAll(PersonEntity.class);
 		assertThat(persons.items().stream()).isEmpty();
 	}
 
-	@Test
-	void prefixedDynamoDbTemplate_scanAll_returnsEmpty() {
-		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.scanAll(PersonEntity.class);
-		assertThat(persons.items().stream()).isEmpty();
-	}
-
-	@Test
-	void dynamoDbTemplate_saveAndScanAllReturnsMultiplePersons_entitySuccessful() {
+	@ParameterizedTest
+	@MethodSource("argumentSource")
+	void dynamoDbTemplate_saveAndScanAllReturnsMultiplePersons_entitySuccessful(
+			DynamoDbTable<PersonEntity> dynamoDbTable, DynamoDbTemplate dynamoDbTemplate) {
 		PersonEntity personEntity1 = new PersonEntity(UUID.randomUUID(), "foo", "bar");
 		PersonEntity personEntity2 = new PersonEntity(UUID.randomUUID(), "foo", "bar");
 		dynamoDbTemplate.save(personEntity1);
 		dynamoDbTemplate.save(personEntity2);
 		PageIterable<PersonEntity> persons = dynamoDbTemplate.scanAll(PersonEntity.class);
 		assertThat(persons.items().stream()).hasSize(2);
-		cleanUp(personEntity1.getUuid());
-		cleanUp(personEntity2.getUuid());
+		cleanUp(dynamoDbTable, personEntity1.getUuid());
+		cleanUp(dynamoDbTable, personEntity2.getUuid());
 	}
 
-	@Test
-	void prefixedDynamoDbTemplate_saveAndScanAllReturnsMultiplePersons_entitySuccessful() {
-		PersonEntity personEntity1 = new PersonEntity(UUID.randomUUID(), "foo", "bar");
-		PersonEntity personEntity2 = new PersonEntity(UUID.randomUUID(), "foo", "bar");
-		prefixedDynamoDbTemplate.save(personEntity1);
-		prefixedDynamoDbTemplate.save(personEntity2);
-		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.scanAll(PersonEntity.class);
-		assertThat(persons.items().stream()).hasSize(2);
-		cleanUpPrefixedTable(personEntity1.getUuid());
-		cleanUpPrefixedTable(personEntity2.getUuid());
-	}
-
-	@Test
-	void dynamoDbTemplate_saveAndScanForParticular_entitySuccessful() {
+	@ParameterizedTest
+	@MethodSource("argumentSource")
+	void dynamoDbTemplate_saveAndScanForParticular_entitySuccessful(DynamoDbTable<PersonEntity> dynamoDbTable,
+			DynamoDbTemplate dynamoDbTemplate) {
 		PersonEntity personEntity1 = new PersonEntity(UUID.randomUUID(), "foo", "bar");
 		PersonEntity personEntity2 = new PersonEntity(UUID.randomUUID(), "foo", "bar");
 		dynamoDbTemplate.save(personEntity1);
@@ -415,31 +286,14 @@ public class DynamoDbTemplateIntegrationTest {
 		PageIterable<PersonEntity> persons = dynamoDbTemplate.scan(scanEnhancedRequest, PersonEntity.class);
 		assertThat(persons.items().stream()).hasSize(1);
 		assertThat(persons.items().iterator().next()).isEqualTo(personEntity1);
-		cleanUp(personEntity1.getUuid());
-		cleanUp(personEntity2.getUuid());
+		cleanUp(dynamoDbTable, personEntity1.getUuid());
+		cleanUp(dynamoDbTable, personEntity2.getUuid());
 	}
 
-	@Test
-	void prefixedDynamoDbTemplate_saveAndScanForParticular_entitySuccessful() {
-		PersonEntity personEntity1 = new PersonEntity(UUID.randomUUID(), "foo", "bar");
-		PersonEntity personEntity2 = new PersonEntity(UUID.randomUUID(), "foo", "bar");
-		prefixedDynamoDbTemplate.save(personEntity1);
-		prefixedDynamoDbTemplate.save(personEntity2);
-		Expression expression = Expression.builder().expression("#uuidToBeLooked = :myValue")
-				.putExpressionName("#uuidToBeLooked", "uuid")
-				.putExpressionValue(":myValue", AttributeValue.builder().s(personEntity1.getUuid().toString()).build())
-				.build();
-		ScanEnhancedRequest scanEnhancedRequest = ScanEnhancedRequest.builder().limit(2).consistentRead(true)
-				.filterExpression(expression).build();
-		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.scan(scanEnhancedRequest, PersonEntity.class);
-		assertThat(persons.items().stream()).hasSize(1);
-		assertThat(persons.items().iterator().next()).isEqualTo(personEntity1);
-		cleanUpPrefixedTable(personEntity1.getUuid());
-		cleanUpPrefixedTable(personEntity2.getUuid());
-	}
-
-	@Test
-	void dynamoDbTemplate_saveAndScanForParticularIndex_entitySuccessful() {
+	@ParameterizedTest
+	@MethodSource("argumentSource")
+	void dynamoDbTemplate_saveAndScanForParticularIndex_entitySuccessful(DynamoDbTable<PersonEntity> dynamoDbTable,
+			DynamoDbTemplate dynamoDbTemplate) {
 		PersonEntity personEntity1 = PersonEntity.Builder.person().withName("foo").withLastName("bar")
 				.withGpk1("my_random_key").withUuid(UUID.randomUUID()).build();
 		PersonEntity personEntity2 = PersonEntity.Builder.person().withName("foo").withLastName("bar")
@@ -454,37 +308,17 @@ public class DynamoDbTemplateIntegrationTest {
 		PageIterable<PersonEntity> persons = dynamoDbTemplate.scan(scanEnhancedRequest, PersonEntity.class, indexName);
 		assertThat(persons.items().stream()).hasSize(1);
 		assertThat(persons.items().iterator().next()).isEqualTo(personEntity1);
-		cleanUp(personEntity1.getUuid());
-		cleanUp(personEntity2.getUuid());
+		cleanUp(dynamoDbTable, personEntity1.getUuid());
+		cleanUp(dynamoDbTable, personEntity2.getUuid());
 	}
 
-	@Test
-	void prefixedDynamoDbTemplate_saveAndScanForParticularIndex_entitySuccessful() {
-		PersonEntity personEntity1 = PersonEntity.Builder.person().withName("foo").withLastName("bar")
-				.withGpk1("my_random_key").withUuid(UUID.randomUUID()).build();
-		PersonEntity personEntity2 = PersonEntity.Builder.person().withName("foo").withLastName("bar")
-				.withGpk1("some_other_key").withUuid(UUID.randomUUID()).build();
-		prefixedDynamoDbTemplate.save(personEntity1);
-		prefixedDynamoDbTemplate.save(personEntity2);
-		Expression expression = Expression.builder().expression("#gsPkToBeLooked = :myValue")
-				.putExpressionName("#gsPkToBeLooked", nameOfGSPK)
-				.putExpressionValue(":myValue", AttributeValue.builder().s(personEntity1.getGsPk()).build()).build();
-		ScanEnhancedRequest scanEnhancedRequest = ScanEnhancedRequest.builder().limit(2).filterExpression(expression)
-				.build();
-		PageIterable<PersonEntity> persons = prefixedDynamoDbTemplate.scan(scanEnhancedRequest, PersonEntity.class,
-				indexName);
-		assertThat(persons.items().stream()).hasSize(1);
-		assertThat(persons.items().iterator().next()).isEqualTo(personEntity1);
-		cleanUpPrefixedTable(personEntity1.getUuid());
-		cleanUpPrefixedTable(personEntity2.getUuid());
-	}
-
-	public static void cleanUp(UUID uuid) {
+	public static void cleanUp(DynamoDbTable<PersonEntity> dynamoDbTable, UUID uuid) {
 		dynamoDbTable.deleteItem(Key.builder().partitionValue(uuid.toString()).build());
 	}
 
-	public static void cleanUpPrefixedTable(UUID uuid) {
-		prefixedDynamoDbTable.deleteItem(Key.builder().partitionValue(uuid.toString()).build());
+	private static java.util.stream.Stream<Arguments> argumentSource() {
+		return java.util.stream.Stream.of(Arguments.of(dynamoDbTable, dynamoDbTemplate),
+				Arguments.of(prefixedDynamoDbTable, prefixedDynamoDbTemplate));
 	}
 
 	private static void describeAndCreateTable(DynamoDbClient dynamoDbClient, @Nullable String tablePrefix) {

--- a/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTemplateIntegrationTest.java
+++ b/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTemplateIntegrationTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.lang.Nullable;
-import org.springframework.mock.env.MockEnvironment;
 import org.springframework.util.StringUtils;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -72,14 +71,12 @@ public class DynamoDbTemplateIntegrationTest {
 				.build();
 		DynamoDbEnhancedClient enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build();
 
-		dynamoDbTemplate = new DynamoDbTemplate(new MockEnvironment(), enhancedClient);
+		dynamoDbTemplate = new DynamoDbTemplate(enhancedClient);
 		dynamoDbTable = DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build().table("person_entity",
 				TableSchema.fromBean(PersonEntity.class));
 		describeAndCreateTable(dynamoDbClient, null);
 
-		prefixedDynamoDbTemplate = new DynamoDbTemplate(
-				new MockEnvironment().withProperty("spring.cloud.aws.dynamodb.table-prefix", "my_prefix_"),
-				enhancedClient);
+		prefixedDynamoDbTemplate = new DynamoDbTemplate("my_prefix_", enhancedClient);
 		prefixedDynamoDbTable = DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build()
 				.table("my_prefix_person_entity", TableSchema.fromBean(PersonEntity.class));
 		describeAndCreateTable(dynamoDbClient, "my_prefix_");


### PR DESCRIPTION
Add option to set DynamoDB table prefix.


## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
A table name prefix can be configured to be used by the default `DynamoDbTableNameResolver`. If specified via the `spring.cloud.aws.dynamodb.table-prefix` property, the table prefix will be prepended to the resolved table name.

For example, if the table prefix is specified as `foo_` and the entity class is named as `Person`, then the resolved table name will be `foo_person`. Since this is an `opt-in` feature, not specifying any table prefix, will resolve the table name as `person` in this example.


## :bulb: Motivation and Context
- Since all DynamoDB tables live in a single namespace, there should be an option to set a prefix to tables.
- This is useful in teh scenario where multiple applications want to use the same _logical_ table name in DynamoDB hence needing a discriminator.


## :green_heart: How did you test it?
- Added unit tests and integration tests.
- Un-prefixed (no table prefix specified) configuration works 
- Prefixed (with table prefix) configuration works

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] I updated reference documentation to reflect the change
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
