### PR TITLE
Downgrade Localstack to 1.4.0

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoaderIntegrationTests.java
@@ -70,7 +70,7 @@ class ParameterStoreConfigDataLoaderIntegrationTests {
 
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
-			DockerImageName.parse("localstack/localstack:2.0.0")).withReuse(true);
+			DockerImageName.parse("localstack/localstack:1.4.0")).withReuse(true);
 
 	@BeforeAll
 	static void beforeAll() {

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
@@ -71,7 +71,7 @@ class SecretsManagerConfigDataLoaderIntegrationTests {
 
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
-			DockerImageName.parse("localstack/localstack:2.0.0")).withReuse(true);
+			DockerImageName.parse("localstack/localstack:1.4.0")).withReuse(true);
 
 	@BeforeAll
 	static void beforeAll() {

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchExportAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchExportAutoConfigurationIntegrationTests.java
@@ -55,7 +55,7 @@ class CloudWatchExportAutoConfigurationIntegrationTests {
 
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
-			DockerImageName.parse("localstack/localstack:2.0.0"));
+			DockerImageName.parse("localstack/localstack:1.4.0"));
 
 	@DynamicPropertySource
 	static void registerProperties(DynamicPropertyRegistry registry) {

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationIntegrationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationIntegrationTest.java
@@ -61,7 +61,7 @@ class SqsAutoConfigurationIntegrationTest {
 
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
-			DockerImageName.parse("localstack/localstack:2.0.0"));
+			DockerImageName.parse("localstack/localstack:1.4.0"));
 
 	@SuppressWarnings("unchecked")
 	@Test

--- a/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTemplateIntegrationTest.java
+++ b/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTemplateIntegrationTest.java
@@ -60,7 +60,7 @@ public class DynamoDbTemplateIntegrationTest {
 
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
-			DockerImageName.parse("localstack/localstack:2.0.0")).withServices(DYNAMODB).withReuse(true);
+			DockerImageName.parse("localstack/localstack:1.4.0")).withServices(DYNAMODB).withReuse(true);
 
 	@BeforeAll
 	public static void createTable() {

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3PathMatchingResourcePatternResolverTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3PathMatchingResourcePatternResolverTests.java
@@ -41,7 +41,7 @@ class S3PathMatchingResourcePatternResolverTests {
 
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
-			DockerImageName.parse("localstack/localstack:2.0.0")).withReuse(true);
+			DockerImageName.parse("localstack/localstack:1.4.0")).withReuse(true);
 
 	private static ResourcePatternResolver resourceLoader;
 

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ResourceIntegrationTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ResourceIntegrationTests.java
@@ -70,7 +70,7 @@ class S3ResourceIntegrationTests {
 
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
-			DockerImageName.parse("localstack/localstack:2.0.0")).withReuse(true);
+			DockerImageName.parse("localstack/localstack:1.4.0")).withReuse(true);
 
 	private static S3Client client;
 	private static S3AsyncClient asyncClient;

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
@@ -68,7 +68,7 @@ class S3TemplateIntegrationTests {
 
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
-			DockerImageName.parse("localstack/localstack:2.0.0")).withReuse(true);
+			DockerImageName.parse("localstack/localstack:1.4.0")).withReuse(true);
 
 	private static S3Client client;
 

