### PR TITLE
Upgrade AWS SDK

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoaderIntegrationTests.java
@@ -66,6 +66,7 @@ import software.amazon.awssdk.services.ssm.model.ParameterType;
 class ParameterStoreConfigDataLoaderIntegrationTests {
 
 	private static final String REGION = "us-east-1";
+	private static final String NEW_LINE_CHAR = System.lineSeparator();
 
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
@@ -116,8 +117,10 @@ class ParameterStoreConfigDataLoaderIntegrationTests {
 			assertThat(e).isInstanceOf(ParameterStoreKeysMissingException.class);
 			// ensure that failure analyzer catches the exception and provides meaningful
 			// error message
-			assertThat(output.getOut())
-					.contains("Description:\n" + "\n" + "Could not import properties from AWS Parameter Store");
+			// Ensure that new line character should be platform independent
+			String errorMessage = "Description:%1$s%1$sCould not import properties from AWS Parameter Store"
+					.formatted(NEW_LINE_CHAR);
+			assertThat(output.getOut()).contains(errorMessage);
 		}
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
@@ -67,6 +67,7 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRespon
 class SecretsManagerConfigDataLoaderIntegrationTests {
 
 	private static final String REGION = "us-east-1";
+	private static final String NEW_LINE_CHAR = System.lineSeparator();
 
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
@@ -188,8 +189,10 @@ class SecretsManagerConfigDataLoaderIntegrationTests {
 			assertThat(e).isInstanceOf(SecretsManagerKeysMissingException.class);
 			// ensure that failure analyzer catches the exception and provides meaningful
 			// error message
-			assertThat(output.getOut())
-					.contains("Description:\n" + "\n" + "Could not import properties from AWS Secrets Manager");
+			// Ensure that new line character should be platform independent
+			String errorMessage = "Description:%1$s%1$sCould not import properties from AWS Secrets Manager"
+					.formatted(NEW_LINE_CHAR);
+			assertThat(output.getOut()).contains(errorMessage);
 		}
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfigurationTests.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.internal.crt.CopyObjectHelper;
 import software.amazon.awssdk.services.s3.internal.crt.S3NativeClientConfiguration;
 
 /**
@@ -93,8 +93,9 @@ class S3CrtAsyncClientAutoConfigurationTests {
 	}
 
 	private static S3NativeClientConfiguration s3NativeClientConfiguration(S3AsyncClient client) {
-		CopyObjectHelper copyObjectHelper = (CopyObjectHelper) ReflectionTestUtils.getField(client, "copyObjectHelper");
-		return (S3NativeClientConfiguration) ReflectionTestUtils.getField(copyObjectHelper,
+		ConfiguredAwsClient configuredClient = new ConfiguredAwsClient(client);
+		SdkAsyncHttpClient sdkAsyncHttpClient = configuredClient.getAsyncHttpClient();
+		return (S3NativeClientConfiguration) ReflectionTestUtils.getField(sdkAsyncHttpClient,
 				"s3NativeClientConfiguration");
 	}
 

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -25,15 +25,15 @@
 	<properties>
 		<javaparser.version>3.24.10</javaparser.version>
 		<spotless.version>2.31.0</spotless.version>
-		<awssdk-v2.version>2.19.25</awssdk-v2.version>
-		<awssdk-v1.version>1.12.394</awssdk-v1.version>
+		<awssdk-v2.version>2.20.30</awssdk-v2.version>
+		<awssdk-v1.version>1.12.433</awssdk-v1.version>
 		<amazon.dax.version>2.0.3</amazon.dax.version>
 		<maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
 		<spring-cloud-commons.version>4.0.1</spring-cloud-commons.version>
 		<testcontainers.version>1.17.6</testcontainers.version>
 		<jakarta.mail.version>2.1.0</jakarta.mail.version>
 		<eclipse.jakarta.mail.version>1.0.0</eclipse.jakarta.mail.version>
-		<aws-crt.version>0.21.3</aws-crt.version>
+		<aws-crt.version>0.21.9</aws-crt.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
Fixes gh-724

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fix below failing tests.
- `S3CrtAsyncClientAutoConfigurationTests` has been modified to make sure autoconfiguration sets property on s3 client
- `ParameterStoreConfigDataLoaderIntegrationTests` and `SecretsManagerConfigDataLoaderIntegrationTests` has assertion which uses hardcoded new line character which was failing the test case on Windows system. Fix it to take the new line character from system.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?

- After upgrading the SDK version ins BOM dependencies. I have rund the build using `mvnd`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
