### PR TITLE
Implement `utilities()` and `waiter()` methods in `CrossRegionS3Client` that delegate to default S3 client.

### DIFF
--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -32,6 +32,7 @@
 		<jakarta.mail.version>2.1.0</jakarta.mail.version>
 		<eclipse.jakarta.mail.version>1.0.0</eclipse.jakarta.mail.version>
 		<aws-crt.version>0.21.12</aws-crt.version>
+		<mockito.version>5.3.1</mockito.version>
 	</properties>
 
 	<dependencyManagement>

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/pom.xml
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/pom.xml
@@ -22,6 +22,16 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>localstack</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/main/java/io/awspring/cloud/s3/crossregion/CrossRegionS3Client.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/main/java/io/awspring/cloud/s3/crossregion/CrossRegionS3Client.java
@@ -26,7 +26,9 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Utilities;
 import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.waiters.S3Waiter;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 public class CrossRegionS3Client extends AbstractCrossRegionS3Client {
@@ -153,5 +155,25 @@ public class CrossRegionS3Client extends AbstractCrossRegionS3Client {
 	@Override
 	public ListObjectsResponse listObjects(ListObjectsRequest request) throws AwsServiceException, SdkClientException {
 		return executeInBucketRegion(request.bucket(), c -> c.listObjects(request), false);
+	}
+
+	/**
+	 * Returns {@link S3Utilities} that use the default S3 client.
+	 *
+	 * @return the S3 utilities
+	 */
+	@Override
+	public S3Utilities utilities() {
+		return executeInDefaultRegion(S3Client::utilities);
+	}
+
+	/**
+	 * Returns {@link S3Waiter} that use the default S3 client.
+	 *
+	 * @return the S3 waiter
+	 */
+	@Override
+	public S3Waiter waiter() {
+		return executeInDefaultRegion(S3Client::waiter);
 	}
 }

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/test/java/io/awspring/cloud/s3/crossregion/CrossRegionS3ClientIntegrationTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/test/java/io/awspring/cloud/s3/crossregion/CrossRegionS3ClientIntegrationTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.s3.crossregion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+import java.net.URL;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.internal.waiters.ResponseOrException;
+import software.amazon.awssdk.core.waiters.WaiterResponse;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+
+/**
+ * Integration tests for {@link CrossRegionS3Client}.
+ *
+ * @author Maciej Walkowiak
+ */
+@Testcontainers
+class CrossRegionS3ClientIntegrationTests {
+
+	@Container
+	static LocalStackContainer localstack = new LocalStackContainer(
+			DockerImageName.parse("localstack/localstack:1.4.0"));
+
+	private static S3Client client;
+
+	@BeforeAll
+	static void beforeAll() {
+		// region and credentials are irrelevant for test, but must be added to make
+		// test work on environments without AWS cli configured
+		StaticCredentialsProvider credentialsProvider = StaticCredentialsProvider
+				.create(AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey()));
+		client = new CrossRegionS3Client(
+				S3Client.builder().region(Region.of(localstack.getRegion())).credentialsProvider(credentialsProvider)
+						.endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3)));
+	}
+
+	@Test
+	void utilitiesDelegateToDefaultClient() {
+		URL url = client.utilities().getUrl(r -> r.key("key").bucket("foo"));
+		assertThat(url).isNotNull();
+	}
+
+	@Test
+	void waiterDelegateToDefaultClient() {
+		AtomicReference<ResponseOrException<HeadBucketResponse>> result = new AtomicReference<>();
+		CompletableFuture.runAsync(() -> {
+			WaiterResponse<HeadBucketResponse> bucket = client.waiter().waitUntilBucketExists(r -> r.bucket("bucket"));
+			result.set(bucket.matched());
+		});
+
+		client.createBucket(r -> r.bucket("bucket"));
+
+		await().untilAsserted(() -> {
+			assertThat(result.get()).isNotNull();
+			assertThat(result.get().response()).satisfies(it -> {
+				assertThat(it).isPresent();
+			});
+		});
+	}
+
+}

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/test/java/io/awspring/cloud/s3/crossregion/CrossRegionS3ClientTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/test/java/io/awspring/cloud/s3/crossregion/CrossRegionS3ClientTests.java
@@ -18,7 +18,12 @@ package io.awspring.cloud.s3.crossregion;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,10 +37,12 @@ import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Utilities;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.waiters.S3Waiter;
 
 /**
  * Unit tests for {@link CrossRegionS3Client}. Integration testing with Localstack is not possible due to:
@@ -157,6 +164,22 @@ class CrossRegionS3ClientTests {
 		crossRegionS3Client.createBucket(r -> r.bucket("first-bucket"));
 		verify(defaultClient, times(1)).headBucket(HeadBucketRequest.builder().bucket("first-bucket").build());
 		verify(defaultClient, times(1)).createBucket(CreateBucketRequest.builder().bucket("first-bucket").build());
+	}
+
+	@Test
+	void utilitiesUsesDefaultClient() {
+		S3Utilities utilities = mock(S3Utilities.class);
+		when(defaultClient.utilities()).thenReturn(utilities);
+		crossRegionS3Client.utilities().getUrl(r -> r.bucket("first-bucket"));
+		verify(defaultClient).utilities();
+	}
+
+	@Test
+	void waiterUsesDefaultClient() {
+		S3Waiter waiter = mock(S3Waiter.class);
+		when(defaultClient.waiter()).thenReturn(waiter);
+		crossRegionS3Client.waiter().waitUntilBucketExists(r -> r.bucket("first-bucket"));
+		verify(defaultClient).waiter();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/test/resources/logback.xml
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="INFO">
+		<appender-ref ref="STDOUT"/>
+	</root>
+
+	<logger name="org.testcontainers" level="INFO"/>
+	<logger name="com.github.dockerjava" level="WARN"/>
+	<logger name="io.awspring" level="INFO"/>
+</configuration>

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Fixes #794 