--- a/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/integration/SnsTemplateIntegrationTest.java
+++ b/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/integration/SnsTemplateIntegrationTest.java
@@ -64,7 +64,7 @@ class SnsTemplateIntegrationTest {
 
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
-			DockerImageName.parse("localstack/localstack:2.0.0")).withServices(SNS).withServices(SQS).withReuse(true);
+			DockerImageName.parse("localstack/localstack:1.4.0")).withServices(SNS).withServices(SQS).withReuse(true);
 
 	@BeforeAll
 	public static void createSnsTemplate() {

--- a/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/sms/SnsSmsTemplateIntegrationTest.java
+++ b/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/sms/SnsSmsTemplateIntegrationTest.java
@@ -43,7 +43,7 @@ class SnsSmsTemplateIntegrationTest {
 
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
-			DockerImageName.parse("localstack/localstack:2.0.0")).withServices(SNS).withEnv("DEBUG", "1");
+			DockerImageName.parse("localstack/localstack:1.4.0")).withServices(SNS).withEnv("DEBUG", "1");
 
 	@BeforeAll
 	public static void createSnsTemplate() {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/BaseSqsIntegrationTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/BaseSqsIntegrationTest.java
@@ -48,7 +48,7 @@ abstract class BaseSqsIntegrationTest {
 
 	protected static final boolean purgeQueues = true;
 
-	private static final String LOCAL_STACK_VERSION = "localstack/localstack:2.0.0";
+	private static final String LOCAL_STACK_VERSION = "localstack/localstack:1.4.0";
 
 	static LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_VERSION));
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapperTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapperTests.java
@@ -58,11 +58,11 @@ class SqsHeaderMapperTests {
 		String headerName = "stringAttribute";
 		String headerValue = "myString";
 		Message message = Message.builder().body("payload")
-			.messageAttributes(
-				Map.of(headerName,
-					MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.STRING)
-						.stringValue(headerValue).build()))
-			.messageId(UUID.randomUUID().toString()).build();
+				.messageAttributes(
+						Map.of(headerName,
+								MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.STRING)
+										.stringValue(headerValue).build()))
+				.messageId(UUID.randomUUID().toString()).build();
 		MessageHeaders headers = mapper.toHeaders(message);
 		assertThat(headers.get(headerName)).isEqualTo(headerValue);
 	}
@@ -73,11 +73,11 @@ class SqsHeaderMapperTests {
 		String headerName = "stringAttribute";
 		String headerValue = "myString";
 		Message message = Message.builder().body("payload")
-			.messageAttributes(
-				Map.of(headerName,
-					MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.STRING + ".Array")
-						.stringValue(headerValue).build()))
-			.messageId(UUID.randomUUID().toString()).build();
+				.messageAttributes(
+						Map.of(headerName,
+								MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.STRING + ".Array")
+										.stringValue(headerValue).build()))
+				.messageId(UUID.randomUUID().toString()).build();
 		MessageHeaders headers = mapper.toHeaders(message);
 		assertThat(headers.get(headerName)).isEqualTo(headerValue);
 	}
@@ -88,10 +88,8 @@ class SqsHeaderMapperTests {
 		String headerName = "stringAttribute";
 		String headerValue = "myString";
 		Message message = Message.builder().body("payload")
-				.messageAttributes(
-						Map.of(headerName,
-								MessageAttributeValue.builder().dataType("invalid data type")
-										.stringValue(headerValue).build()))
+				.messageAttributes(Map.of(headerName,
+						MessageAttributeValue.builder().dataType("invalid data type").stringValue(headerValue).build()))
 				.messageId(UUID.randomUUID().toString()).build();
 		MessageHeaders headers = mapper.toHeaders(message);
 		assertThat(headers.get(headerName)).isEqualTo(headerValue);
@@ -103,11 +101,11 @@ class SqsHeaderMapperTests {
 		String headerName = "stringAttribute";
 		SdkBytes headerValue = SdkBytes.fromUtf8String("myString");
 		Message message = Message.builder().body("payload")
-			.messageAttributes(
-				Map.of(headerName,
-					MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.BINARY)
-						.binaryValue(headerValue).build()))
-			.messageId(UUID.randomUUID().toString()).build();
+				.messageAttributes(
+						Map.of(headerName,
+								MessageAttributeValue.builder().dataType(MessageAttributeDataTypes.BINARY)
+										.binaryValue(headerValue).build()))
+				.messageId(UUID.randomUUID().toString()).build();
 		MessageHeaders headers = mapper.toHeaders(message);
 		assertThat(headers.get(headerName)).isEqualTo(headerValue);
 	}

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/BaseSqsIntegrationTest.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/BaseSqsIntegrationTest.java
@@ -32,7 +32,7 @@ abstract class BaseSqsIntegrationTest {
 
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
-			DockerImageName.parse("localstack/localstack:2.0.0")).withReuse(true);
+			DockerImageName.parse("localstack/localstack:1.4.0")).withReuse(true);
 
 	@BeforeAll
 	static void beforeAll() throws IOException, InterruptedException {


### PR DESCRIPTION
One of the recent commits introduced flakiness to tests. This PR is meant to verify if Localstack 2.0 is the guilty one.