### PR TITLE
SES sourceArn is configurable via properties

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -57,6 +57,7 @@
 |spring.cloud.aws.ses.enabled | `+++true+++` | Enables Simple Email Service integration.
 |spring.cloud.aws.ses.endpoint |  | Overrides the default endpoint.
 |spring.cloud.aws.ses.region |  | Overrides the default region.
+|spring.cloud.aws.ses.source-arn |  | Configures source ARN. Used only for sending authorization.
 |spring.cloud.aws.sns.enabled | `+++true+++` | Enables SNS integration.
 |spring.cloud.aws.sns.endpoint |  | Overrides the default endpoint.
 |spring.cloud.aws.sns.region |  | Overrides the default region.

--- a/docs/src/main/asciidoc/ses.adoc
+++ b/docs/src/main/asciidoc/ses.adoc
@@ -132,6 +132,7 @@ The Spring Boot Starter for SES provides the following configuration options:
 | `spring.cloud.aws.ses.enabled` | Enables the SES integration. | No | `true`
 | `spring.cloud.aws.ses.endpoint` | Configures endpoint used by `SesClient`. | No |
 | `spring.cloud.aws.ses.region` | Configures region used by `SesClient`. | No |
+| `spring.cloud.aws.ses.sourceArn` | Configures source ARN, used only for sending authorization. | No |
 |===
 
 Amazon SES is not available in all https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html[regions] of the
@@ -140,9 +141,14 @@ service will produce an error while using the mail service. Therefore, the regio
 sender configuration. The example below shows a typical combination of a region (`EU-CENTRAL-1`) that does not provide
 an SES service where the client is overridden to use a valid region (`EU-WEST-1`).
 
+`sourceArn` is the ARN of the identity that is associated with the sending authorization policy that permits you to send
+for the email address specified in the Source parameter. For information about when to use this parameter, see the
+description of SendRawEmail in this guide, or see the https://docs.aws.amazon.com/ses/latest/dg/sending-authorization-delegate-sender-tasks-email.html[Amazon SES Developer Guide].
+
 [source,properties,indent=0]
 ----
 spring.cloud.aws.ses.region=eu-west-1
+spring.cloud.aws.ses.sourceArn=arn:aws:ses:eu-west-1:123456789012:identity/example.com
 ----
 
 === IAM Permissions

--- a/docs/src/main/asciidoc/ses.adoc
+++ b/docs/src/main/asciidoc/ses.adoc
@@ -141,9 +141,8 @@ service will produce an error while using the mail service. Therefore, the regio
 sender configuration. The example below shows a typical combination of a region (`EU-CENTRAL-1`) that does not provide
 an SES service where the client is overridden to use a valid region (`EU-WEST-1`).
 
