### PR TITLE
Fix: To determine the filename of the S3Resource

### DIFF
--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Resource.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Resource.java
@@ -171,6 +171,11 @@ public class S3Resource extends AbstractResource implements WritableResource {
 		return s3OutputStreamProvider.create(location.getBucket(), location.getObject(), objectMetadata);
 	}
 
+	@Override
+	public String getFilename() {
+		return this.location.getObject();
+	}
+
 	public Location getLocation() {
 		return location;
 	}

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ResourceTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ResourceTests.java
@@ -16,9 +16,9 @@
 package io.awspring.cloud.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.mock;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -45,14 +45,14 @@ class S3ResourceTests {
 	}
 
 	@Test
-	void s3ResourceGetFileNameShouldNotThrowException() {
+	void getFileNameDoesNotThrowException() {
 		S3Resource resourceOne = new S3Resource("bucket", "objectOne", mock(S3Client.class),
 				mock(S3OutputStreamProvider.class));
 		S3Resource resourceTwo = new S3Resource("bucket", "objectTwo", mock(S3Client.class),
 				mock(S3OutputStreamProvider.class));
-		Assertions.assertEquals("objectOne", resourceOne.getFilename());
-		Assertions.assertEquals("objectTwo", resourceTwo.getFilename());
-		Assertions.assertDoesNotThrow(() -> resourceOne.getFilename().compareTo(resourceTwo.getFilename()));
+		assertThat(resourceOne.getFilename()).isEqualTo("objectOne");
+		assertThat(resourceTwo.getFilename()).isEqualTo("objectTwo");
+		assertThatNoException().isThrownBy(() -> resourceOne.getFilename().compareTo(resourceTwo.getFilename()));
 	}
 
 }

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ResourceTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ResourceTests.java
@@ -18,6 +18,7 @@ package io.awspring.cloud.s3;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -41,6 +42,17 @@ class S3ResourceTests {
 		S3Resource resource = new S3Resource("bucket", "", mock(S3Client.class), mock(S3OutputStreamProvider.class));
 		S3Resource result = resource.createRelative("foo");
 		assertThat(result.getLocation()).isEqualTo(Location.of("bucket", "foo"));
+	}
+
+	@Test
+	void s3ResourceGetFileNameShouldNotThrowException() {
+		S3Resource resourceOne = new S3Resource("bucket", "objectOne", mock(S3Client.class),
+				mock(S3OutputStreamProvider.class));
+		S3Resource resourceTwo = new S3Resource("bucket", "objectTwo", mock(S3Client.class),
+				mock(S3OutputStreamProvider.class));
+		Assertions.assertEquals("objectOne", resourceOne.getFilename());
+		Assertions.assertEquals("objectTwo", resourceTwo.getFilename());
+		Assertions.assertDoesNotThrow(() -> resourceOne.getFilename().compareTo(resourceTwo.getFilename()));
 	}
 
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fixes the NPE error when trying to determine the filename of an S3Resource. 
The method org.springframework.core.io.Resource#getFilename for S3Resource was not implemented and was returning null. So whenever S3Resource#getFilename was invoked - like during compareTo(), the process would throw NPE

Changes:
- Added the implementation of S3Resource#getFilename. It now returns `io.awspring.cloud.s3.Location#getObject`
- Added test case for the corresponding updates

## :bulb: Motivation and Context
Fixes issue https://github.com/awspring/spring-cloud-aws/issues/748


## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
