### PR TITLE
Resolve SNS topic ARN by full topic name

### DIFF
--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/TopicsListingTopicArnResolver.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/TopicsListingTopicArnResolver.java
@@ -71,7 +71,7 @@ public class TopicsListingTopicArnResolver implements TopicArnResolver {
 
 	private Arn checkIfArnIsInList(String topicName, ListTopicsResponse listTopicsResponse) {
 		Optional<String> arn = listTopicsResponse.topics().stream().map(Topic::topicArn)
-				.filter(ta -> ta.contains(topicName)).findFirst();
+				.filter(ta -> ta.endsWith(":" + topicName)).findFirst();
 		if (arn.isPresent()) {
 			return Arn.fromString(arn.get());
 		}

--- a/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/core/TopicsListingTopicArnResolverTest.java
+++ b/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/core/TopicsListingTopicArnResolverTest.java
@@ -41,7 +41,7 @@ class TopicsListingTopicArnResolverTest {
 
 	/**
 	 * SNS topic ARN should be resolved by full topic name rather by just a substring. i.e. "topic1" should not be
-	 * resolved to arn:aws:sns:eu-west-1:123456789012:topic11 but rather to arn:aws:sns:eu-west-1:123456789012:topic11
+	 * resolved to arn:aws:sns:eu-west-1:123456789012:topic11 but rather to arn:aws:sns:eu-west-1:123456789012:topic1
 	 */
 	@Test
 	void shouldResolveArnBasedOnTopicName() {

--- a/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/core/TopicsListingTopicArnResolverTest.java
+++ b/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/core/TopicsListingTopicArnResolverTest.java
@@ -17,27 +17,20 @@ package io.awspring.cloud.sns.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.arns.Arn;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.model.ListTopicsResponse;
 import software.amazon.awssdk.services.sns.model.Topic;
 
-@ExtendWith(MockitoExtension.class)
 class TopicsListingTopicArnResolverTest {
-	@Mock
-	private SnsClient snsClient;
+	private final SnsClient snsClient = mock(SnsClient.class);
 
-	@InjectMocks
-	private TopicsListingTopicArnResolver resolver;
+	private final TopicsListingTopicArnResolver resolver = new TopicsListingTopicArnResolver(snsClient);
 
 	/**
 	 * SNS topic ARN should be resolved by full topic name rather by just a substring. i.e. "topic1" should not be
@@ -45,23 +38,19 @@ class TopicsListingTopicArnResolverTest {
 	 */
 	@Test
 	void shouldResolveArnBasedOnTopicName() {
-		// given
 		given(snsClient.listTopics()).willReturn(aResponseContainingArnsForTopicNames("topic11", "topic1"));
 
-		// when
 		Arn arn = resolver.resolveTopicArn("topic1");
 
-		// then
 		assertThat(arn.toString()).isEqualTo("arn:aws:sns:eu-west-1:123456789012:topic1");
 	}
 
 	private ListTopicsResponse aResponseContainingArnsForTopicNames(String... topicNames) {
-
 		return ListTopicsResponse.builder().topics(stubTopics(topicNames)).build();
 	}
 
 	private List<Topic> stubTopics(String... topicNames) {
-		return Arrays.stream(topicNames).map(name -> createTopic(name)).collect(Collectors.toList());
+		return Arrays.stream(topicNames).map(this::createTopic).toList();
 	}
 
 	private Topic createTopic(String name) {

--- a/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/core/TopicsListingTopicArnResolverTest.java
+++ b/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/core/TopicsListingTopicArnResolverTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sns.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.arns.Arn;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.ListTopicsResponse;
+import software.amazon.awssdk.services.sns.model.Topic;
+
+@ExtendWith(MockitoExtension.class)
+class TopicsListingTopicArnResolverTest {
+	@Mock
+	private SnsClient snsClient;
+
+	@InjectMocks
+	private TopicsListingTopicArnResolver resolver;
+
+	/**
+	 * SNS topic ARN should be resolved by full topic name rather by just a substring. i.e. "topic1" should not be
+	 * resolved to arn:aws:sns:eu-west-1:123456789012:topic11 but rather to arn:aws:sns:eu-west-1:123456789012:topic11
+	 */
+	@Test
+	void shouldResolveArnBasedOnTopicName() {
+		// given
+		given(snsClient.listTopics()).willReturn(aResponseContainingArnsForTopicNames("topic11", "topic1"));
+
+		// when
+		Arn arn = resolver.resolveTopicArn("topic1");
+
+		// then
+		assertThat(arn.toString()).isEqualTo("arn:aws:sns:eu-west-1:123456789012:topic1");
+	}
+
+	private ListTopicsResponse aResponseContainingArnsForTopicNames(String... topicNames) {
+
+		return ListTopicsResponse.builder().topics(stubTopics(topicNames)).build();
+	}
+
+	private List<Topic> stubTopics(String... topicNames) {
+		return Arrays.stream(topicNames).map(name -> createTopic(name)).collect(Collectors.toList());
+	}
+
+	private Topic createTopic(String name) {
+		return Topic.builder().topicArn("arn:aws:sns:eu-west-1:123456789012:" + name).build();
+	}
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
TopicsListingTopicArnResolver had a bug, it could incorrectly resolve ARN based on topic name in the case when there would be more than one topic containing the same string.


## :bulb: Motivation and Context
Given ARNs:
- arn:aws:sns:eu-west-1:123456789012:MyTopicB
- arn:aws:sns:eu-west-1:123456789012:MyTopicC
- arn:aws:sns:eu-west-1:123456789012:MyTopic

TopicsListingTopicArnResolver could randomly resolve "MyTopic" to any of above 3 ARNs.

## :green_heart: How did you test it?
by unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
