### PR TITLE
Aligning cloudwatch metric properties to spring boot 3.0

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -4,7 +4,7 @@
 |spring.cloud.aws.cloudwatch.endpoint |  | Overrides the default endpoint.
 |spring.cloud.aws.cloudwatch.region |  | Overrides the default region.
 |spring.cloud.aws.credentials.access-key |  | The access key to be used with a static provider.
-|spring.cloud.aws.credentials.instance-profile |  | Configures an instance profile credentials provider with no further configuration.
+|spring.cloud.aws.credentials.instance-profile | `+++false+++` | Configures an instance profile credentials provider with no further configuration.
 |spring.cloud.aws.credentials.profile |  | The AWS profile.
 |spring.cloud.aws.credentials.secret-key |  | The secret key to be used with a static provider.
 |spring.cloud.aws.credentials.sts.async-credentials-update |  | 
@@ -33,10 +33,10 @@
 |spring.cloud.aws.fips-enabled |  | Configure whether the SDK should use the AWS fips endpoints.
 |spring.cloud.aws.parameterstore.endpoint |  | Overrides the default endpoint.
 |spring.cloud.aws.parameterstore.region |  | Overrides the default region.
-|spring.cloud.aws.parameterstore.reload.max-wait-for-restart |  | If {@link ReloadStrategy#RESTART_CONTEXT} is configured, maximum waiting time for server restart.
-|spring.cloud.aws.parameterstore.reload.period |  | Refresh period for {@link PollingAwsPropertySourceChangeDetector}.
+|spring.cloud.aws.parameterstore.reload.max-wait-for-restart | `+++2s+++` | If {@link ReloadStrategy#RESTART_CONTEXT} is configured, maximum waiting time for server restart.
+|spring.cloud.aws.parameterstore.reload.period | `+++1m+++` | Refresh period for {@link PollingAwsPropertySourceChangeDetector}.
 |spring.cloud.aws.parameterstore.reload.strategy |  | Reload strategy to run when properties change.
-|spring.cloud.aws.region.instance-profile |  | Configures an instance profile region provider with no further configuration.
+|spring.cloud.aws.region.instance-profile | `+++false+++` | Configures an instance profile region provider with no further configuration.
 |spring.cloud.aws.region.profile |  | The AWS profile.
 |spring.cloud.aws.region.static |  | 
 |spring.cloud.aws.s3.accelerate-mode-enabled |  | Option to enable using the accelerate endpoint when accessing S3. Accelerate endpoints allow faster transfer of objects by using Amazon CloudFront's globally distributed edge locations.
@@ -55,8 +55,8 @@
 |spring.cloud.aws.s3.use-arn-region-enabled |  | If an S3 resource ARN is passed in as the target of an S3 operation that has a different region to the one the client was configured with, this flag must be set to 'true' to permit the client to make a cross-region call to the region specified in the ARN otherwise an exception will be thrown.
 |spring.cloud.aws.secretsmanager.endpoint |  | Overrides the default endpoint.
 |spring.cloud.aws.secretsmanager.region |  | Overrides the default region.
-|spring.cloud.aws.secretsmanager.reload.max-wait-for-restart |  | If {@link ReloadStrategy#RESTART_CONTEXT} is configured, maximum waiting time for server restart.
-|spring.cloud.aws.secretsmanager.reload.period |  | Refresh period for {@link PollingAwsPropertySourceChangeDetector}.
+|spring.cloud.aws.secretsmanager.reload.max-wait-for-restart | `+++2s+++` | If {@link ReloadStrategy#RESTART_CONTEXT} is configured, maximum waiting time for server restart.
+|spring.cloud.aws.secretsmanager.reload.period | `+++1m+++` | Refresh period for {@link PollingAwsPropertySourceChangeDetector}.
 |spring.cloud.aws.secretsmanager.reload.strategy |  | Reload strategy to run when properties change.
 |spring.cloud.aws.ses.enabled | `+++true+++` | Enables Simple Email Service integration.
 |spring.cloud.aws.ses.endpoint |  | Overrides the default endpoint.

--- a/docs/src/main/asciidoc/cloudwatch.adoc
+++ b/docs/src/main/asciidoc/cloudwatch.adoc
@@ -10,7 +10,7 @@ To send metrics to CloudWatch add a dependency to `micrometer-registry-cloudwatc
 </dependency>
 ----
 
-Additionally, CloudWatch integration requires a value provided for `management.metrics.export.cloudwatch.namespace` configuration property.
+Additionally, CloudWatch integration requires a value provided for `management.cloudwatch.metrics.export.namespace` configuration property.
 
 Following configuration properties are available to configure CloudWatch integration:
 
@@ -20,11 +20,11 @@ Following configuration properties are available to configure CloudWatch integra
 |default
 |description
 
-|management.metrics.export.cloudwatch.namespace
+|management.cloudwatch.metrics.export.namespace
 |
 |The namespace which will be used when sending metrics to CloudWatch. This property is needed and must not be null.
 
-|management.metrics.export.cloudwatch.step
+|management.cloudwatch.metrics.export.step
 |1m
 |The interval at which metrics are sent to CloudWatch. The default is 1 minute.
 

--- a/docs/src/main/asciidoc/migration.adoc
+++ b/docs/src/main/asciidoc/migration.adoc
@@ -26,6 +26,9 @@ Properties that have changed from 2.x to 3.x are listed below:
 
 |`aws.secretsmanager.region`
 |`spring.cloud.aws.secretsmanager.region`
+
+|`management.metrics.export.cloudwatch.*`
+|`management.cloudwatch.metrics.export.*`
 |===
 
 Properties that have been removed in 3.x are listed below:

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
@@ -52,7 +52,7 @@ import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClientBuilder;
 @AutoConfigureAfter({ CredentialsProviderAutoConfiguration.class, RegionProviderAutoConfiguration.class,
 		MetricsAutoConfiguration.class })
 @EnableConfigurationProperties({ CloudWatchRegistryProperties.class, CloudWatchProperties.class })
-@ConditionalOnProperty(prefix = "management.metrics.export.cloudwatch", name = "namespace")
+@ConditionalOnProperty(prefix = "management.cloudwatch.metrics.export", name = "namespace")
 @ConditionalOnClass({ CloudWatchAsyncClient.class, CloudWatchMeterRegistry.class, AwsRegionProvider.class })
 public class CloudWatchExportAutoConfiguration {
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchRegistryProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchRegistryProperties.java
@@ -27,7 +27,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Eddú Meléndez
  * @since 2.0.0
  */
-@ConfigurationProperties(prefix = "management.metrics.export.cloudwatch")
+@ConfigurationProperties(prefix = "management.cloudwatch.metrics.export")
 public class CloudWatchRegistryProperties extends StepRegistryProperties {
 
 	private static final int DEFAULT_BATCH_SIZE = 20;

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchExportAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchExportAutoConfigurationIntegrationTests.java
@@ -72,8 +72,8 @@ class CloudWatchExportAutoConfigurationIntegrationTests {
 		try (ConfigurableApplicationContext context = application.run(
 				"--spring.cloud.aws.endpoint=" + localstack.getEndpointOverride(SSM).toString(),
 				"--spring.cloud.aws.credentials.access-key=noop", "--spring.cloud.aws.credentials.secret-key=noop",
-				"--spring.cloud.aws.region.static=us-east-1", "--management.metrics.export.cloudwatch.step=5s",
-				"--management.metrics.export.cloudwatch.namespace=awspring/spring-cloud-aws",
+				"--spring.cloud.aws.region.static=us-east-1", "--management.cloudwatch.metrics.export.step=5s",
+				"--management.cloudwatch.metrics.export.namespace=awspring/spring-cloud-aws",
 				"--management.metrics.enable.all=false", "--management.metrics.enable.test=true")) {
 
 			MeterRegistry meterRegistry = context.getBean(MeterRegistry.class);

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchExportAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchExportAutoConfigurationTest.java
@@ -62,7 +62,7 @@ class CloudWatchExportAutoConfigurationTest {
 
 	@Test
 	void enableAutoConfigurationSettingNamespace() {
-		this.contextRunner.withPropertyValues("management.metrics.export.cloudwatch.namespace:test").run(context -> {
+		this.contextRunner.withPropertyValues("management.cloudwatch.metrics.export.namespace:test").run(context -> {
 			assertThat(context).hasSingleBean(CloudWatchMeterRegistry.class);
 			assertThat(context).hasSingleBean(CloudWatchConfig.class);
 			assertThat(context).hasSingleBean(Clock.class);
@@ -74,7 +74,7 @@ class CloudWatchExportAutoConfigurationTest {
 
 	@Test
 	void enableAutoConfigurationWithSpecificRegion() {
-		this.contextRunner.withPropertyValues("management.metrics.export.cloudwatch.namespace:test",
+		this.contextRunner.withPropertyValues("management.cloudwatch.metrics.export.namespace:test",
 				"spring.cloud.aws.cloudwatch.region:us-east-1").run(context -> {
 					assertThat(context).hasSingleBean(CloudWatchMeterRegistry.class);
 					assertThat(context).hasSingleBean(Clock.class);
@@ -95,7 +95,7 @@ class CloudWatchExportAutoConfigurationTest {
 
 	@Test
 	void enableAutoConfigurationWithCustomEndpoint() {
-		this.contextRunner.withPropertyValues("management.metrics.export.cloudwatch.namespace:test",
+		this.contextRunner.withPropertyValues("management.cloudwatch.metrics.export.namespace:test",
 				"spring.cloud.aws.cloudwatch.endpoint:http://localhost:8090").run(context -> {
 					ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(CloudWatchAsyncClient.class));
 					assertThat(client.getEndpoint()).isEqualTo(URI.create("http://localhost:8090"));
@@ -105,7 +105,7 @@ class CloudWatchExportAutoConfigurationTest {
 
 	@Test
 	void withCustomGlobalEndpoint() {
-		this.contextRunner.withPropertyValues("management.metrics.export.cloudwatch.namespace:test",
+		this.contextRunner.withPropertyValues("management.cloudwatch.metrics.export.namespace:test",
 				"spring.cloud.aws.endpoint:http://localhost:8090").run(context -> {
 					ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(CloudWatchAsyncClient.class));
 					assertThat(client.getEndpoint()).isEqualTo(URI.create("http://localhost:8090"));
@@ -115,7 +115,7 @@ class CloudWatchExportAutoConfigurationTest {
 
 	@Test
 	void withCustomGlobalEndpointAndCloudWatchEndpoint() {
-		this.contextRunner.withPropertyValues("management.metrics.export.cloudwatch.namespace:test",
+		this.contextRunner.withPropertyValues("management.cloudwatch.metrics.export.namespace:test",
 				"spring.cloud.aws.endpoint:http://localhost:8090",
 				"spring.cloud.aws.cloudwatch.endpoint:http://localhost:9999").run(context -> {
 					ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(CloudWatchAsyncClient.class));
@@ -126,7 +126,7 @@ class CloudWatchExportAutoConfigurationTest {
 
 	@Test
 	void useAwsConfigurerClient() {
-		this.contextRunner.withPropertyValues("management.metrics.export.cloudwatch.namespace:test")
+		this.contextRunner.withPropertyValues("management.cloudwatch.metrics.export.namespace:test")
 				.withUserConfiguration(CustomAwsConfigurerClient.class).run(context -> {
 					ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(CloudWatchAsyncClient.class));
 					assertThat(client.getApiCallTimeout()).isEqualTo(Duration.ofMillis(1542));


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Aligning cloudwatch metric properties to spring boot 3.0.


## :bulb: Motivation and Context
fixes #776

## :green_heart: How did you test it?
Executing existing adopted unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