-`sourceArn` is the ARN of the identity that is associated with the sending authorization policy that permits you to send
-for the email address specified in the Source parameter. For information about when to use this parameter, see the
-description of SendRawEmail in this guide, or see the https://docs.aws.amazon.com/ses/latest/dg/sending-authorization-delegate-sender-tasks-email.html[Amazon SES Developer Guide].
+`sourceArn` is the ARN of the identity that is associated with the sending authorization policy. For information about when to use this parameter, see the
+description see https://docs.aws.amazon.com/ses/latest/dg/sending-authorization-delegate-sender-tasks-email.html[Amazon SES Developer Guide].
 
 [source,properties,indent=0]
 ----

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesAutoConfiguration.java
@@ -61,14 +61,14 @@ public class SesAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingClass("jakarta.mail.Session")
-	public MailSender simpleMailSender(SesClient sesClient) {
-		return new SimpleEmailServiceMailSender(sesClient);
+	public MailSender simpleMailSender(SesClient sesClient, SesProperties properties) {
+		return new SimpleEmailServiceMailSender(sesClient, properties.getSourceArn());
 	}
 
 	@Bean
 	@ConditionalOnClass(name = "jakarta.mail.Session")
-	public JavaMailSender javaMailSender(SesClient sesClient) {
-		return new SimpleEmailServiceJavaMailSender(sesClient);
+	public JavaMailSender javaMailSender(SesClient sesClient, SesProperties properties) {
+		return new SimpleEmailServiceJavaMailSender(sesClient, properties.getSourceArn());
 	}
 
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesProperties.java
@@ -17,6 +17,7 @@ package io.awspring.cloud.autoconfigure.ses;
 
 import io.awspring.cloud.autoconfigure.AwsClientProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.lang.Nullable;
 
 /**
  * Properties related to AWS Simple Email Service.
@@ -32,4 +33,15 @@ public class SesProperties extends AwsClientProperties {
 	 */
 	public static final String PREFIX = "spring.cloud.aws.ses";
 
+	@Nullable
+	private String sourceArn;
+
+	@Nullable
+	public String getSourceArn() {
+		return sourceArn;
+	}
+
+	public void setSourceArn(@Nullable String sourceArn) {
+		this.sourceArn = sourceArn;
+	}
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesProperties.java
@@ -33,6 +33,9 @@ public class SesProperties extends AwsClientProperties {
 	 */
 	public static final String PREFIX = "spring.cloud.aws.ses";
 
+	/**
+	 * Configures source ARN. Used only for sending authorization.
+	 */
 	@Nullable
 	private String sourceArn;
 

--- a/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/SimpleEmailServiceJavaMailSender.java
+++ b/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/SimpleEmailServiceJavaMailSender.java
@@ -75,7 +75,11 @@ public class SimpleEmailServiceJavaMailSender extends SimpleEmailServiceMailSend
 	private FileTypeMap defaultFileTypeMap;
 
 	public SimpleEmailServiceJavaMailSender(SesClient sesClient) {
-		super(sesClient);
+		this(sesClient, null);
+	}
+
+	public SimpleEmailServiceJavaMailSender(SesClient sesClient, @Nullable String sourceArn) {
+		super(sesClient, sourceArn);
 	}
 
 	/**
@@ -202,8 +206,8 @@ public class SimpleEmailServiceJavaMailSender extends SimpleEmailServiceMailSend
 			try {
 				RawMessage rawMessage = createRawMessage(mimeMessage);
 
-				SendRawEmailResponse sendRawEmailResponse = getEmailService()
-						.sendRawEmail(SendRawEmailRequest.builder().rawMessage(rawMessage).build());
+				SendRawEmailResponse sendRawEmailResponse = getEmailService().sendRawEmail(
+						SendRawEmailRequest.builder().sourceArn(getSourceArn()).rawMessage(rawMessage).build());
 
 				if (LOGGER.isDebugEnabled()) {
 					LOGGER.debug("Message with id: {} successfully sent", sendRawEmailResponse.messageId());

--- a/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/SimpleEmailServiceMailSender.java
+++ b/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/SimpleEmailServiceMailSender.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
+import org.springframework.lang.Nullable;
 import org.springframework.mail.MailException;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.MailSender;
@@ -50,8 +51,16 @@ public class SimpleEmailServiceMailSender implements MailSender, DisposableBean 
 
 	private final SesClient sesClient;
 
+	@Nullable
+	private final String sourceArn;
+
 	public SimpleEmailServiceMailSender(SesClient sesClient) {
+		this(sesClient, null);
+	}
+
+	public SimpleEmailServiceMailSender(SesClient sesClient, @Nullable String sourceArn) {
 		this.sesClient = sesClient;
+		this.sourceArn = sourceArn;
 	}
 
 	@Override
@@ -94,6 +103,11 @@ public class SimpleEmailServiceMailSender implements MailSender, DisposableBean 
 		return this.sesClient;
 	}
 
+	@Nullable
+	protected String getSourceArn() {
+		return sourceArn;
+	}
+
 	private SendEmailRequest prepareMessage(SimpleMailMessage simpleMailMessage) {
 		Assert.notNull(simpleMailMessage, "simpleMailMessage are required");
 		Destination.Builder destinationBuilder = Destination.builder();
@@ -112,7 +126,8 @@ public class SimpleEmailServiceMailSender implements MailSender, DisposableBean 
 		Message message = Message.builder().body(body).subject(subject).build();
 
 		SendEmailRequest.Builder emailRequestBuilder = SendEmailRequest.builder()
-				.destination(destinationBuilder.build()).source(simpleMailMessage.getFrom()).message(message);
+				.destination(destinationBuilder.build()).source(simpleMailMessage.getFrom()).sourceArn(getSourceArn())
+				.message(message);
 
 		if (StringUtils.hasText(simpleMailMessage.getReplyTo())) {
 			emailRequestBuilder.replyToAddresses(simpleMailMessage.getReplyTo());

--- a/spring-cloud-aws-ses/src/test/java/io/awspring/cloud/ses/SimpleEmailServiceJavaMailSenderTest.java
+++ b/spring-cloud-aws-ses/src/test/java/io/awspring/cloud/ses/SimpleEmailServiceJavaMailSenderTest.java
@@ -149,7 +149,8 @@ class SimpleEmailServiceJavaMailSenderTest {
 	void testSendMimeMessage() throws MessagingException {
 		SesClient emailService = mock(SesClient.class);
 
-		JavaMailSender mailSender = new SimpleEmailServiceJavaMailSender(emailService);
+		JavaMailSender mailSender = new SimpleEmailServiceJavaMailSender(emailService,
+				"arn:aws:ses:us-east-1:00000001:identity/domain.com");
 
 		ArgumentCaptor<SendRawEmailRequest> request = ArgumentCaptor.forClass(SendRawEmailRequest.class);
 		when(emailService.sendRawEmail(request.capture()))
@@ -158,6 +159,7 @@ class SimpleEmailServiceJavaMailSenderTest {
 		MimeMessage mimeMessage = createMimeMessage();
 		mailSender.send(mimeMessage);
 		assertThat(mimeMessage.getMessageID()).isEqualTo("123");
+		assertThat(request.getValue().sourceArn()).isEqualTo("arn:aws:ses:us-east-1:00000001:identity/domain.com");
 	}
 
 	@Test

--- a/spring-cloud-aws-ses/src/test/java/io/awspring/cloud/ses/SimpleEmailServiceMailSenderTest.java
+++ b/spring-cloud-aws-ses/src/test/java/io/awspring/cloud/ses/SimpleEmailServiceMailSenderTest.java
@@ -45,7 +45,8 @@ class SimpleEmailServiceMailSenderTest {
 	@Test
 	void testSendSimpleMailWithMinimalProperties() {
 		SesClient emailService = mock(SesClient.class);
-		SimpleEmailServiceMailSender mailSender = new SimpleEmailServiceMailSender(emailService);
+		SimpleEmailServiceMailSender mailSender = new SimpleEmailServiceMailSender(emailService,
+				"arn:aws:ses:us-east-1:00000000:identity/domain.com");
 
 		SimpleMailMessage simpleMailMessage = createSimpleMailMessage();
 
@@ -63,6 +64,7 @@ class SimpleEmailServiceMailSenderTest {
 		assertThat(sendEmailRequest.message().body().text().data()).isEqualTo(simpleMailMessage.getText());
 		assertThat(sendEmailRequest.destination().ccAddresses().size()).isEqualTo(0);
 		assertThat(sendEmailRequest.destination().bccAddresses().size()).isEqualTo(0);
+		assertThat(sendEmailRequest.sourceArn()).isEqualTo("arn:aws:ses:us-east-1:00000000:identity/domain.com");
 	}
 
 	@Test


### PR DESCRIPTION
AWS Java SDK v2 SES API ensures the necessary methods to setup `sourceArn` property at message sending moment but this configuration is not yet available via properties.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
Based on experiences if `sourceArn` is not specified in `SendRawEmailRequest` or in `SendEmailRequest` then one will be picked. It works well until there is only one verfied identity in AWS SES but when there are multiple ones, currently there is no control over which one to be used.
This PR gives the possibility to set the `sourceArn` in the application properties/yaml file.


## :bulb: Motivation and Context
Context: there is an AWS account having multiple verfied identities in SES.
Motiviation: developers want to specify the verified identity to be used.

## :green_heart: How did you test it?
Existing unit tests are updated to test if the `sourceArn` is passed to the request.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
