### PR TITLE
Use SqsTemplate instead of raw SqsAsyncClient in SQS integration tests

### DIFF
--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsFifoIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsFifoIntegrationTests.java
@@ -37,6 +37,8 @@ import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementOrdering;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementResultCallback;
 import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementHandler;
 import io.awspring.cloud.sqs.listener.acknowledgement.handler.OnSuccessAcknowledgementHandler;
+import io.awspring.cloud.sqs.operations.SendResult;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,7 +50,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -66,12 +67,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.Assert;
 import org.springframework.util.StopWatch;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
-import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
-import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 
 /**
  * Integration tests for handling SQS FIFO queues.
@@ -105,12 +105,14 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 
 	private static final String ERROR_ON_ACK_FACTORY = "errorOnAckFactory";
 
+	private static final String TEST_SQS_TEMPLATE_BEAN_NAME = "testSqsTemplate";
+
 	@Autowired
 	LatchContainer latchContainer;
 
 	@Autowired
-	@Qualifier(TEST_SQS_ASYNC_CLIENT_BEAN_NAME)
-	SqsAsyncClient sqsAsyncClient;
+	@Qualifier(TEST_SQS_TEMPLATE_BEAN_NAME)
+	SqsTemplate sqsTemplate;
 
 	@Autowired
 	ObjectMapper objectMapper;
@@ -176,6 +178,7 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 			loadSimulator.setBound(1000);
 			loadSimulator.setRandom(true);
 		}
+
 	}
 
 	@Test
@@ -184,15 +187,13 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 		String messageGroupId = UUID.randomUUID().toString();
 		List<String> values = IntStream.range(0, this.settings.messagesPerTest).mapToObj(String::valueOf)
 				.collect(toList());
-		String queueUrl = fetchQueueUrl(FIFO_RECEIVES_MESSAGES_IN_ORDER_QUEUE_NAME);
-		sendMessageTo(queueUrl, values, messageGroupId);
+		sendMessageTo(FIFO_RECEIVES_MESSAGES_IN_ORDER_QUEUE_NAME, values, messageGroupId);
 		assertThat(latchContainer.receivesMessageLatch.await(settings.latchTimeoutSeconds, TimeUnit.SECONDS)).isTrue();
 		assertThat(receivesMessageInOrderListener.receivedMessages).containsExactlyElementsOf(values);
 	}
 
 	@Test
 	void receivesMessagesInOrderFromManyMessageGroups() throws Exception {
-		String queueUrl = fetchQueueUrl(FIFO_RECEIVES_MESSAGE_IN_ORDER_MANY_GROUPS_QUEUE_NAME);
 		int messagesPerTest = Math.max(this.settings.messagesPerTest, 30);
 		int numberOfMessageGroups = messagesPerTest / Math.max(this.settings.messagesPerMessageGroup, 10);
 		int messagesPerMessageGroup = Math.max(messagesPerTest / numberOfMessageGroups, 1);
@@ -206,7 +207,7 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 		LoadSimulator loadSimulator = new LoadSimulator().setLoadEnabled(true).setRandom(true).setBound(20);
 		IntStream.range(0, messageGroups.size()).forEach(index -> {
 			if (this.settings.sendMessages) {
-				sendMessageTo(queueUrl, values, messageGroups.get(index));
+				sendMessageTo(FIFO_RECEIVES_MESSAGE_IN_ORDER_MANY_GROUPS_QUEUE_NAME, values, messageGroups.get(index));
 			}
 			if (index % 10 == 0) {
 				loadSimulator.runLoad();
@@ -233,8 +234,7 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 		List<String> values = IntStream.range(0, this.settings.messagesPerTest).mapToObj(String::valueOf)
 				.collect(toList());
 		String messageGroupId = UUID.randomUUID().toString();
-		String queueUrl = fetchQueueUrl(FIFO_STOPS_PROCESSING_ON_ERROR_QUEUE_NAME);
-		sendMessageTo(queueUrl, values, messageGroupId);
+		sendMessageTo(FIFO_STOPS_PROCESSING_ON_ERROR_QUEUE_NAME, values, messageGroupId);
 		assertThat(latchContainer.stopsProcessingOnErrorLatch1.await(settings.latchTimeoutSeconds, TimeUnit.SECONDS))
 				.isTrue();
 		logger.debug("receivedMessagesBeforeException: {}", stopsOnErrorListener.receivedMessagesBeforeException);
@@ -263,8 +263,7 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 		List<String> values = IntStream.range(0, this.settings.messagesPerTest).mapToObj(String::valueOf)
 				.collect(toList());
 		String messageGroupId = UUID.randomUUID().toString();
-		String queueUrl = fetchQueueUrl(FIFO_STOPS_PROCESSING_ON_ACK_ERROR_ERROR_QUEUE_NAME);
-		sendMessageTo(queueUrl, values, messageGroupId);
+		sendMessageTo(FIFO_STOPS_PROCESSING_ON_ACK_ERROR_ERROR_QUEUE_NAME, values, messageGroupId);
 		assertThat(latchContainer.stopsProcessingOnAckErrorLatch1.await(settings.latchTimeoutSeconds, TimeUnit.SECONDS))
 				.isTrue();
 		logger.debug("Messages consumed before error: {}", messagesContainer.stopsProcessingOnAckErrorBeforeThrown);
@@ -289,10 +288,9 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 		String messageGroupId1 = UUID.randomUUID().toString();
 		String messageGroupId2 = UUID.randomUUID().toString();
 		String messageGroupId3 = UUID.randomUUID().toString();
-		String queueUrl = fetchQueueUrl(FIFO_RECEIVES_BATCHES_MANY_GROUPS_QUEUE_NAME);
-		sendMessageTo(queueUrl, values, messageGroupId1);
-		sendMessageTo(queueUrl, values, messageGroupId2);
-		sendMessageTo(queueUrl, values, messageGroupId3);
+		sendMessageTo(FIFO_RECEIVES_BATCHES_MANY_GROUPS_QUEUE_NAME, values, messageGroupId1);
+		sendMessageTo(FIFO_RECEIVES_BATCHES_MANY_GROUPS_QUEUE_NAME, values, messageGroupId2);
+		sendMessageTo(FIFO_RECEIVES_BATCHES_MANY_GROUPS_QUEUE_NAME, values, messageGroupId3);
 		assertThat(latchContainer.receivesBatchManyGroupsLatch.await(settings.latchTimeoutSeconds, TimeUnit.SECONDS))
 				.isTrue();
 		assertThat(receivesBatchesFromManyGroupsListener.receivedMessages.get(messageGroupId1))
@@ -305,10 +303,9 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void manuallyCreatesContainer() throws Exception {
-		String queueUrl = fetchQueueUrl(FIFO_MANUALLY_CREATE_CONTAINER_QUEUE_NAME);
 		List<String> values = IntStream.range(0, this.settings.messagesPerTest).mapToObj(String::valueOf)
 				.collect(toList());
-		sendMessageTo(queueUrl, values, UUID.randomUUID().toString());
+		sendMessageTo(FIFO_MANUALLY_CREATE_CONTAINER_QUEUE_NAME, values, UUID.randomUUID().toString());
 		assertThat(latchContainer.manuallyCreatedContainerLatch.await(settings.latchTimeoutSeconds, TimeUnit.SECONDS))
 				.isTrue();
 		assertThat(messagesContainer.manuallyCreatedContainerMessages).containsExactlyElementsOf(values);
@@ -316,10 +313,9 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void manuallyCreatesBatchContainer() throws Exception {
-		String queueUrl = fetchQueueUrl(FIFO_MANUALLY_CREATE_BATCH_CONTAINER_QUEUE_NAME);
 		List<String> values = IntStream.range(0, this.settings.messagesPerTest).mapToObj(String::valueOf)
 				.collect(toList());
-		sendMessageTo(queueUrl, values, UUID.randomUUID().toString());
+		sendMessageTo(FIFO_MANUALLY_CREATE_BATCH_CONTAINER_QUEUE_NAME, values, UUID.randomUUID().toString());
 		assertThat(
 				latchContainer.manuallyCreatedBatchContainerLatch.await(settings.latchTimeoutSeconds, TimeUnit.SECONDS))
 						.isTrue();
@@ -328,10 +324,9 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void manuallyCreatesFactory() throws Exception {
-		String queueUrl = fetchQueueUrl(FIFO_MANUALLY_CREATE_FACTORY_QUEUE_NAME);
 		List<String> values = IntStream.range(0, this.settings.messagesPerTest).mapToObj(String::valueOf)
 				.collect(toList());
-		sendMessageTo(queueUrl, values, UUID.randomUUID().toString());
+		sendMessageTo(FIFO_MANUALLY_CREATE_FACTORY_QUEUE_NAME, values, UUID.randomUUID().toString());
 		assertThat(latchContainer.manuallyCreatedFactoryLatch.await(settings.latchTimeoutSeconds, TimeUnit.SECONDS))
 				.isTrue();
 		assertThat(messagesContainer.manuallyCreatedFactoryMessages).containsExactlyElementsOf(values);
@@ -339,10 +334,9 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void manuallyCreatesBatchFactory() throws Exception {
-		String queueUrl = fetchQueueUrl(FIFO_MANUALLY_CREATE_BATCH_FACTORY_QUEUE_NAME);
 		List<String> values = IntStream.range(0, this.settings.messagesPerTest).mapToObj(String::valueOf)
 				.collect(toList());
-		sendMessageTo(queueUrl, values, UUID.randomUUID().toString());
+		sendMessageTo(FIFO_MANUALLY_CREATE_BATCH_FACTORY_QUEUE_NAME, values, UUID.randomUUID().toString());
 		assertThat(
 				latchContainer.manuallyCreatedBatchFactoryLatch.await(settings.latchTimeoutSeconds, TimeUnit.SECONDS))
 						.isTrue();
@@ -466,6 +460,7 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 			messages.forEach(msg -> latchContainer.receivesBatchManyGroupsLatch.countDown());
 			logger.trace("Finished processing messages {} for group id {}", values, messageGroupId);
 		}
+
 	}
 
 	private void sendMessageTo(String queueUrl, List<String> messageBodies, String messageGroupId) {
@@ -483,40 +478,40 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 		}
 	}
 
-	private CompletableFuture<Void> sendManyTo(String queueUrl, List<String> messageBodies, String messageGroupId) {
+	private CompletableFuture<Void> sendManyTo(String queueName, List<String> messageBodies, String messageGroupId) {
 		return IntStream.range(0, (int) Math.ceil(messageBodies.size() / 10.))
 				.mapToObj(index -> messageBodies.subList(index * 10, Math.min((index + 1) * 10, messageBodies.size())))
 				.reduce(CompletableFuture.completedFuture(null), (previousFuture, messages) -> previousFuture
-						.thenCompose(theVoid -> doSendMessageTo(queueUrl, messages, messageGroupId).thenRun(() -> {
+						.thenCompose(theVoid -> doSendMessageTo(queueName, messages, messageGroupId).thenRun(() -> {
 						})), (a, b) -> a);
 	}
 
 	AtomicInteger messagesSent = new AtomicInteger();
 
-	private CompletableFuture<SendMessageBatchResponse> doSendMessageTo(String queueUrl, List<String> messageBodies,
+	private CompletableFuture<SendResult.Batch<String>> doSendMessageTo(String queueName, List<String> messageBodies,
 			String messageGroupId) {
-		return sqsAsyncClient.sendMessageBatch(req -> req
-				.entries(messageBodies.stream().map(body -> createEntry(body, messageGroupId)).collect(toList()))
-				.queueUrl(queueUrl).build()).whenComplete((v, t) -> {
+		return sqsTemplate
+				.sendManyAsync(queueName,
+						messageBodies.stream().map(payload -> createMessage(payload, messageGroupId)).collect(toList()))
+				.whenComplete((v, t) -> {
 					if (t != null) {
 						logger.error("Error sending messages", t);
 					}
 					else {
 						int sent = messagesSent.addAndGet(messageBodies.size());
 						if (sent % 1000 == 0) {
-							logger.debug("Sent {} messages to queue {}", sent, queueUrl);
+							logger.debug("Sent {} messages to queue {}", sent, queueName);
 						}
 					}
 				});
 	}
 
-	private SendMessageBatchRequestEntry createEntry(String body, String messageGroupId) {
-		return SendMessageBatchRequestEntry.builder().messageBody(body).id(UUID.randomUUID().toString())
-				.messageGroupId(messageGroupId).messageDeduplicationId(UUID.randomUUID().toString()).build();
-	}
-
-	private String fetchQueueUrl(String receivesMessageQueueName) throws InterruptedException, ExecutionException {
-		return this.sqsAsyncClient.getQueueUrl(req -> req.queueName(receivesMessageQueueName)).get().queueUrl();
+	private Message<String> createMessage(String body, String messageGroupId) {
+		return MessageBuilder.withPayload(body)
+				.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId)
+				.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER,
+						UUID.randomUUID().toString())
+				.build();
 	}
 
 	static class LatchContainer {
@@ -802,6 +797,11 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 		@Bean(name = TEST_SQS_ASYNC_CLIENT_BEAN_NAME)
 		SqsAsyncClient sqsAsyncClientProducer() {
 			return BaseSqsIntegrationTest.createHighThroughputAsyncClient();
+		}
+
+		@Bean(name = TEST_SQS_TEMPLATE_BEAN_NAME)
+		SqsTemplate sqsTemplate(SqsAsyncClient sqsAsyncClient) {
+			return SqsTemplate.builder().sqsAsyncClient(sqsAsyncClient).build();
 		}
 
 	}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsFifoIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsFifoIntegrationTests.java
@@ -463,17 +463,17 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 
 	}
 
-	private void sendMessageTo(String queueUrl, List<String> messageBodies, String messageGroupId) {
+	private void sendMessageTo(String queueName, List<String> messageBodies, String messageGroupId) {
 		try {
 			if (useLocalStackClient) {
-				sendManyTo(queueUrl, messageBodies, messageGroupId).join();
+				sendManyTo(queueName, messageBodies, messageGroupId).join();
 			}
 			else {
-				sendManyTo(queueUrl, messageBodies, messageGroupId);
+				sendManyTo(queueName, messageBodies, messageGroupId);
 			}
 		}
 		catch (Exception e) {
-			logger.error("Error sending messages to queue {}", queueUrl, e);
+			logger.error("Error sending messages to queue {}", queueName, e);
 			throw (RuntimeException) e;
 		}
 	}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
@@ -158,7 +158,9 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void receivesMessage() throws Exception {
-		sendMessageTo(RECEIVES_MESSAGE_QUEUE_NAME, "receivesMessage-payload");
+		String messageBody = "receivesMessage-payload";
+		sqsTemplate.sendAsync(RECEIVES_MESSAGE_QUEUE_NAME, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}", RECEIVES_MESSAGE_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.receivesMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.invocableHandlerMethodLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.acknowledgementCallbackSuccessLatch.await(10, TimeUnit.SECONDS)).isTrue();
@@ -166,56 +168,74 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void receivesMessageBatch() throws Exception {
-		sendMessageTo(RECEIVES_MESSAGE_BATCH_QUEUE_NAME, "receivesMessageBatch-payload");
+		String messageBody = "receivesMessageBatch-payload";
+		sqsTemplate.sendAsync(RECEIVES_MESSAGE_BATCH_QUEUE_NAME, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}", RECEIVES_MESSAGE_BATCH_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.receivesMessageBatchLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.acknowledgementCallbackBatchLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
 	void receivesMessageAsync() throws Exception {
-		sendMessageTo(RECEIVES_MESSAGE_ASYNC_QUEUE_NAME, "receivesMessageAsync-payload");
+		String messageBody = "receivesMessageAsync-payload";
+		sqsTemplate.sendAsync(RECEIVES_MESSAGE_ASYNC_QUEUE_NAME, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}", RECEIVES_MESSAGE_ASYNC_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.receivesMessageAsyncLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
 	void doesNotAckOnError() throws Exception {
-		sendMessageTo(DOES_NOT_ACK_ON_ERROR_QUEUE_NAME, "doesNotAckOnError-payload");
+		String messageBody = "doesNotAckOnError-payload";
+		sqsTemplate.sendAsync(DOES_NOT_ACK_ON_ERROR_QUEUE_NAME, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}", DOES_NOT_ACK_ON_ERROR_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.doesNotAckLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.acknowledgementCallbackErrorLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
 	void doesNotAckOnErrorAsync() throws Exception {
-		sendMessageTo(DOES_NOT_ACK_ON_ERROR_ASYNC_QUEUE_NAME, "doesNotAckOnErrorAsync-payload");
+		String messageBody = "doesNotAckOnErrorAsync-payload";
+		sqsTemplate.sendAsync(DOES_NOT_ACK_ON_ERROR_ASYNC_QUEUE_NAME, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}", DOES_NOT_ACK_ON_ERROR_ASYNC_QUEUE_NAME,
+				messageBody);
 		assertThat(latchContainer.doesNotAckAsyncLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
 	void doesNotAckOnErrorBatch() throws Exception {
-		List<String> values = IntStream.range(0, 10).mapToObj(index -> "doesNotAckOnErrorBatch-payload-" + index)
-				.collect(Collectors.toList());
-		sendMessageBatch(DOES_NOT_ACK_ON_ERROR_BATCH_QUEUE_NAME, values);
+		List<Message<String>> messages = IntStream.range(0, 10)
+				.mapToObj(index -> "doesNotAckOnErrorBatch-payload-" + index)
+				.map(payload -> MessageBuilder.withPayload(payload).build()).collect(Collectors.toList());
+		sqsTemplate.sendManyAsync(DOES_NOT_ACK_ON_ERROR_BATCH_QUEUE_NAME, messages);
+		logger.debug("Sent messages to queue {} with messages {}", DOES_NOT_ACK_ON_ERROR_BATCH_QUEUE_NAME, messages);
 		assertThat(latchContainer.doesNotAckBatchLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
 	void doesNotAckOnErrorBatchAsync() throws Exception {
-		List<String> values = IntStream.range(0, 10).mapToObj(index -> "doesNotAckOnErrorBatchAsync-payload-" + index)
-				.collect(Collectors.toList());
-		sendMessageBatch(DOES_NOT_ACK_ON_ERROR_BATCH_ASYNC_QUEUE_NAME, values);
+		List<Message<String>> messages = IntStream.range(0, 10)
+				.mapToObj(index -> "doesNotAckOnErrorBatchAsync-payload-" + index)
+				.map(payload -> MessageBuilder.withPayload(payload).build()).collect(Collectors.toList());
+		sqsTemplate.sendManyAsync(DOES_NOT_ACK_ON_ERROR_BATCH_ASYNC_QUEUE_NAME, messages);
+		logger.debug("Sent messages to queue {} with messages {}", DOES_NOT_ACK_ON_ERROR_BATCH_ASYNC_QUEUE_NAME,
+				messages);
 		assertThat(latchContainer.doesNotAckBatchAsyncLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
 	void resolvesManyParameterTypes() throws Exception {
-		sendMessageTo(RESOLVES_PARAMETER_TYPES_QUEUE_NAME, "many-parameter-types-payload");
+		String messageBody = "many-parameter-types-payload";
+		sqsTemplate.sendAsync(RESOLVES_PARAMETER_TYPES_QUEUE_NAME, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_PARAMETER_TYPES_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.manyParameterTypesLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.manyParameterTypesSecondLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
 	void manuallyCreatesContainer() throws Exception {
-		sendMessageTo(MANUALLY_CREATE_CONTAINER_QUEUE_NAME, "Testing manually creates container");
+		String messageBody = "Testing manually creates container";
+		sqsTemplate.sendAsync(MANUALLY_CREATE_CONTAINER_QUEUE_NAME, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}", MANUALLY_CREATE_CONTAINER_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.manuallyCreatedContainerLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
@@ -232,7 +252,9 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 					.pollTimeout(Duration.ofSeconds(3)))
 			.build();
 		container.start();
-		sendMessageTo(MANUALLY_START_CONTAINER, "MyTest");
+		String messageBody1 = "MyTest";
+		sqsTemplate.sendAsync(MANUALLY_START_CONTAINER, messageBody1);
+		logger.debug("Sent message to queue {} with messageBody {}", MANUALLY_START_CONTAINER, messageBody1);
 		assertThat(latchContainer.manuallyStartedContainerLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		container.stop();
 		container.setMessageListener(msg -> latchContainer.manuallyStartedContainerLatch2.countDown());
@@ -240,7 +262,9 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		builder.acknowledgementMode(AcknowledgementMode.ALWAYS);
 		container.configure(options -> options.fromBuilder(builder));
 		container.start();
-		sendMessageTo(MANUALLY_START_CONTAINER, "MyTest2");
+		String messageBody2 = "MyTest2";
+		sqsTemplate.sendAsync(MANUALLY_START_CONTAINER, messageBody2);
+		logger.debug("Sent message to queue {} with messageBody {}", MANUALLY_START_CONTAINER, messageBody2);
 		assertThat(latchContainer.manuallyStartedContainerLatch2.await(10, TimeUnit.SECONDS)).isTrue();
 		container.stop();
 	}
@@ -248,21 +272,12 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void manuallyCreatesFactory() throws Exception {
-		sendMessageTo(MANUALLY_CREATE_FACTORY_QUEUE_NAME, "Testing manually creates factory");
+		String messageBody = "Testing manually creates factory";
+		sqsTemplate.sendAsync(MANUALLY_CREATE_FACTORY_QUEUE_NAME, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}", MANUALLY_CREATE_FACTORY_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.manuallyCreatedFactoryLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.manuallyCreatedFactorySourceFactoryLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.manuallyCreatedFactorySinkLatch.await(10, TimeUnit.SECONDS)).isTrue();
-	}
-
-	private void sendMessageTo(String queueName, String messageBody) {
-		sqsTemplate.sendAsync(queueName, messageBody);
-		logger.debug("Sent message to queue {} with messageBody {}", queueName, messageBody);
-	}
-
-	private void sendMessageBatch(String queueName, Collection<String> messageBodies) {
-		sqsTemplate.sendManyAsync(queueName, messageBodies.stream()
-				.map(payload -> MessageBuilder.withPayload(payload).build()).collect(Collectors.toList()));
-		logger.debug("Sent messages to queue {} with messageBodies {}", queueName, messageBodies);
 	}
 
 	static class ReceivesMessageListener {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
@@ -159,7 +159,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void receivesMessage() throws Exception {
 		String messageBody = "receivesMessage-payload";
-		sqsTemplate.sendAsync(RECEIVES_MESSAGE_QUEUE_NAME, messageBody);
+		sqsTemplate.send(RECEIVES_MESSAGE_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", RECEIVES_MESSAGE_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.receivesMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.invocableHandlerMethodLatch.await(10, TimeUnit.SECONDS)).isTrue();
@@ -169,7 +169,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void receivesMessageBatch() throws Exception {
 		String messageBody = "receivesMessageBatch-payload";
-		sqsTemplate.sendAsync(RECEIVES_MESSAGE_BATCH_QUEUE_NAME, messageBody);
+		sqsTemplate.send(RECEIVES_MESSAGE_BATCH_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", RECEIVES_MESSAGE_BATCH_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.receivesMessageBatchLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.acknowledgementCallbackBatchLatch.await(10, TimeUnit.SECONDS)).isTrue();
@@ -178,7 +178,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void receivesMessageAsync() throws Exception {
 		String messageBody = "receivesMessageAsync-payload";
-		sqsTemplate.sendAsync(RECEIVES_MESSAGE_ASYNC_QUEUE_NAME, messageBody);
+		sqsTemplate.send(RECEIVES_MESSAGE_ASYNC_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", RECEIVES_MESSAGE_ASYNC_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.receivesMessageAsyncLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
@@ -186,7 +186,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void doesNotAckOnError() throws Exception {
 		String messageBody = "doesNotAckOnError-payload";
-		sqsTemplate.sendAsync(DOES_NOT_ACK_ON_ERROR_QUEUE_NAME, messageBody);
+		sqsTemplate.send(DOES_NOT_ACK_ON_ERROR_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", DOES_NOT_ACK_ON_ERROR_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.doesNotAckLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.acknowledgementCallbackErrorLatch.await(10, TimeUnit.SECONDS)).isTrue();
@@ -195,7 +195,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void doesNotAckOnErrorAsync() throws Exception {
 		String messageBody = "doesNotAckOnErrorAsync-payload";
-		sqsTemplate.sendAsync(DOES_NOT_ACK_ON_ERROR_ASYNC_QUEUE_NAME, messageBody);
+		sqsTemplate.send(DOES_NOT_ACK_ON_ERROR_ASYNC_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", DOES_NOT_ACK_ON_ERROR_ASYNC_QUEUE_NAME,
 				messageBody);
 		assertThat(latchContainer.doesNotAckAsyncLatch.await(10, TimeUnit.SECONDS)).isTrue();
@@ -225,7 +225,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void resolvesManyParameterTypes() throws Exception {
 		String messageBody = "many-parameter-types-payload";
-		sqsTemplate.sendAsync(RESOLVES_PARAMETER_TYPES_QUEUE_NAME, messageBody);
+		sqsTemplate.send(RESOLVES_PARAMETER_TYPES_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_PARAMETER_TYPES_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.manyParameterTypesLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.manyParameterTypesSecondLatch.await(10, TimeUnit.SECONDS)).isTrue();
@@ -234,7 +234,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void manuallyCreatesContainer() throws Exception {
 		String messageBody = "Testing manually creates container";
-		sqsTemplate.sendAsync(MANUALLY_CREATE_CONTAINER_QUEUE_NAME, messageBody);
+		sqsTemplate.send(MANUALLY_CREATE_CONTAINER_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", MANUALLY_CREATE_CONTAINER_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.manuallyCreatedContainerLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
@@ -253,7 +253,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 			.build();
 		container.start();
 		String messageBody1 = "MyTest";
-		sqsTemplate.sendAsync(MANUALLY_START_CONTAINER, messageBody1);
+		sqsTemplate.send(MANUALLY_START_CONTAINER, messageBody1);
 		logger.debug("Sent message to queue {} with messageBody {}", MANUALLY_START_CONTAINER, messageBody1);
 		assertThat(latchContainer.manuallyStartedContainerLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		container.stop();
@@ -263,7 +263,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		container.configure(options -> options.fromBuilder(builder));
 		container.start();
 		String messageBody2 = "MyTest2";
-		sqsTemplate.sendAsync(MANUALLY_START_CONTAINER, messageBody2);
+		sqsTemplate.send(MANUALLY_START_CONTAINER, messageBody2);
 		logger.debug("Sent message to queue {} with messageBody {}", MANUALLY_START_CONTAINER, messageBody2);
 		assertThat(latchContainer.manuallyStartedContainerLatch2.await(10, TimeUnit.SECONDS)).isTrue();
 		container.stop();
@@ -273,7 +273,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void manuallyCreatesFactory() throws Exception {
 		String messageBody = "Testing manually creates factory";
-		sqsTemplate.sendAsync(MANUALLY_CREATE_FACTORY_QUEUE_NAME, messageBody);
+		sqsTemplate.send(MANUALLY_CREATE_FACTORY_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", MANUALLY_CREATE_FACTORY_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.manuallyCreatedFactoryLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.manuallyCreatedFactorySourceFactoryLatch.await(10, TimeUnit.SECONDS)).isTrue();

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsInterceptorIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsInterceptorIntegrationTests.java
@@ -97,7 +97,7 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void shouldReceiveChangedMessageOnComponents() throws Exception {
-		sqsTemplate.sendAsync(RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME, SHOULD_CHANGE_PAYLOAD);
+		sqsTemplate.send(RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME, SHOULD_CHANGE_PAYLOAD);
 		logger.debug("Sent message to queue {} with messageBody {}", RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME,
 				SHOULD_CHANGE_PAYLOAD);
 		assertThat(latchContainer.receivesChangedMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
@@ -106,7 +106,7 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void shouldReceiveChangedMessageOnComponentsWhenError() throws Exception {
-		sqsTemplate.sendAsync(RECEIVES_CHANGED_MESSAGE_ON_ERROR_QUEUE_NAME, SHOULD_CHANGE_PAYLOAD);
+		sqsTemplate.send(RECEIVES_CHANGED_MESSAGE_ON_ERROR_QUEUE_NAME, SHOULD_CHANGE_PAYLOAD);
 		logger.debug("Sent message to queue {} with messageBody {}", RECEIVES_CHANGED_MESSAGE_ON_ERROR_QUEUE_NAME,
 				SHOULD_CHANGE_PAYLOAD);
 		assertThat(latchContainer.receivesChangedMessageOnErrorLatch.await(10, TimeUnit.SECONDS)).isTrue();

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsInterceptorIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsInterceptorIntegrationTests.java
@@ -37,7 +37,6 @@ import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -98,20 +97,19 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void shouldReceiveChangedMessageOnComponents() throws Exception {
-		sendMessageTo(RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME, SHOULD_CHANGE_PAYLOAD);
+		sqsTemplate.sendAsync(RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME, SHOULD_CHANGE_PAYLOAD);
+		logger.debug("Sent message to queue {} with messageBody {}", RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME,
+				SHOULD_CHANGE_PAYLOAD);
 		assertThat(latchContainer.receivesChangedMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(receivesChangedPayloadListener.receivedMessages).containsExactly(CHANGED_PAYLOAD);
 	}
 
 	@Test
 	void shouldReceiveChangedMessageOnComponentsWhenError() throws Exception {
-		sendMessageTo(RECEIVES_CHANGED_MESSAGE_ON_ERROR_QUEUE_NAME, SHOULD_CHANGE_PAYLOAD);
+		sqsTemplate.sendAsync(RECEIVES_CHANGED_MESSAGE_ON_ERROR_QUEUE_NAME, SHOULD_CHANGE_PAYLOAD);
+		logger.debug("Sent message to queue {} with messageBody {}", RECEIVES_CHANGED_MESSAGE_ON_ERROR_QUEUE_NAME,
+				SHOULD_CHANGE_PAYLOAD);
 		assertThat(latchContainer.receivesChangedMessageOnErrorLatch.await(10, TimeUnit.SECONDS)).isTrue();
-	}
-
-	private void sendMessageTo(String queueName, String messageBody) throws InterruptedException, ExecutionException {
-		sqsTemplate.sendAsync(queueName, messageBody);
-		logger.debug("Sent message to queue {} with messageBody {}", queueName, messageBody);
 	}
 
 	static class ReceivesChangedPayloadListener {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsLoadIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsLoadIntegrationTests.java
@@ -32,12 +32,12 @@ import io.awspring.cloud.sqs.listener.StandardSqsComponentFactory;
 import io.awspring.cloud.sqs.listener.acknowledgement.SqsAcknowledgementExecutor;
 import io.awspring.cloud.sqs.listener.source.AbstractSqsMessageSource;
 import io.awspring.cloud.sqs.listener.source.MessageSource;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -57,11 +57,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.Assert;
 import org.springframework.util.StopWatch;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
-import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
 
 /**
  * Load test for SQS integration.
@@ -83,14 +83,16 @@ class SqsLoadIntegrationTests extends BaseSqsIntegrationTest {
 
 	private static final String TEST_SQS_ASYNC_CLIENT_BEAN_NAME = "testSqsAsyncClient";
 
+	private static final String TEST_SQS_TEMPLATE_BEAN_NAME = "testSqsTemplate";
+
 	private static final String HIGH_THROUGHPUT_FACTORY_NAME = "highThroughputFactory";
 
 	@Autowired
 	LatchContainer latchContainer;
 
 	@Autowired
-	@Qualifier(TEST_SQS_ASYNC_CLIENT_BEAN_NAME)
-	SqsAsyncClient sqsAsyncClient;
+	@Qualifier(TEST_SQS_TEMPLATE_BEAN_NAME)
+	SqsTemplate sqsTemplate;
 
 	@Autowired
 	ObjectMapper objectMapper;
@@ -164,16 +166,14 @@ class SqsLoadIntegrationTests extends BaseSqsIntegrationTest {
 			CountDownLatch listenerLatch, CountDownLatch acknowledgementLatch)
 			throws InterruptedException, ExecutionException {
 		Assert.isTrue(settings.totalMessages >= 20, "Minimum of 20 messages");
-		String queueUrl1 = fetchQueueUrl(queue1);
-		String queueUrl2 = fetchQueueUrl(queue2);
 		LoadSimulator sendLoadSimulator = new LoadSimulator();
 		sendLoadSimulator.setLoadEnabled(settings.totalMessages > 1000);
 		logger.debug("Starting watch");
 		StopWatch watch = new StopWatch();
 		watch.start();
 		IntStream.range(0, Math.max(settings.totalMessages / 20, 1)).forEach(index -> {
-			sendMessageBatchAsync(queueUrl1);
-			sendMessageBatchAsync(queueUrl2);
+			sendMessageBatchAsync(queue1);
+			sendMessageBatchAsync(queue2);
 			if (index % 20 == 0) {
 				sendLoadSimulator.runLoad(50);
 			}
@@ -203,21 +203,20 @@ class SqsLoadIntegrationTests extends BaseSqsIntegrationTest {
 
 	AtomicInteger bodyInteger = new AtomicInteger();
 
-	private void sendMessageBatchAsync(String queueUrl) {
+	private void sendMessageBatchAsync(String queueName) {
 		if (!settings.sendMessages) {
 			return;
 		}
-		Collection<SendMessageBatchRequestEntry> batchEntries = getBatchEntries();
-		doSendMessageBatch(queueUrl, batchEntries);
+		Collection<Message<String>> messages = getMessages();
+		doSendMessageBatch(queueName, messages);
 	}
 
-	private void doSendMessageBatch(String queueUrl, Collection<SendMessageBatchRequestEntry> batchEntries) {
-		sqsAsyncClient.sendMessageBatch(req -> req.entries(batchEntries).queueUrl(queueUrl).build())
-				.thenRun(this::logSend).exceptionally(t -> {
-					logger.error("Error sending messages - retrying", t);
-					doSendMessageBatch(queueUrl, batchEntries);
-					return null;
-				});
+	private void doSendMessageBatch(String queueName, Collection<Message<String>> messages) {
+		sqsTemplate.sendManyAsync(queueName, messages).thenRun(this::logSend).exceptionally(t -> {
+			logger.error("Error sending messages - retrying", t);
+			doSendMessageBatch(queueName, messages);
+			return null;
+		});
 	}
 
 	private void logSend() {
@@ -227,11 +226,11 @@ class SqsLoadIntegrationTests extends BaseSqsIntegrationTest {
 		}
 	}
 
-	private Collection<SendMessageBatchRequestEntry> getBatchEntries() {
+	private Collection<Message<String>> getMessages() {
 		return IntStream.range(0, Math.min(settings.totalMessages / 2, 10)).mapToObj(index -> {
-			String id = UUID.randomUUID().toString();
-			logger.trace("Sending message with id {}", id);
-			return SendMessageBatchRequestEntry.builder().id(id).messageBody(getBody()).build();
+			Message<String> message = MessageBuilder.withPayload(getBody()).build();
+			logger.trace("Sending message with id {}", message.getHeaders().get("id"));
+			return message;
 		}).collect(Collectors.toList());
 	}
 
@@ -243,10 +242,6 @@ class SqsLoadIntegrationTests extends BaseSqsIntegrationTest {
 		catch (JsonProcessingException e) {
 			throw new RuntimeException(e);
 		}
-	}
-
-	private String fetchQueueUrl(String receivesMessageQueueName) throws InterruptedException, ExecutionException {
-		return sqsAsyncClient.getQueueUrl(req -> req.queueName(receivesMessageQueueName)).get().queueUrl();
 	}
 
 	static class MessageContainer {
@@ -407,6 +402,11 @@ class SqsLoadIntegrationTests extends BaseSqsIntegrationTest {
 		@Bean(name = TEST_SQS_ASYNC_CLIENT_BEAN_NAME)
 		SqsAsyncClient sqsAsyncClientProducer() {
 			return BaseSqsIntegrationTest.createHighThroughputAsyncClient();
+		}
+
+		@Bean(name = TEST_SQS_TEMPLATE_BEAN_NAME)
+		SqsTemplate sqsTemplate(SqsAsyncClient sqsAsyncClient) {
+			return SqsTemplate.builder().sqsAsyncClient(sqsAsyncClient).build();
 		}
 
 		private final AtomicInteger acks = new AtomicInteger();

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
@@ -91,7 +91,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void resolvesPojoParameterTypes() throws Exception {
 		String messageBody = objectMapper.writeValueAsString(new MyPojo("pojoParameterType", "secondValue"));
-		sqsTemplate.sendAsync(RESOLVES_POJO_TYPES_QUEUE_NAME, messageBody);
+		sqsTemplate.send(RESOLVES_POJO_TYPES_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_TYPES_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.resolvesPojoLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
@@ -99,7 +99,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void resolvesPojoMessage() throws Exception {
 		String messageBody = objectMapper.writeValueAsString(new MyPojo("resolvesPojoMessage", "secondValue"));
-		sqsTemplate.sendAsync(RESOLVES_POJO_MESSAGE_QUEUE_NAME, messageBody);
+		sqsTemplate.send(RESOLVES_POJO_MESSAGE_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_MESSAGE_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.resolvesPojoMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
@@ -107,7 +107,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void resolvesPojoList() throws Exception {
 		String messageBody = objectMapper.writeValueAsString(new MyPojo("resolvesPojoList", "secondValue"));
-		sqsTemplate.sendAsync(RESOLVES_POJO_LIST_QUEUE_NAME, messageBody);
+		sqsTemplate.send(RESOLVES_POJO_LIST_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_LIST_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.resolvesPojoListLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
@@ -115,7 +115,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void resolvesPojoMessageList() throws Exception {
 		String messageBody = objectMapper.writeValueAsString(new MyPojo("resolvesPojoMessageList", "secondValue"));
-		sqsTemplate.sendAsync(RESOLVES_POJO_MESSAGE_LIST_QUEUE_NAME, messageBody);
+		sqsTemplate.send(RESOLVES_POJO_MESSAGE_LIST_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_MESSAGE_LIST_QUEUE_NAME,
 				messageBody);
 		assertThat(latchContainer.resolvesPojoMessageListLatch.await(10, TimeUnit.SECONDS)).isTrue();
@@ -124,7 +124,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void resolvesPojoFromHeader() throws Exception {
 		String messageBody = objectMapper.writeValueAsString(new MyPojo("pojoParameterType", "secondValue"));
-		sqsTemplate.sendAsync(RESOLVES_POJO_FROM_HEADER_QUEUE_NAME,
+		sqsTemplate.send(RESOLVES_POJO_FROM_HEADER_QUEUE_NAME,
 				MessageBuilder.createMessage(messageBody, new MessagingMessageHeaders(getHeaderMapping(MyPojo.class))));
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_FROM_HEADER_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.resolvesPojoFromMappingLatch.await(10, TimeUnit.SECONDS)).isTrue();
@@ -133,7 +133,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void resolvesMyOtherPojoFromHeader() throws Exception {
 		String messageBody = objectMapper.writeValueAsString(new MyOtherPojo("pojoParameterType", "secondValue"));
-		sqsTemplate.sendAsync(RESOLVES_MY_OTHER_POJO_FROM_HEADER_QUEUE_NAME, MessageBuilder.createMessage(messageBody,
+		sqsTemplate.send(RESOLVES_MY_OTHER_POJO_FROM_HEADER_QUEUE_NAME, MessageBuilder.createMessage(messageBody,
 				new MessagingMessageHeaders(getHeaderMapping(MyOtherPojo.class))));
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_MY_OTHER_POJO_FROM_HEADER_QUEUE_NAME,
 				messageBody);

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
@@ -332,20 +332,6 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 
 	}
 
-	// private void sendMessageTo(String queueName, Object messageBody) throws JsonProcessingException {
-	// String payload = objectMapper.writeValueAsString(messageBody);
-	// sqsTemplate.sendAsync(queueName, payload);
-	// logger.debug("Sent message to queue {} with messageBody {}", queueName, messageBody);
-	// }
-
-	// private void sendMessageTo(String queueName, Object messageBody, Map<String, Object> messageAttributes)
-	// throws JsonProcessingException {
-	// String payload = objectMapper.writeValueAsString(messageBody);
-	// sqsTemplate.sendAsync(queueName,
-	// MessageBuilder.createMessage(payload, new MessagingMessageHeaders(messageAttributes)));
-	// logger.debug("Sent message to queue {} with messageBody {}", queueName, messageBody);
-	// }
-
 	static class MyPojo implements MyInterface {
 
 		String firstField;

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
@@ -17,7 +17,6 @@ package io.awspring.cloud.sqs.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.sqs.annotation.SqsListener;
 import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration;
@@ -91,39 +90,53 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Test
 	void resolvesPojoParameterTypes() throws Exception {
-		sendMessageTo(RESOLVES_POJO_TYPES_QUEUE_NAME, new MyPojo("pojoParameterType", "secondValue"));
+		String messageBody = objectMapper.writeValueAsString(new MyPojo("pojoParameterType", "secondValue"));
+		sqsTemplate.sendAsync(RESOLVES_POJO_TYPES_QUEUE_NAME, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_TYPES_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.resolvesPojoLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
 	void resolvesPojoMessage() throws Exception {
-		sendMessageTo(RESOLVES_POJO_MESSAGE_QUEUE_NAME, new MyPojo("resolvesPojoMessage", "secondValue"));
+		String messageBody = objectMapper.writeValueAsString(new MyPojo("resolvesPojoMessage", "secondValue"));
+		sqsTemplate.sendAsync(RESOLVES_POJO_MESSAGE_QUEUE_NAME, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_MESSAGE_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.resolvesPojoMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
 	void resolvesPojoList() throws Exception {
-		sendMessageTo(RESOLVES_POJO_LIST_QUEUE_NAME, new MyPojo("resolvesPojoList", "secondValue"));
+		String messageBody = objectMapper.writeValueAsString(new MyPojo("resolvesPojoList", "secondValue"));
+		sqsTemplate.sendAsync(RESOLVES_POJO_LIST_QUEUE_NAME, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_LIST_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.resolvesPojoListLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
 	void resolvesPojoMessageList() throws Exception {
-		sendMessageTo(RESOLVES_POJO_MESSAGE_LIST_QUEUE_NAME, new MyPojo("resolvesPojoMessageList", "secondValue"));
+		String messageBody = objectMapper.writeValueAsString(new MyPojo("resolvesPojoMessageList", "secondValue"));
+		sqsTemplate.sendAsync(RESOLVES_POJO_MESSAGE_LIST_QUEUE_NAME, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_MESSAGE_LIST_QUEUE_NAME,
+				messageBody);
 		assertThat(latchContainer.resolvesPojoMessageListLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
 	void resolvesPojoFromHeader() throws Exception {
-		sendMessageTo(RESOLVES_POJO_FROM_HEADER_QUEUE_NAME, new MyPojo("pojoParameterType", "secondValue"),
-				getHeaderMapping(MyPojo.class));
+		String messageBody = objectMapper.writeValueAsString(new MyPojo("pojoParameterType", "secondValue"));
+		sqsTemplate.sendAsync(RESOLVES_POJO_FROM_HEADER_QUEUE_NAME,
+				MessageBuilder.createMessage(messageBody, new MessagingMessageHeaders(getHeaderMapping(MyPojo.class))));
+		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_FROM_HEADER_QUEUE_NAME, messageBody);
 		assertThat(latchContainer.resolvesPojoFromMappingLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
 	void resolvesMyOtherPojoFromHeader() throws Exception {
-		sendMessageTo(RESOLVES_MY_OTHER_POJO_FROM_HEADER_QUEUE_NAME,
-				new MyOtherPojo("pojoParameterType", "secondValue"), getHeaderMapping(MyOtherPojo.class));
+		String messageBody = objectMapper.writeValueAsString(new MyOtherPojo("pojoParameterType", "secondValue"));
+		sqsTemplate.sendAsync(RESOLVES_MY_OTHER_POJO_FROM_HEADER_QUEUE_NAME, MessageBuilder.createMessage(messageBody,
+				new MessagingMessageHeaders(getHeaderMapping(MyOtherPojo.class))));
+		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_MY_OTHER_POJO_FROM_HEADER_QUEUE_NAME,
+				messageBody);
 		assertThat(latchContainer.resolvesMyOtherPojoFromMappingLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
@@ -319,19 +332,19 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 
 	}
 
-	private void sendMessageTo(String queueName, Object messageBody) throws JsonProcessingException {
-		String payload = objectMapper.writeValueAsString(messageBody);
-		sqsTemplate.sendAsync(queueName, payload);
-		logger.debug("Sent message to queue {} with messageBody {}", queueName, messageBody);
-	}
+	// private void sendMessageTo(String queueName, Object messageBody) throws JsonProcessingException {
+	// String payload = objectMapper.writeValueAsString(messageBody);
+	// sqsTemplate.sendAsync(queueName, payload);
+	// logger.debug("Sent message to queue {} with messageBody {}", queueName, messageBody);
+	// }
 
-	private void sendMessageTo(String queueName, Object messageBody, Map<String, Object> messageAttributes)
-			throws JsonProcessingException {
-		String payload = objectMapper.writeValueAsString(messageBody);
-		sqsTemplate.sendAsync(queueName,
-				MessageBuilder.createMessage(payload, new MessagingMessageHeaders(messageAttributes)));
-		logger.debug("Sent message to queue {} with messageBody {}", queueName, messageBody);
-	}
+	// private void sendMessageTo(String queueName, Object messageBody, Map<String, Object> messageAttributes)
+	// throws JsonProcessingException {
+	// String payload = objectMapper.writeValueAsString(messageBody);
+	// sqsTemplate.sendAsync(queueName,
+	// MessageBuilder.createMessage(payload, new MessagingMessageHeaders(messageAttributes)));
+	// logger.debug("Sent message to queue {} with messageBody {}", queueName, messageBody);
+	// }
 
 	static class MyPojo implements MyInterface {
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
For integration tests in SQS module, raw SqsAsyncClient client was substituted by SqsTemplate in methods for sending messages to queues.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Resolves awspring/spring-cloud-aws#658

When the integration tests for the SQS integration were created, SqsTemplate didn't exist.
Now it's necessary to change them so they use the template instead of the raw SqsAsyncClient.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
