### PR TITLE
Fix: mapping SQS message attributes with custom type

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
@@ -181,11 +181,16 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 		MessageAttributeValue value = entry.getValue();
 		String dataType = value.dataType();
 		Assert.notNull(dataType, "dataType must not be null");
-		return MessageAttributeDataTypes.STRING.equals(dataType)
-			? value.stringValue()
-			: MessageAttributeDataTypes.BINARY.equals(dataType)
-				? value.binaryValue()
-				: getNumberValue(value);
+
+		if (dataType.contains(".")) {
+			dataType = dataType.substring(0, dataType.indexOf('.'));
+		}
+
+		return switch (dataType) {
+			case MessageAttributeDataTypes.NUMBER -> getNumberValue(value);
+			case MessageAttributeDataTypes.BINARY -> value.binaryValue();
+			default -> value.stringValue();
+		};
 	}
 
 	private Map<String, String> getMessageSystemAttributesAsHeaders(Message source) {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapperTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapperTests.java
@@ -58,9 +58,39 @@ class SqsHeaderMapperTests {
 		String headerName = "stringAttribute";
 		String headerValue = "myString";
 		Message message = Message.builder().body("payload")
+			.messageAttributes(
+				Map.of(headerName,
+					MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.STRING)
+						.stringValue(headerValue).build()))
+			.messageId(UUID.randomUUID().toString()).build();
+		MessageHeaders headers = mapper.toHeaders(message);
+		assertThat(headers.get(headerName)).isEqualTo(headerValue);
+	}
+
+	@Test
+	void shouldAddStringCustomMessageAttributes() {
+		SqsHeaderMapper mapper = new SqsHeaderMapper();
+		String headerName = "stringAttribute";
+		String headerValue = "myString";
+		Message message = Message.builder().body("payload")
+			.messageAttributes(
+				Map.of(headerName,
+					MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.STRING + ".Array")
+						.stringValue(headerValue).build()))
+			.messageId(UUID.randomUUID().toString()).build();
+		MessageHeaders headers = mapper.toHeaders(message);
+		assertThat(headers.get(headerName)).isEqualTo(headerValue);
+	}
+
+	@Test
+	void shouldDefaultToStringIfDataTypeUnknownMessageAttributes() {
+		SqsHeaderMapper mapper = new SqsHeaderMapper();
+		String headerName = "stringAttribute";
+		String headerValue = "myString";
+		Message message = Message.builder().body("payload")
 				.messageAttributes(
 						Map.of(headerName,
-								MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.STRING)
+								MessageAttributeValue.builder().dataType("invalid data type")
 										.stringValue(headerValue).build()))
 				.messageId(UUID.randomUUID().toString()).build();
 		MessageHeaders headers = mapper.toHeaders(message);
@@ -73,9 +103,24 @@ class SqsHeaderMapperTests {
 		String headerName = "stringAttribute";
 		SdkBytes headerValue = SdkBytes.fromUtf8String("myString");
 		Message message = Message.builder().body("payload")
+			.messageAttributes(
+				Map.of(headerName,
+					MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.BINARY)
+						.binaryValue(headerValue).build()))
+			.messageId(UUID.randomUUID().toString()).build();
+		MessageHeaders headers = mapper.toHeaders(message);
+		assertThat(headers.get(headerName)).isEqualTo(headerValue);
+	}
+
+	@Test
+	void shouldAddBinaryCustomMessageAttributes() {
+		SqsHeaderMapper mapper = new SqsHeaderMapper();
+		String headerName = "stringAttribute";
+		SdkBytes headerValue = SdkBytes.fromUtf8String("myString");
+		Message message = Message.builder().body("payload")
 				.messageAttributes(
 						Map.of(headerName,
-								MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.BINARY)
+								MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.BINARY + ".protobuf")
 										.binaryValue(headerValue).build()))
 				.messageId(UUID.randomUUID().toString()).build();
 		MessageHeaders headers = mapper.toHeaders(message);


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Fixes an error trying to parse a message attribute value as a Number when its data type is String or Binary with a custom data type.

Changes:
* Ignore custom type (`.custom-data-type`) when determining data type.
* Default to String for unknown data types instead of Number.

## :bulb: Motivation and Context

Fixes issue #745

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
