### PR TITLE
Fix missing MessageHeaders returned from MessageConverter

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
@@ -205,13 +205,12 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 
 	@Override
 	public S fromMessagingMessage(Message<?> message, @Nullable MessageConversionContext context) {
-		MessageHeaders headers = getMessageHeaders(message);
+		Message<?> convertedMessage = Objects.requireNonNull(
+				this.payloadMessageConverter.toMessage(message.getPayload(), message.getHeaders()),
+				() -> "payloadMessageConverter returned null message for message " + message);
+		MessageHeaders headers = getMessageHeaders(convertedMessage);
 		S messageWithHeaders = this.headerMapper.fromHeaders(headers);
-		Object payload = Objects
-				.requireNonNull(this.payloadMessageConverter.toMessage(message.getPayload(), message.getHeaders()),
-						() -> "payloadMessageConverter returned null message for message " + message)
-				.getPayload();
-		return doConvertMessage(messageWithHeaders, payload);
+		return doConvertMessage(messageWithHeaders, convertedMessage.getPayload());
 	}
 
 	private MessageHeaders getMessageHeaders(Message<?> message) {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverterTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverterTests.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.support.MessageBuilder;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 
@@ -112,6 +113,25 @@ class SqsMessagingMessageConverterTests {
 		converter.setPayloadTypeMapper(msg -> MyPojo.class);
 		org.springframework.messaging.Message<?> resultMessage = converter.toMessagingMessage(message);
 		assertThat(resultMessage.getPayload()).isEqualTo(myPojo);
+	}
+
+	@Test
+	void shouldUseHeadersFromPayloadConverter() {
+		MessageConverter payloadConverter = mock(MessageConverter.class);
+		org.springframework.messaging.Message convertedMessageWithContentType = MessageBuilder.withPayload("example")
+			.setHeader("contentType", "application/json").build();
+		when(payloadConverter.toMessage(any(MyPojo.class), any())).thenReturn(convertedMessageWithContentType);
+
+		SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+		converter.setPayloadMessageConverter(payloadConverter);
+		converter.setPayloadTypeMapper(msg -> MyPojo.class);
+
+		org.springframework.messaging.Message<MyPojo> message = MessageBuilder.createMessage(new MyPojo(),
+			new MessageHeaders(null));
+		Message resultMessage = converter.fromMessagingMessage(message);
+
+		assertThat(resultMessage.messageAttributes()).containsEntry("contentType",
+				MessageAttributeValue.builder().stringValue("application/json").dataType("String").build());
 	}
 
 	static class MyPojo {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
`AbstractMessagingMessageConverter` now uses `MessageHeader`s generated from the `MessageConverter`. Previously, it was converting `MessageHeader`s, but 
not any headers such as `contentType` that were returned by the `MessageConverter`. 

For example, `AbstractMessageConverter` typically adds the `contentType` header, setting it to something like `application/json`. Without the 
`contentType` header, older versions can fail to deserialise messages, depending on how they're configured.

## :bulb: Motivation and Context

Fixes issue [#777](https://github.com/awspring/spring-cloud-aws/issues/777).


## :green_heart: How did you test it?
I have added an additional test case to `SqsMessagingMessageConverterTests`, which I believe highlights the problem.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps

Forgive me, this is my first PR raised against the project, and I most likely haven't followed proper convention. Any help would be appreciated!
