### PR TITLE
Conditionally add a random UUID dedup ID if the queue isn't configured for content based deduplication

### DIFF
--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/main/java/io/awspring/cloud/s3/crossregion/AbstractCrossRegionS3Client.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/main/java/io/awspring/cloud/s3/crossregion/AbstractCrossRegionS3Client.java
@@ -16,753 +16,544 @@
 package io.awspring.cloud.s3.crossregion;
 
 import java.util.function.Function;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.services.s3.S3Client;
 
 abstract class AbstractCrossRegionS3Client implements S3Client {
 
-	abstract <R> R executeInBucketRegion(String bucket, Function<S3Client, R> fn);
-
-	abstract <R> R executeInDefaultRegion(Function<S3Client, R> fn);
-
-	@Override
-	public String serviceName() {
-		return S3Client.SERVICE_NAME;
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.AbortMultipartUploadResponse abortMultipartUpload(
-			software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.abortMultipartUpload(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse completeMultipartUpload(
-			software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.completeMultipartUpload(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.CopyObjectResponse copyObject(
-			software.amazon.awssdk.services.s3.model.CopyObjectRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.copyObject(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.CreateBucketResponse createBucket(
-			software.amazon.awssdk.services.s3.model.CreateBucketRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.createBucket(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse createMultipartUpload(
-			software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.createMultipartUpload(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteBucketResponse deleteBucket(
-			software.amazon.awssdk.services.s3.model.DeleteBucketRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucket(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteBucketAnalyticsConfigurationResponse deleteBucketAnalyticsConfiguration(
-			software.amazon.awssdk.services.s3.model.DeleteBucketAnalyticsConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketAnalyticsConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteBucketCorsResponse deleteBucketCors(
-			software.amazon.awssdk.services.s3.model.DeleteBucketCorsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketCors(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteBucketEncryptionResponse deleteBucketEncryption(
-			software.amazon.awssdk.services.s3.model.DeleteBucketEncryptionRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketEncryption(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteBucketIntelligentTieringConfigurationResponse deleteBucketIntelligentTieringConfiguration(
-			software.amazon.awssdk.services.s3.model.DeleteBucketIntelligentTieringConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketIntelligentTieringConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteBucketInventoryConfigurationResponse deleteBucketInventoryConfiguration(
-			software.amazon.awssdk.services.s3.model.DeleteBucketInventoryConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketInventoryConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteBucketLifecycleResponse deleteBucketLifecycle(
-			software.amazon.awssdk.services.s3.model.DeleteBucketLifecycleRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketLifecycle(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteBucketMetricsConfigurationResponse deleteBucketMetricsConfiguration(
-			software.amazon.awssdk.services.s3.model.DeleteBucketMetricsConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketMetricsConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteBucketOwnershipControlsResponse deleteBucketOwnershipControls(
-			software.amazon.awssdk.services.s3.model.DeleteBucketOwnershipControlsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketOwnershipControls(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteBucketPolicyResponse deleteBucketPolicy(
-			software.amazon.awssdk.services.s3.model.DeleteBucketPolicyRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketPolicy(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteBucketReplicationResponse deleteBucketReplication(
-			software.amazon.awssdk.services.s3.model.DeleteBucketReplicationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketReplication(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteBucketTaggingResponse deleteBucketTagging(
-			software.amazon.awssdk.services.s3.model.DeleteBucketTaggingRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketTagging(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteBucketWebsiteResponse deleteBucketWebsite(
-			software.amazon.awssdk.services.s3.model.DeleteBucketWebsiteRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketWebsite(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteObjectResponse deleteObject(
-			software.amazon.awssdk.services.s3.model.DeleteObjectRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteObject(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteObjectTaggingResponse deleteObjectTagging(
-			software.amazon.awssdk.services.s3.model.DeleteObjectTaggingRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteObjectTagging(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeleteObjectsResponse deleteObjects(
-			software.amazon.awssdk.services.s3.model.DeleteObjectsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteObjects(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.DeletePublicAccessBlockResponse deletePublicAccessBlock(
-			software.amazon.awssdk.services.s3.model.DeletePublicAccessBlockRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deletePublicAccessBlock(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketAccelerateConfigurationResponse getBucketAccelerateConfiguration(
-			software.amazon.awssdk.services.s3.model.GetBucketAccelerateConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketAccelerateConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketAclResponse getBucketAcl(
-			software.amazon.awssdk.services.s3.model.GetBucketAclRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketAcl(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketAnalyticsConfigurationResponse getBucketAnalyticsConfiguration(
-			software.amazon.awssdk.services.s3.model.GetBucketAnalyticsConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketAnalyticsConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketCorsResponse getBucketCors(
-			software.amazon.awssdk.services.s3.model.GetBucketCorsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketCors(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketEncryptionResponse getBucketEncryption(
-			software.amazon.awssdk.services.s3.model.GetBucketEncryptionRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketEncryption(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketIntelligentTieringConfigurationResponse getBucketIntelligentTieringConfiguration(
-			software.amazon.awssdk.services.s3.model.GetBucketIntelligentTieringConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketIntelligentTieringConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketInventoryConfigurationResponse getBucketInventoryConfiguration(
-			software.amazon.awssdk.services.s3.model.GetBucketInventoryConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketInventoryConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketLifecycleConfigurationResponse getBucketLifecycleConfiguration(
-			software.amazon.awssdk.services.s3.model.GetBucketLifecycleConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketLifecycleConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketLocationResponse getBucketLocation(
-			software.amazon.awssdk.services.s3.model.GetBucketLocationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketLocation(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketLoggingResponse getBucketLogging(
-			software.amazon.awssdk.services.s3.model.GetBucketLoggingRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketLogging(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketMetricsConfigurationResponse getBucketMetricsConfiguration(
-			software.amazon.awssdk.services.s3.model.GetBucketMetricsConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketMetricsConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketNotificationConfigurationResponse getBucketNotificationConfiguration(
-			software.amazon.awssdk.services.s3.model.GetBucketNotificationConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketNotificationConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketOwnershipControlsResponse getBucketOwnershipControls(
-			software.amazon.awssdk.services.s3.model.GetBucketOwnershipControlsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketOwnershipControls(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketPolicyResponse getBucketPolicy(
-			software.amazon.awssdk.services.s3.model.GetBucketPolicyRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketPolicy(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketPolicyStatusResponse getBucketPolicyStatus(
-			software.amazon.awssdk.services.s3.model.GetBucketPolicyStatusRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketPolicyStatus(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketReplicationResponse getBucketReplication(
-			software.amazon.awssdk.services.s3.model.GetBucketReplicationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketReplication(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketRequestPaymentResponse getBucketRequestPayment(
-			software.amazon.awssdk.services.s3.model.GetBucketRequestPaymentRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketRequestPayment(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketTaggingResponse getBucketTagging(
-			software.amazon.awssdk.services.s3.model.GetBucketTaggingRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketTagging(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketVersioningResponse getBucketVersioning(
-			software.amazon.awssdk.services.s3.model.GetBucketVersioningRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketVersioning(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetBucketWebsiteResponse getBucketWebsite(
-			software.amazon.awssdk.services.s3.model.GetBucketWebsiteRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketWebsite(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.core.ResponseInputStream<software.amazon.awssdk.services.s3.model.GetObjectResponse> getObject(
-			software.amazon.awssdk.services.s3.model.GetObjectRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetObjectResponse getObject(
-			software.amazon.awssdk.services.s3.model.GetObjectRequest p0, java.nio.file.Path p1)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0, p1));
-	}
-
-	@Override
-	public <ReturnT> ReturnT getObject(software.amazon.awssdk.services.s3.model.GetObjectRequest p0,
-			software.amazon.awssdk.core.sync.ResponseTransformer<software.amazon.awssdk.services.s3.model.GetObjectResponse, ReturnT> p1)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0, p1));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetObjectAclResponse getObjectAcl(
-			software.amazon.awssdk.services.s3.model.GetObjectAclRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectAcl(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.core.ResponseBytes<software.amazon.awssdk.services.s3.model.GetObjectResponse> getObjectAsBytes(
-			software.amazon.awssdk.services.s3.model.GetObjectRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectAsBytes(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetObjectAttributesResponse getObjectAttributes(
-			software.amazon.awssdk.services.s3.model.GetObjectAttributesRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectAttributes(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetObjectLegalHoldResponse getObjectLegalHold(
-			software.amazon.awssdk.services.s3.model.GetObjectLegalHoldRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectLegalHold(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetObjectLockConfigurationResponse getObjectLockConfiguration(
-			software.amazon.awssdk.services.s3.model.GetObjectLockConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectLockConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetObjectRetentionResponse getObjectRetention(
-			software.amazon.awssdk.services.s3.model.GetObjectRetentionRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectRetention(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetObjectTaggingResponse getObjectTagging(
-			software.amazon.awssdk.services.s3.model.GetObjectTaggingRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTagging(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.core.ResponseInputStream<software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse> getObjectTorrent(
-			software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrent(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse getObjectTorrent(
-			software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0, java.nio.file.Path p1)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrent(p0, p1));
-	}
-
-	@Override
-	public <ReturnT> ReturnT getObjectTorrent(software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0,
-			software.amazon.awssdk.core.sync.ResponseTransformer<software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse, ReturnT> p1)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrent(p0, p1));
-	}
-
-	@Override
-	public software.amazon.awssdk.core.ResponseBytes<software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse> getObjectTorrentAsBytes(
-			software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrentAsBytes(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.GetPublicAccessBlockResponse getPublicAccessBlock(
-			software.amazon.awssdk.services.s3.model.GetPublicAccessBlockRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getPublicAccessBlock(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.HeadBucketResponse headBucket(
-			software.amazon.awssdk.services.s3.model.HeadBucketRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.headBucket(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.HeadObjectResponse headObject(
-			software.amazon.awssdk.services.s3.model.HeadObjectRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.headObject(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.ListBucketAnalyticsConfigurationsResponse listBucketAnalyticsConfigurations(
-			software.amazon.awssdk.services.s3.model.ListBucketAnalyticsConfigurationsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketAnalyticsConfigurations(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.ListBucketIntelligentTieringConfigurationsResponse listBucketIntelligentTieringConfigurations(
-			software.amazon.awssdk.services.s3.model.ListBucketIntelligentTieringConfigurationsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketIntelligentTieringConfigurations(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.ListBucketInventoryConfigurationsResponse listBucketInventoryConfigurations(
-			software.amazon.awssdk.services.s3.model.ListBucketInventoryConfigurationsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketInventoryConfigurations(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.ListBucketMetricsConfigurationsResponse listBucketMetricsConfigurations(
-			software.amazon.awssdk.services.s3.model.ListBucketMetricsConfigurationsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketMetricsConfigurations(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.ListBucketsResponse listBuckets(
-			software.amazon.awssdk.services.s3.model.ListBucketsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInDefaultRegion(s3Client -> s3Client.listBuckets(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.ListMultipartUploadsResponse listMultipartUploads(
-			software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listMultipartUploads(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.paginators.ListMultipartUploadsIterable listMultipartUploadsPaginator(
-			software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listMultipartUploadsPaginator(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse listObjectVersions(
-			software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectVersions(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.paginators.ListObjectVersionsIterable listObjectVersionsPaginator(
-			software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectVersionsPaginator(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.ListObjectsResponse listObjects(
-			software.amazon.awssdk.services.s3.model.ListObjectsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjects(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.ListObjectsV2Response listObjectsV2(
-			software.amazon.awssdk.services.s3.model.ListObjectsV2Request p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectsV2(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable listObjectsV2Paginator(
-			software.amazon.awssdk.services.s3.model.ListObjectsV2Request p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectsV2Paginator(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.ListPartsResponse listParts(
-			software.amazon.awssdk.services.s3.model.ListPartsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listParts(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.paginators.ListPartsIterable listPartsPaginator(
-			software.amazon.awssdk.services.s3.model.ListPartsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listPartsPaginator(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketAccelerateConfigurationResponse putBucketAccelerateConfiguration(
-			software.amazon.awssdk.services.s3.model.PutBucketAccelerateConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketAccelerateConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketAclResponse putBucketAcl(
-			software.amazon.awssdk.services.s3.model.PutBucketAclRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketAcl(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketAnalyticsConfigurationResponse putBucketAnalyticsConfiguration(
-			software.amazon.awssdk.services.s3.model.PutBucketAnalyticsConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketAnalyticsConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketCorsResponse putBucketCors(
-			software.amazon.awssdk.services.s3.model.PutBucketCorsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketCors(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketEncryptionResponse putBucketEncryption(
-			software.amazon.awssdk.services.s3.model.PutBucketEncryptionRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketEncryption(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketIntelligentTieringConfigurationResponse putBucketIntelligentTieringConfiguration(
-			software.amazon.awssdk.services.s3.model.PutBucketIntelligentTieringConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketIntelligentTieringConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketInventoryConfigurationResponse putBucketInventoryConfiguration(
-			software.amazon.awssdk.services.s3.model.PutBucketInventoryConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketInventoryConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketLifecycleConfigurationResponse putBucketLifecycleConfiguration(
-			software.amazon.awssdk.services.s3.model.PutBucketLifecycleConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketLifecycleConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketLoggingResponse putBucketLogging(
-			software.amazon.awssdk.services.s3.model.PutBucketLoggingRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketLogging(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketMetricsConfigurationResponse putBucketMetricsConfiguration(
-			software.amazon.awssdk.services.s3.model.PutBucketMetricsConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketMetricsConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketNotificationConfigurationResponse putBucketNotificationConfiguration(
-			software.amazon.awssdk.services.s3.model.PutBucketNotificationConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketNotificationConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketOwnershipControlsResponse putBucketOwnershipControls(
-			software.amazon.awssdk.services.s3.model.PutBucketOwnershipControlsRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketOwnershipControls(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketPolicyResponse putBucketPolicy(
-			software.amazon.awssdk.services.s3.model.PutBucketPolicyRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketPolicy(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketReplicationResponse putBucketReplication(
-			software.amazon.awssdk.services.s3.model.PutBucketReplicationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketReplication(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketRequestPaymentResponse putBucketRequestPayment(
-			software.amazon.awssdk.services.s3.model.PutBucketRequestPaymentRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketRequestPayment(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketTaggingResponse putBucketTagging(
-			software.amazon.awssdk.services.s3.model.PutBucketTaggingRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketTagging(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketVersioningResponse putBucketVersioning(
-			software.amazon.awssdk.services.s3.model.PutBucketVersioningRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketVersioning(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutBucketWebsiteResponse putBucketWebsite(
-			software.amazon.awssdk.services.s3.model.PutBucketWebsiteRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketWebsite(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutObjectResponse putObject(
-			software.amazon.awssdk.services.s3.model.PutObjectRequest p0, java.nio.file.Path p1)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObject(p0, p1));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutObjectResponse putObject(
-			software.amazon.awssdk.services.s3.model.PutObjectRequest p0,
-			software.amazon.awssdk.core.sync.RequestBody p1) throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObject(p0, p1));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutObjectAclResponse putObjectAcl(
-			software.amazon.awssdk.services.s3.model.PutObjectAclRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectAcl(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutObjectLegalHoldResponse putObjectLegalHold(
-			software.amazon.awssdk.services.s3.model.PutObjectLegalHoldRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectLegalHold(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutObjectLockConfigurationResponse putObjectLockConfiguration(
-			software.amazon.awssdk.services.s3.model.PutObjectLockConfigurationRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectLockConfiguration(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutObjectRetentionResponse putObjectRetention(
-			software.amazon.awssdk.services.s3.model.PutObjectRetentionRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectRetention(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutObjectTaggingResponse putObjectTagging(
-			software.amazon.awssdk.services.s3.model.PutObjectTaggingRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectTagging(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.PutPublicAccessBlockResponse putPublicAccessBlock(
-			software.amazon.awssdk.services.s3.model.PutPublicAccessBlockRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putPublicAccessBlock(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.RestoreObjectResponse restoreObject(
-			software.amazon.awssdk.services.s3.model.RestoreObjectRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.restoreObject(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.UploadPartResponse uploadPart(
-			software.amazon.awssdk.services.s3.model.UploadPartRequest p0, java.nio.file.Path p1)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.uploadPart(p0, p1));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.UploadPartResponse uploadPart(
-			software.amazon.awssdk.services.s3.model.UploadPartRequest p0,
-			software.amazon.awssdk.core.sync.RequestBody p1) throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.uploadPart(p0, p1));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.UploadPartCopyResponse uploadPartCopy(
-			software.amazon.awssdk.services.s3.model.UploadPartCopyRequest p0)
-			throws AwsServiceException, SdkClientException {
-		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.uploadPartCopy(p0));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.WriteGetObjectResponseResponse writeGetObjectResponse(
-			software.amazon.awssdk.services.s3.model.WriteGetObjectResponseRequest p0, java.nio.file.Path p1)
-			throws AwsServiceException, SdkClientException {
-		return executeInDefaultRegion(s3Client -> s3Client.writeGetObjectResponse(p0, p1));
-	}
-
-	@Override
-	public software.amazon.awssdk.services.s3.model.WriteGetObjectResponseResponse writeGetObjectResponse(
-			software.amazon.awssdk.services.s3.model.WriteGetObjectResponseRequest p0,
-			software.amazon.awssdk.core.sync.RequestBody p1) throws AwsServiceException, SdkClientException {
-		return executeInDefaultRegion(s3Client -> s3Client.writeGetObjectResponse(p0, p1));
-	}
+    abstract <R> R executeInBucketRegion(String bucket, Function<S3Client, R> fn);
+
+    abstract <R> R executeInDefaultRegion(Function<S3Client, R> fn);
+
+    @Override
+    public String serviceName() {
+        return S3Client.SERVICE_NAME;
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.AbortMultipartUploadResponse abortMultipartUpload(software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.abortMultipartUpload(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse completeMultipartUpload(software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.completeMultipartUpload(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.CopyObjectResponse copyObject(software.amazon.awssdk.services.s3.model.CopyObjectRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.copyObject(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.CreateBucketResponse createBucket(software.amazon.awssdk.services.s3.model.CreateBucketRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.createBucket(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse createMultipartUpload(software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.createMultipartUpload(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteBucketResponse deleteBucket(software.amazon.awssdk.services.s3.model.DeleteBucketRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucket(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteBucketAnalyticsConfigurationResponse deleteBucketAnalyticsConfiguration(software.amazon.awssdk.services.s3.model.DeleteBucketAnalyticsConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketAnalyticsConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteBucketCorsResponse deleteBucketCors(software.amazon.awssdk.services.s3.model.DeleteBucketCorsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketCors(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteBucketEncryptionResponse deleteBucketEncryption(software.amazon.awssdk.services.s3.model.DeleteBucketEncryptionRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketEncryption(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteBucketIntelligentTieringConfigurationResponse deleteBucketIntelligentTieringConfiguration(software.amazon.awssdk.services.s3.model.DeleteBucketIntelligentTieringConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketIntelligentTieringConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteBucketInventoryConfigurationResponse deleteBucketInventoryConfiguration(software.amazon.awssdk.services.s3.model.DeleteBucketInventoryConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketInventoryConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteBucketLifecycleResponse deleteBucketLifecycle(software.amazon.awssdk.services.s3.model.DeleteBucketLifecycleRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketLifecycle(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteBucketMetricsConfigurationResponse deleteBucketMetricsConfiguration(software.amazon.awssdk.services.s3.model.DeleteBucketMetricsConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketMetricsConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteBucketOwnershipControlsResponse deleteBucketOwnershipControls(software.amazon.awssdk.services.s3.model.DeleteBucketOwnershipControlsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketOwnershipControls(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteBucketPolicyResponse deleteBucketPolicy(software.amazon.awssdk.services.s3.model.DeleteBucketPolicyRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketPolicy(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteBucketReplicationResponse deleteBucketReplication(software.amazon.awssdk.services.s3.model.DeleteBucketReplicationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketReplication(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteBucketTaggingResponse deleteBucketTagging(software.amazon.awssdk.services.s3.model.DeleteBucketTaggingRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketTagging(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteBucketWebsiteResponse deleteBucketWebsite(software.amazon.awssdk.services.s3.model.DeleteBucketWebsiteRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketWebsite(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteObjectResponse deleteObject(software.amazon.awssdk.services.s3.model.DeleteObjectRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteObject(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteObjectTaggingResponse deleteObjectTagging(software.amazon.awssdk.services.s3.model.DeleteObjectTaggingRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteObjectTagging(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeleteObjectsResponse deleteObjects(software.amazon.awssdk.services.s3.model.DeleteObjectsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteObjects(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.DeletePublicAccessBlockResponse deletePublicAccessBlock(software.amazon.awssdk.services.s3.model.DeletePublicAccessBlockRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deletePublicAccessBlock(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketAccelerateConfigurationResponse getBucketAccelerateConfiguration(software.amazon.awssdk.services.s3.model.GetBucketAccelerateConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketAccelerateConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketAclResponse getBucketAcl(software.amazon.awssdk.services.s3.model.GetBucketAclRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketAcl(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketAnalyticsConfigurationResponse getBucketAnalyticsConfiguration(software.amazon.awssdk.services.s3.model.GetBucketAnalyticsConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketAnalyticsConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketCorsResponse getBucketCors(software.amazon.awssdk.services.s3.model.GetBucketCorsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketCors(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketEncryptionResponse getBucketEncryption(software.amazon.awssdk.services.s3.model.GetBucketEncryptionRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketEncryption(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketIntelligentTieringConfigurationResponse getBucketIntelligentTieringConfiguration(software.amazon.awssdk.services.s3.model.GetBucketIntelligentTieringConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketIntelligentTieringConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketInventoryConfigurationResponse getBucketInventoryConfiguration(software.amazon.awssdk.services.s3.model.GetBucketInventoryConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketInventoryConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketLifecycleConfigurationResponse getBucketLifecycleConfiguration(software.amazon.awssdk.services.s3.model.GetBucketLifecycleConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketLifecycleConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketLocationResponse getBucketLocation(software.amazon.awssdk.services.s3.model.GetBucketLocationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketLocation(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketLoggingResponse getBucketLogging(software.amazon.awssdk.services.s3.model.GetBucketLoggingRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketLogging(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketMetricsConfigurationResponse getBucketMetricsConfiguration(software.amazon.awssdk.services.s3.model.GetBucketMetricsConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketMetricsConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketNotificationConfigurationResponse getBucketNotificationConfiguration(software.amazon.awssdk.services.s3.model.GetBucketNotificationConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketNotificationConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketOwnershipControlsResponse getBucketOwnershipControls(software.amazon.awssdk.services.s3.model.GetBucketOwnershipControlsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketOwnershipControls(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketPolicyResponse getBucketPolicy(software.amazon.awssdk.services.s3.model.GetBucketPolicyRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketPolicy(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketPolicyStatusResponse getBucketPolicyStatus(software.amazon.awssdk.services.s3.model.GetBucketPolicyStatusRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketPolicyStatus(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketReplicationResponse getBucketReplication(software.amazon.awssdk.services.s3.model.GetBucketReplicationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketReplication(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketRequestPaymentResponse getBucketRequestPayment(software.amazon.awssdk.services.s3.model.GetBucketRequestPaymentRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketRequestPayment(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketTaggingResponse getBucketTagging(software.amazon.awssdk.services.s3.model.GetBucketTaggingRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketTagging(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketVersioningResponse getBucketVersioning(software.amazon.awssdk.services.s3.model.GetBucketVersioningRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketVersioning(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetBucketWebsiteResponse getBucketWebsite(software.amazon.awssdk.services.s3.model.GetBucketWebsiteRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketWebsite(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.core.ResponseInputStream<software.amazon.awssdk.services.s3.model.GetObjectResponse> getObject(software.amazon.awssdk.services.s3.model.GetObjectRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetObjectResponse getObject(software.amazon.awssdk.services.s3.model.GetObjectRequest p0, java.nio.file.Path p1) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0, p1));
+    }
+
+    @Override
+    public <ReturnT> ReturnT getObject(software.amazon.awssdk.services.s3.model.GetObjectRequest p0, software.amazon.awssdk.core.sync.ResponseTransformer<software.amazon.awssdk.services.s3.model.GetObjectResponse, ReturnT> p1) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0, p1));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetObjectAclResponse getObjectAcl(software.amazon.awssdk.services.s3.model.GetObjectAclRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectAcl(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.core.ResponseBytes<software.amazon.awssdk.services.s3.model.GetObjectResponse> getObjectAsBytes(software.amazon.awssdk.services.s3.model.GetObjectRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectAsBytes(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetObjectAttributesResponse getObjectAttributes(software.amazon.awssdk.services.s3.model.GetObjectAttributesRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectAttributes(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetObjectLegalHoldResponse getObjectLegalHold(software.amazon.awssdk.services.s3.model.GetObjectLegalHoldRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectLegalHold(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetObjectLockConfigurationResponse getObjectLockConfiguration(software.amazon.awssdk.services.s3.model.GetObjectLockConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectLockConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetObjectRetentionResponse getObjectRetention(software.amazon.awssdk.services.s3.model.GetObjectRetentionRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectRetention(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetObjectTaggingResponse getObjectTagging(software.amazon.awssdk.services.s3.model.GetObjectTaggingRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTagging(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.core.ResponseInputStream<software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse> getObjectTorrent(software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrent(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse getObjectTorrent(software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0, java.nio.file.Path p1) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrent(p0, p1));
+    }
+
+    @Override
+    public <ReturnT> ReturnT getObjectTorrent(software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0, software.amazon.awssdk.core.sync.ResponseTransformer<software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse, ReturnT> p1) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrent(p0, p1));
+    }
+
+    @Override
+    public software.amazon.awssdk.core.ResponseBytes<software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse> getObjectTorrentAsBytes(software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrentAsBytes(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.GetPublicAccessBlockResponse getPublicAccessBlock(software.amazon.awssdk.services.s3.model.GetPublicAccessBlockRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getPublicAccessBlock(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.HeadBucketResponse headBucket(software.amazon.awssdk.services.s3.model.HeadBucketRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.headBucket(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.HeadObjectResponse headObject(software.amazon.awssdk.services.s3.model.HeadObjectRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.headObject(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.ListBucketAnalyticsConfigurationsResponse listBucketAnalyticsConfigurations(software.amazon.awssdk.services.s3.model.ListBucketAnalyticsConfigurationsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketAnalyticsConfigurations(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.ListBucketIntelligentTieringConfigurationsResponse listBucketIntelligentTieringConfigurations(software.amazon.awssdk.services.s3.model.ListBucketIntelligentTieringConfigurationsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketIntelligentTieringConfigurations(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.ListBucketInventoryConfigurationsResponse listBucketInventoryConfigurations(software.amazon.awssdk.services.s3.model.ListBucketInventoryConfigurationsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketInventoryConfigurations(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.ListBucketMetricsConfigurationsResponse listBucketMetricsConfigurations(software.amazon.awssdk.services.s3.model.ListBucketMetricsConfigurationsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketMetricsConfigurations(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.ListBucketsResponse listBuckets(software.amazon.awssdk.services.s3.model.ListBucketsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInDefaultRegion(s3Client -> s3Client.listBuckets(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.ListMultipartUploadsResponse listMultipartUploads(software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listMultipartUploads(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.paginators.ListMultipartUploadsIterable listMultipartUploadsPaginator(software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listMultipartUploadsPaginator(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse listObjectVersions(software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectVersions(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.paginators.ListObjectVersionsIterable listObjectVersionsPaginator(software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectVersionsPaginator(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.ListObjectsResponse listObjects(software.amazon.awssdk.services.s3.model.ListObjectsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjects(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.ListObjectsV2Response listObjectsV2(software.amazon.awssdk.services.s3.model.ListObjectsV2Request p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectsV2(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable listObjectsV2Paginator(software.amazon.awssdk.services.s3.model.ListObjectsV2Request p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectsV2Paginator(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.ListPartsResponse listParts(software.amazon.awssdk.services.s3.model.ListPartsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listParts(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.paginators.ListPartsIterable listPartsPaginator(software.amazon.awssdk.services.s3.model.ListPartsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listPartsPaginator(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketAccelerateConfigurationResponse putBucketAccelerateConfiguration(software.amazon.awssdk.services.s3.model.PutBucketAccelerateConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketAccelerateConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketAclResponse putBucketAcl(software.amazon.awssdk.services.s3.model.PutBucketAclRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketAcl(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketAnalyticsConfigurationResponse putBucketAnalyticsConfiguration(software.amazon.awssdk.services.s3.model.PutBucketAnalyticsConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketAnalyticsConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketCorsResponse putBucketCors(software.amazon.awssdk.services.s3.model.PutBucketCorsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketCors(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketEncryptionResponse putBucketEncryption(software.amazon.awssdk.services.s3.model.PutBucketEncryptionRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketEncryption(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketIntelligentTieringConfigurationResponse putBucketIntelligentTieringConfiguration(software.amazon.awssdk.services.s3.model.PutBucketIntelligentTieringConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketIntelligentTieringConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketInventoryConfigurationResponse putBucketInventoryConfiguration(software.amazon.awssdk.services.s3.model.PutBucketInventoryConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketInventoryConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketLifecycleConfigurationResponse putBucketLifecycleConfiguration(software.amazon.awssdk.services.s3.model.PutBucketLifecycleConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketLifecycleConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketLoggingResponse putBucketLogging(software.amazon.awssdk.services.s3.model.PutBucketLoggingRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketLogging(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketMetricsConfigurationResponse putBucketMetricsConfiguration(software.amazon.awssdk.services.s3.model.PutBucketMetricsConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketMetricsConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketNotificationConfigurationResponse putBucketNotificationConfiguration(software.amazon.awssdk.services.s3.model.PutBucketNotificationConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketNotificationConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketOwnershipControlsResponse putBucketOwnershipControls(software.amazon.awssdk.services.s3.model.PutBucketOwnershipControlsRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketOwnershipControls(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketPolicyResponse putBucketPolicy(software.amazon.awssdk.services.s3.model.PutBucketPolicyRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketPolicy(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketReplicationResponse putBucketReplication(software.amazon.awssdk.services.s3.model.PutBucketReplicationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketReplication(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketRequestPaymentResponse putBucketRequestPayment(software.amazon.awssdk.services.s3.model.PutBucketRequestPaymentRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketRequestPayment(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketTaggingResponse putBucketTagging(software.amazon.awssdk.services.s3.model.PutBucketTaggingRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketTagging(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketVersioningResponse putBucketVersioning(software.amazon.awssdk.services.s3.model.PutBucketVersioningRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketVersioning(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutBucketWebsiteResponse putBucketWebsite(software.amazon.awssdk.services.s3.model.PutBucketWebsiteRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketWebsite(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutObjectResponse putObject(software.amazon.awssdk.services.s3.model.PutObjectRequest p0, java.nio.file.Path p1) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObject(p0, p1));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutObjectResponse putObject(software.amazon.awssdk.services.s3.model.PutObjectRequest p0, software.amazon.awssdk.core.sync.RequestBody p1) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObject(p0, p1));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutObjectAclResponse putObjectAcl(software.amazon.awssdk.services.s3.model.PutObjectAclRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectAcl(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutObjectLegalHoldResponse putObjectLegalHold(software.amazon.awssdk.services.s3.model.PutObjectLegalHoldRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectLegalHold(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutObjectLockConfigurationResponse putObjectLockConfiguration(software.amazon.awssdk.services.s3.model.PutObjectLockConfigurationRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectLockConfiguration(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutObjectRetentionResponse putObjectRetention(software.amazon.awssdk.services.s3.model.PutObjectRetentionRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectRetention(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutObjectTaggingResponse putObjectTagging(software.amazon.awssdk.services.s3.model.PutObjectTaggingRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectTagging(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.PutPublicAccessBlockResponse putPublicAccessBlock(software.amazon.awssdk.services.s3.model.PutPublicAccessBlockRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putPublicAccessBlock(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.RestoreObjectResponse restoreObject(software.amazon.awssdk.services.s3.model.RestoreObjectRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.restoreObject(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.UploadPartResponse uploadPart(software.amazon.awssdk.services.s3.model.UploadPartRequest p0, java.nio.file.Path p1) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.uploadPart(p0, p1));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.UploadPartResponse uploadPart(software.amazon.awssdk.services.s3.model.UploadPartRequest p0, software.amazon.awssdk.core.sync.RequestBody p1) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.uploadPart(p0, p1));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.UploadPartCopyResponse uploadPartCopy(software.amazon.awssdk.services.s3.model.UploadPartCopyRequest p0) throws AwsServiceException, SdkClientException {
+        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.uploadPartCopy(p0));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.WriteGetObjectResponseResponse writeGetObjectResponse(software.amazon.awssdk.services.s3.model.WriteGetObjectResponseRequest p0, java.nio.file.Path p1) throws AwsServiceException, SdkClientException {
+        return executeInDefaultRegion(s3Client -> s3Client.writeGetObjectResponse(p0, p1));
+    }
+
+    @Override
+    public software.amazon.awssdk.services.s3.model.WriteGetObjectResponseResponse writeGetObjectResponse(software.amazon.awssdk.services.s3.model.WriteGetObjectResponseRequest p0, software.amazon.awssdk.core.sync.RequestBody p1) throws AwsServiceException, SdkClientException {
+        return executeInDefaultRegion(s3Client -> s3Client.writeGetObjectResponse(p0, p1));
+    }
 }
+

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/main/java/io/awspring/cloud/s3/crossregion/AbstractCrossRegionS3Client.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/main/java/io/awspring/cloud/s3/crossregion/AbstractCrossRegionS3Client.java
@@ -16,544 +16,753 @@
 package io.awspring.cloud.s3.crossregion;
 
 import java.util.function.Function;
-import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3Client;
 
 abstract class AbstractCrossRegionS3Client implements S3Client {
 
-    abstract <R> R executeInBucketRegion(String bucket, Function<S3Client, R> fn);
-
-    abstract <R> R executeInDefaultRegion(Function<S3Client, R> fn);
-
-    @Override
-    public String serviceName() {
-        return S3Client.SERVICE_NAME;
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.AbortMultipartUploadResponse abortMultipartUpload(software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.abortMultipartUpload(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse completeMultipartUpload(software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.completeMultipartUpload(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.CopyObjectResponse copyObject(software.amazon.awssdk.services.s3.model.CopyObjectRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.copyObject(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.CreateBucketResponse createBucket(software.amazon.awssdk.services.s3.model.CreateBucketRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.createBucket(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse createMultipartUpload(software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.createMultipartUpload(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteBucketResponse deleteBucket(software.amazon.awssdk.services.s3.model.DeleteBucketRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucket(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteBucketAnalyticsConfigurationResponse deleteBucketAnalyticsConfiguration(software.amazon.awssdk.services.s3.model.DeleteBucketAnalyticsConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketAnalyticsConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteBucketCorsResponse deleteBucketCors(software.amazon.awssdk.services.s3.model.DeleteBucketCorsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketCors(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteBucketEncryptionResponse deleteBucketEncryption(software.amazon.awssdk.services.s3.model.DeleteBucketEncryptionRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketEncryption(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteBucketIntelligentTieringConfigurationResponse deleteBucketIntelligentTieringConfiguration(software.amazon.awssdk.services.s3.model.DeleteBucketIntelligentTieringConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketIntelligentTieringConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteBucketInventoryConfigurationResponse deleteBucketInventoryConfiguration(software.amazon.awssdk.services.s3.model.DeleteBucketInventoryConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketInventoryConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteBucketLifecycleResponse deleteBucketLifecycle(software.amazon.awssdk.services.s3.model.DeleteBucketLifecycleRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketLifecycle(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteBucketMetricsConfigurationResponse deleteBucketMetricsConfiguration(software.amazon.awssdk.services.s3.model.DeleteBucketMetricsConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketMetricsConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteBucketOwnershipControlsResponse deleteBucketOwnershipControls(software.amazon.awssdk.services.s3.model.DeleteBucketOwnershipControlsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketOwnershipControls(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteBucketPolicyResponse deleteBucketPolicy(software.amazon.awssdk.services.s3.model.DeleteBucketPolicyRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketPolicy(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteBucketReplicationResponse deleteBucketReplication(software.amazon.awssdk.services.s3.model.DeleteBucketReplicationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketReplication(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteBucketTaggingResponse deleteBucketTagging(software.amazon.awssdk.services.s3.model.DeleteBucketTaggingRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketTagging(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteBucketWebsiteResponse deleteBucketWebsite(software.amazon.awssdk.services.s3.model.DeleteBucketWebsiteRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketWebsite(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteObjectResponse deleteObject(software.amazon.awssdk.services.s3.model.DeleteObjectRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteObject(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteObjectTaggingResponse deleteObjectTagging(software.amazon.awssdk.services.s3.model.DeleteObjectTaggingRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteObjectTagging(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeleteObjectsResponse deleteObjects(software.amazon.awssdk.services.s3.model.DeleteObjectsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteObjects(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.DeletePublicAccessBlockResponse deletePublicAccessBlock(software.amazon.awssdk.services.s3.model.DeletePublicAccessBlockRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deletePublicAccessBlock(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketAccelerateConfigurationResponse getBucketAccelerateConfiguration(software.amazon.awssdk.services.s3.model.GetBucketAccelerateConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketAccelerateConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketAclResponse getBucketAcl(software.amazon.awssdk.services.s3.model.GetBucketAclRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketAcl(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketAnalyticsConfigurationResponse getBucketAnalyticsConfiguration(software.amazon.awssdk.services.s3.model.GetBucketAnalyticsConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketAnalyticsConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketCorsResponse getBucketCors(software.amazon.awssdk.services.s3.model.GetBucketCorsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketCors(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketEncryptionResponse getBucketEncryption(software.amazon.awssdk.services.s3.model.GetBucketEncryptionRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketEncryption(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketIntelligentTieringConfigurationResponse getBucketIntelligentTieringConfiguration(software.amazon.awssdk.services.s3.model.GetBucketIntelligentTieringConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketIntelligentTieringConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketInventoryConfigurationResponse getBucketInventoryConfiguration(software.amazon.awssdk.services.s3.model.GetBucketInventoryConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketInventoryConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketLifecycleConfigurationResponse getBucketLifecycleConfiguration(software.amazon.awssdk.services.s3.model.GetBucketLifecycleConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketLifecycleConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketLocationResponse getBucketLocation(software.amazon.awssdk.services.s3.model.GetBucketLocationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketLocation(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketLoggingResponse getBucketLogging(software.amazon.awssdk.services.s3.model.GetBucketLoggingRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketLogging(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketMetricsConfigurationResponse getBucketMetricsConfiguration(software.amazon.awssdk.services.s3.model.GetBucketMetricsConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketMetricsConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketNotificationConfigurationResponse getBucketNotificationConfiguration(software.amazon.awssdk.services.s3.model.GetBucketNotificationConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketNotificationConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketOwnershipControlsResponse getBucketOwnershipControls(software.amazon.awssdk.services.s3.model.GetBucketOwnershipControlsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketOwnershipControls(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketPolicyResponse getBucketPolicy(software.amazon.awssdk.services.s3.model.GetBucketPolicyRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketPolicy(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketPolicyStatusResponse getBucketPolicyStatus(software.amazon.awssdk.services.s3.model.GetBucketPolicyStatusRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketPolicyStatus(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketReplicationResponse getBucketReplication(software.amazon.awssdk.services.s3.model.GetBucketReplicationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketReplication(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketRequestPaymentResponse getBucketRequestPayment(software.amazon.awssdk.services.s3.model.GetBucketRequestPaymentRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketRequestPayment(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketTaggingResponse getBucketTagging(software.amazon.awssdk.services.s3.model.GetBucketTaggingRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketTagging(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketVersioningResponse getBucketVersioning(software.amazon.awssdk.services.s3.model.GetBucketVersioningRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketVersioning(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetBucketWebsiteResponse getBucketWebsite(software.amazon.awssdk.services.s3.model.GetBucketWebsiteRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketWebsite(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.core.ResponseInputStream<software.amazon.awssdk.services.s3.model.GetObjectResponse> getObject(software.amazon.awssdk.services.s3.model.GetObjectRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetObjectResponse getObject(software.amazon.awssdk.services.s3.model.GetObjectRequest p0, java.nio.file.Path p1) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0, p1));
-    }
-
-    @Override
-    public <ReturnT> ReturnT getObject(software.amazon.awssdk.services.s3.model.GetObjectRequest p0, software.amazon.awssdk.core.sync.ResponseTransformer<software.amazon.awssdk.services.s3.model.GetObjectResponse, ReturnT> p1) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0, p1));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetObjectAclResponse getObjectAcl(software.amazon.awssdk.services.s3.model.GetObjectAclRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectAcl(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.core.ResponseBytes<software.amazon.awssdk.services.s3.model.GetObjectResponse> getObjectAsBytes(software.amazon.awssdk.services.s3.model.GetObjectRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectAsBytes(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetObjectAttributesResponse getObjectAttributes(software.amazon.awssdk.services.s3.model.GetObjectAttributesRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectAttributes(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetObjectLegalHoldResponse getObjectLegalHold(software.amazon.awssdk.services.s3.model.GetObjectLegalHoldRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectLegalHold(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetObjectLockConfigurationResponse getObjectLockConfiguration(software.amazon.awssdk.services.s3.model.GetObjectLockConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectLockConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetObjectRetentionResponse getObjectRetention(software.amazon.awssdk.services.s3.model.GetObjectRetentionRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectRetention(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetObjectTaggingResponse getObjectTagging(software.amazon.awssdk.services.s3.model.GetObjectTaggingRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTagging(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.core.ResponseInputStream<software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse> getObjectTorrent(software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrent(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse getObjectTorrent(software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0, java.nio.file.Path p1) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrent(p0, p1));
-    }
-
-    @Override
-    public <ReturnT> ReturnT getObjectTorrent(software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0, software.amazon.awssdk.core.sync.ResponseTransformer<software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse, ReturnT> p1) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrent(p0, p1));
-    }
-
-    @Override
-    public software.amazon.awssdk.core.ResponseBytes<software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse> getObjectTorrentAsBytes(software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrentAsBytes(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.GetPublicAccessBlockResponse getPublicAccessBlock(software.amazon.awssdk.services.s3.model.GetPublicAccessBlockRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getPublicAccessBlock(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.HeadBucketResponse headBucket(software.amazon.awssdk.services.s3.model.HeadBucketRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.headBucket(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.HeadObjectResponse headObject(software.amazon.awssdk.services.s3.model.HeadObjectRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.headObject(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.ListBucketAnalyticsConfigurationsResponse listBucketAnalyticsConfigurations(software.amazon.awssdk.services.s3.model.ListBucketAnalyticsConfigurationsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketAnalyticsConfigurations(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.ListBucketIntelligentTieringConfigurationsResponse listBucketIntelligentTieringConfigurations(software.amazon.awssdk.services.s3.model.ListBucketIntelligentTieringConfigurationsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketIntelligentTieringConfigurations(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.ListBucketInventoryConfigurationsResponse listBucketInventoryConfigurations(software.amazon.awssdk.services.s3.model.ListBucketInventoryConfigurationsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketInventoryConfigurations(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.ListBucketMetricsConfigurationsResponse listBucketMetricsConfigurations(software.amazon.awssdk.services.s3.model.ListBucketMetricsConfigurationsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketMetricsConfigurations(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.ListBucketsResponse listBuckets(software.amazon.awssdk.services.s3.model.ListBucketsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInDefaultRegion(s3Client -> s3Client.listBuckets(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.ListMultipartUploadsResponse listMultipartUploads(software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listMultipartUploads(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.paginators.ListMultipartUploadsIterable listMultipartUploadsPaginator(software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listMultipartUploadsPaginator(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse listObjectVersions(software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectVersions(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.paginators.ListObjectVersionsIterable listObjectVersionsPaginator(software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectVersionsPaginator(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.ListObjectsResponse listObjects(software.amazon.awssdk.services.s3.model.ListObjectsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjects(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.ListObjectsV2Response listObjectsV2(software.amazon.awssdk.services.s3.model.ListObjectsV2Request p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectsV2(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable listObjectsV2Paginator(software.amazon.awssdk.services.s3.model.ListObjectsV2Request p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectsV2Paginator(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.ListPartsResponse listParts(software.amazon.awssdk.services.s3.model.ListPartsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listParts(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.paginators.ListPartsIterable listPartsPaginator(software.amazon.awssdk.services.s3.model.ListPartsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listPartsPaginator(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketAccelerateConfigurationResponse putBucketAccelerateConfiguration(software.amazon.awssdk.services.s3.model.PutBucketAccelerateConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketAccelerateConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketAclResponse putBucketAcl(software.amazon.awssdk.services.s3.model.PutBucketAclRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketAcl(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketAnalyticsConfigurationResponse putBucketAnalyticsConfiguration(software.amazon.awssdk.services.s3.model.PutBucketAnalyticsConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketAnalyticsConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketCorsResponse putBucketCors(software.amazon.awssdk.services.s3.model.PutBucketCorsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketCors(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketEncryptionResponse putBucketEncryption(software.amazon.awssdk.services.s3.model.PutBucketEncryptionRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketEncryption(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketIntelligentTieringConfigurationResponse putBucketIntelligentTieringConfiguration(software.amazon.awssdk.services.s3.model.PutBucketIntelligentTieringConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketIntelligentTieringConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketInventoryConfigurationResponse putBucketInventoryConfiguration(software.amazon.awssdk.services.s3.model.PutBucketInventoryConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketInventoryConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketLifecycleConfigurationResponse putBucketLifecycleConfiguration(software.amazon.awssdk.services.s3.model.PutBucketLifecycleConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketLifecycleConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketLoggingResponse putBucketLogging(software.amazon.awssdk.services.s3.model.PutBucketLoggingRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketLogging(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketMetricsConfigurationResponse putBucketMetricsConfiguration(software.amazon.awssdk.services.s3.model.PutBucketMetricsConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketMetricsConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketNotificationConfigurationResponse putBucketNotificationConfiguration(software.amazon.awssdk.services.s3.model.PutBucketNotificationConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketNotificationConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketOwnershipControlsResponse putBucketOwnershipControls(software.amazon.awssdk.services.s3.model.PutBucketOwnershipControlsRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketOwnershipControls(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketPolicyResponse putBucketPolicy(software.amazon.awssdk.services.s3.model.PutBucketPolicyRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketPolicy(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketReplicationResponse putBucketReplication(software.amazon.awssdk.services.s3.model.PutBucketReplicationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketReplication(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketRequestPaymentResponse putBucketRequestPayment(software.amazon.awssdk.services.s3.model.PutBucketRequestPaymentRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketRequestPayment(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketTaggingResponse putBucketTagging(software.amazon.awssdk.services.s3.model.PutBucketTaggingRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketTagging(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketVersioningResponse putBucketVersioning(software.amazon.awssdk.services.s3.model.PutBucketVersioningRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketVersioning(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutBucketWebsiteResponse putBucketWebsite(software.amazon.awssdk.services.s3.model.PutBucketWebsiteRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketWebsite(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutObjectResponse putObject(software.amazon.awssdk.services.s3.model.PutObjectRequest p0, java.nio.file.Path p1) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObject(p0, p1));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutObjectResponse putObject(software.amazon.awssdk.services.s3.model.PutObjectRequest p0, software.amazon.awssdk.core.sync.RequestBody p1) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObject(p0, p1));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutObjectAclResponse putObjectAcl(software.amazon.awssdk.services.s3.model.PutObjectAclRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectAcl(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutObjectLegalHoldResponse putObjectLegalHold(software.amazon.awssdk.services.s3.model.PutObjectLegalHoldRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectLegalHold(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutObjectLockConfigurationResponse putObjectLockConfiguration(software.amazon.awssdk.services.s3.model.PutObjectLockConfigurationRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectLockConfiguration(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutObjectRetentionResponse putObjectRetention(software.amazon.awssdk.services.s3.model.PutObjectRetentionRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectRetention(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutObjectTaggingResponse putObjectTagging(software.amazon.awssdk.services.s3.model.PutObjectTaggingRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectTagging(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.PutPublicAccessBlockResponse putPublicAccessBlock(software.amazon.awssdk.services.s3.model.PutPublicAccessBlockRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putPublicAccessBlock(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.RestoreObjectResponse restoreObject(software.amazon.awssdk.services.s3.model.RestoreObjectRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.restoreObject(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.UploadPartResponse uploadPart(software.amazon.awssdk.services.s3.model.UploadPartRequest p0, java.nio.file.Path p1) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.uploadPart(p0, p1));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.UploadPartResponse uploadPart(software.amazon.awssdk.services.s3.model.UploadPartRequest p0, software.amazon.awssdk.core.sync.RequestBody p1) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.uploadPart(p0, p1));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.UploadPartCopyResponse uploadPartCopy(software.amazon.awssdk.services.s3.model.UploadPartCopyRequest p0) throws AwsServiceException, SdkClientException {
-        return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.uploadPartCopy(p0));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.WriteGetObjectResponseResponse writeGetObjectResponse(software.amazon.awssdk.services.s3.model.WriteGetObjectResponseRequest p0, java.nio.file.Path p1) throws AwsServiceException, SdkClientException {
-        return executeInDefaultRegion(s3Client -> s3Client.writeGetObjectResponse(p0, p1));
-    }
-
-    @Override
-    public software.amazon.awssdk.services.s3.model.WriteGetObjectResponseResponse writeGetObjectResponse(software.amazon.awssdk.services.s3.model.WriteGetObjectResponseRequest p0, software.amazon.awssdk.core.sync.RequestBody p1) throws AwsServiceException, SdkClientException {
-        return executeInDefaultRegion(s3Client -> s3Client.writeGetObjectResponse(p0, p1));
-    }
+	abstract <R> R executeInBucketRegion(String bucket, Function<S3Client, R> fn);
+
+	abstract <R> R executeInDefaultRegion(Function<S3Client, R> fn);
+
+	@Override
+	public String serviceName() {
+		return S3Client.SERVICE_NAME;
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.AbortMultipartUploadResponse abortMultipartUpload(
+			software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.abortMultipartUpload(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse completeMultipartUpload(
+			software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.completeMultipartUpload(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.CopyObjectResponse copyObject(
+			software.amazon.awssdk.services.s3.model.CopyObjectRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.copyObject(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.CreateBucketResponse createBucket(
+			software.amazon.awssdk.services.s3.model.CreateBucketRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.createBucket(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse createMultipartUpload(
+			software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.createMultipartUpload(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteBucketResponse deleteBucket(
+			software.amazon.awssdk.services.s3.model.DeleteBucketRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucket(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteBucketAnalyticsConfigurationResponse deleteBucketAnalyticsConfiguration(
+			software.amazon.awssdk.services.s3.model.DeleteBucketAnalyticsConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketAnalyticsConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteBucketCorsResponse deleteBucketCors(
+			software.amazon.awssdk.services.s3.model.DeleteBucketCorsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketCors(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteBucketEncryptionResponse deleteBucketEncryption(
+			software.amazon.awssdk.services.s3.model.DeleteBucketEncryptionRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketEncryption(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteBucketIntelligentTieringConfigurationResponse deleteBucketIntelligentTieringConfiguration(
+			software.amazon.awssdk.services.s3.model.DeleteBucketIntelligentTieringConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketIntelligentTieringConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteBucketInventoryConfigurationResponse deleteBucketInventoryConfiguration(
+			software.amazon.awssdk.services.s3.model.DeleteBucketInventoryConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketInventoryConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteBucketLifecycleResponse deleteBucketLifecycle(
+			software.amazon.awssdk.services.s3.model.DeleteBucketLifecycleRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketLifecycle(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteBucketMetricsConfigurationResponse deleteBucketMetricsConfiguration(
+			software.amazon.awssdk.services.s3.model.DeleteBucketMetricsConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketMetricsConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteBucketOwnershipControlsResponse deleteBucketOwnershipControls(
+			software.amazon.awssdk.services.s3.model.DeleteBucketOwnershipControlsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketOwnershipControls(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteBucketPolicyResponse deleteBucketPolicy(
+			software.amazon.awssdk.services.s3.model.DeleteBucketPolicyRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketPolicy(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteBucketReplicationResponse deleteBucketReplication(
+			software.amazon.awssdk.services.s3.model.DeleteBucketReplicationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketReplication(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteBucketTaggingResponse deleteBucketTagging(
+			software.amazon.awssdk.services.s3.model.DeleteBucketTaggingRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketTagging(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteBucketWebsiteResponse deleteBucketWebsite(
+			software.amazon.awssdk.services.s3.model.DeleteBucketWebsiteRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteBucketWebsite(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteObjectResponse deleteObject(
+			software.amazon.awssdk.services.s3.model.DeleteObjectRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteObject(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteObjectTaggingResponse deleteObjectTagging(
+			software.amazon.awssdk.services.s3.model.DeleteObjectTaggingRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteObjectTagging(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeleteObjectsResponse deleteObjects(
+			software.amazon.awssdk.services.s3.model.DeleteObjectsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deleteObjects(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.DeletePublicAccessBlockResponse deletePublicAccessBlock(
+			software.amazon.awssdk.services.s3.model.DeletePublicAccessBlockRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.deletePublicAccessBlock(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketAccelerateConfigurationResponse getBucketAccelerateConfiguration(
+			software.amazon.awssdk.services.s3.model.GetBucketAccelerateConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketAccelerateConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketAclResponse getBucketAcl(
+			software.amazon.awssdk.services.s3.model.GetBucketAclRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketAcl(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketAnalyticsConfigurationResponse getBucketAnalyticsConfiguration(
+			software.amazon.awssdk.services.s3.model.GetBucketAnalyticsConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketAnalyticsConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketCorsResponse getBucketCors(
+			software.amazon.awssdk.services.s3.model.GetBucketCorsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketCors(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketEncryptionResponse getBucketEncryption(
+			software.amazon.awssdk.services.s3.model.GetBucketEncryptionRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketEncryption(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketIntelligentTieringConfigurationResponse getBucketIntelligentTieringConfiguration(
+			software.amazon.awssdk.services.s3.model.GetBucketIntelligentTieringConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketIntelligentTieringConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketInventoryConfigurationResponse getBucketInventoryConfiguration(
+			software.amazon.awssdk.services.s3.model.GetBucketInventoryConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketInventoryConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketLifecycleConfigurationResponse getBucketLifecycleConfiguration(
+			software.amazon.awssdk.services.s3.model.GetBucketLifecycleConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketLifecycleConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketLocationResponse getBucketLocation(
+			software.amazon.awssdk.services.s3.model.GetBucketLocationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketLocation(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketLoggingResponse getBucketLogging(
+			software.amazon.awssdk.services.s3.model.GetBucketLoggingRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketLogging(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketMetricsConfigurationResponse getBucketMetricsConfiguration(
+			software.amazon.awssdk.services.s3.model.GetBucketMetricsConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketMetricsConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketNotificationConfigurationResponse getBucketNotificationConfiguration(
+			software.amazon.awssdk.services.s3.model.GetBucketNotificationConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketNotificationConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketOwnershipControlsResponse getBucketOwnershipControls(
+			software.amazon.awssdk.services.s3.model.GetBucketOwnershipControlsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketOwnershipControls(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketPolicyResponse getBucketPolicy(
+			software.amazon.awssdk.services.s3.model.GetBucketPolicyRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketPolicy(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketPolicyStatusResponse getBucketPolicyStatus(
+			software.amazon.awssdk.services.s3.model.GetBucketPolicyStatusRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketPolicyStatus(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketReplicationResponse getBucketReplication(
+			software.amazon.awssdk.services.s3.model.GetBucketReplicationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketReplication(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketRequestPaymentResponse getBucketRequestPayment(
+			software.amazon.awssdk.services.s3.model.GetBucketRequestPaymentRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketRequestPayment(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketTaggingResponse getBucketTagging(
+			software.amazon.awssdk.services.s3.model.GetBucketTaggingRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketTagging(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketVersioningResponse getBucketVersioning(
+			software.amazon.awssdk.services.s3.model.GetBucketVersioningRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketVersioning(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetBucketWebsiteResponse getBucketWebsite(
+			software.amazon.awssdk.services.s3.model.GetBucketWebsiteRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getBucketWebsite(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.core.ResponseInputStream<software.amazon.awssdk.services.s3.model.GetObjectResponse> getObject(
+			software.amazon.awssdk.services.s3.model.GetObjectRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetObjectResponse getObject(
+			software.amazon.awssdk.services.s3.model.GetObjectRequest p0, java.nio.file.Path p1)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0, p1));
+	}
+
+	@Override
+	public <ReturnT> ReturnT getObject(software.amazon.awssdk.services.s3.model.GetObjectRequest p0,
+			software.amazon.awssdk.core.sync.ResponseTransformer<software.amazon.awssdk.services.s3.model.GetObjectResponse, ReturnT> p1)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObject(p0, p1));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetObjectAclResponse getObjectAcl(
+			software.amazon.awssdk.services.s3.model.GetObjectAclRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectAcl(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.core.ResponseBytes<software.amazon.awssdk.services.s3.model.GetObjectResponse> getObjectAsBytes(
+			software.amazon.awssdk.services.s3.model.GetObjectRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectAsBytes(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetObjectAttributesResponse getObjectAttributes(
+			software.amazon.awssdk.services.s3.model.GetObjectAttributesRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectAttributes(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetObjectLegalHoldResponse getObjectLegalHold(
+			software.amazon.awssdk.services.s3.model.GetObjectLegalHoldRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectLegalHold(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetObjectLockConfigurationResponse getObjectLockConfiguration(
+			software.amazon.awssdk.services.s3.model.GetObjectLockConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectLockConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetObjectRetentionResponse getObjectRetention(
+			software.amazon.awssdk.services.s3.model.GetObjectRetentionRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectRetention(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetObjectTaggingResponse getObjectTagging(
+			software.amazon.awssdk.services.s3.model.GetObjectTaggingRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTagging(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.core.ResponseInputStream<software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse> getObjectTorrent(
+			software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrent(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse getObjectTorrent(
+			software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0, java.nio.file.Path p1)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrent(p0, p1));
+	}
+
+	@Override
+	public <ReturnT> ReturnT getObjectTorrent(software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0,
+			software.amazon.awssdk.core.sync.ResponseTransformer<software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse, ReturnT> p1)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrent(p0, p1));
+	}
+
+	@Override
+	public software.amazon.awssdk.core.ResponseBytes<software.amazon.awssdk.services.s3.model.GetObjectTorrentResponse> getObjectTorrentAsBytes(
+			software.amazon.awssdk.services.s3.model.GetObjectTorrentRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getObjectTorrentAsBytes(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.GetPublicAccessBlockResponse getPublicAccessBlock(
+			software.amazon.awssdk.services.s3.model.GetPublicAccessBlockRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.getPublicAccessBlock(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.HeadBucketResponse headBucket(
+			software.amazon.awssdk.services.s3.model.HeadBucketRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.headBucket(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.HeadObjectResponse headObject(
+			software.amazon.awssdk.services.s3.model.HeadObjectRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.headObject(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.ListBucketAnalyticsConfigurationsResponse listBucketAnalyticsConfigurations(
+			software.amazon.awssdk.services.s3.model.ListBucketAnalyticsConfigurationsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketAnalyticsConfigurations(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.ListBucketIntelligentTieringConfigurationsResponse listBucketIntelligentTieringConfigurations(
+			software.amazon.awssdk.services.s3.model.ListBucketIntelligentTieringConfigurationsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketIntelligentTieringConfigurations(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.ListBucketInventoryConfigurationsResponse listBucketInventoryConfigurations(
+			software.amazon.awssdk.services.s3.model.ListBucketInventoryConfigurationsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketInventoryConfigurations(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.ListBucketMetricsConfigurationsResponse listBucketMetricsConfigurations(
+			software.amazon.awssdk.services.s3.model.ListBucketMetricsConfigurationsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listBucketMetricsConfigurations(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.ListBucketsResponse listBuckets(
+			software.amazon.awssdk.services.s3.model.ListBucketsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInDefaultRegion(s3Client -> s3Client.listBuckets(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.ListMultipartUploadsResponse listMultipartUploads(
+			software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listMultipartUploads(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.paginators.ListMultipartUploadsIterable listMultipartUploadsPaginator(
+			software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listMultipartUploadsPaginator(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse listObjectVersions(
+			software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectVersions(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.paginators.ListObjectVersionsIterable listObjectVersionsPaginator(
+			software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectVersionsPaginator(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.ListObjectsResponse listObjects(
+			software.amazon.awssdk.services.s3.model.ListObjectsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjects(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.ListObjectsV2Response listObjectsV2(
+			software.amazon.awssdk.services.s3.model.ListObjectsV2Request p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectsV2(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable listObjectsV2Paginator(
+			software.amazon.awssdk.services.s3.model.ListObjectsV2Request p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listObjectsV2Paginator(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.ListPartsResponse listParts(
+			software.amazon.awssdk.services.s3.model.ListPartsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listParts(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.paginators.ListPartsIterable listPartsPaginator(
+			software.amazon.awssdk.services.s3.model.ListPartsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.listPartsPaginator(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketAccelerateConfigurationResponse putBucketAccelerateConfiguration(
+			software.amazon.awssdk.services.s3.model.PutBucketAccelerateConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketAccelerateConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketAclResponse putBucketAcl(
+			software.amazon.awssdk.services.s3.model.PutBucketAclRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketAcl(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketAnalyticsConfigurationResponse putBucketAnalyticsConfiguration(
+			software.amazon.awssdk.services.s3.model.PutBucketAnalyticsConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketAnalyticsConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketCorsResponse putBucketCors(
+			software.amazon.awssdk.services.s3.model.PutBucketCorsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketCors(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketEncryptionResponse putBucketEncryption(
+			software.amazon.awssdk.services.s3.model.PutBucketEncryptionRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketEncryption(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketIntelligentTieringConfigurationResponse putBucketIntelligentTieringConfiguration(
+			software.amazon.awssdk.services.s3.model.PutBucketIntelligentTieringConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketIntelligentTieringConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketInventoryConfigurationResponse putBucketInventoryConfiguration(
+			software.amazon.awssdk.services.s3.model.PutBucketInventoryConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketInventoryConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketLifecycleConfigurationResponse putBucketLifecycleConfiguration(
+			software.amazon.awssdk.services.s3.model.PutBucketLifecycleConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketLifecycleConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketLoggingResponse putBucketLogging(
+			software.amazon.awssdk.services.s3.model.PutBucketLoggingRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketLogging(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketMetricsConfigurationResponse putBucketMetricsConfiguration(
+			software.amazon.awssdk.services.s3.model.PutBucketMetricsConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketMetricsConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketNotificationConfigurationResponse putBucketNotificationConfiguration(
+			software.amazon.awssdk.services.s3.model.PutBucketNotificationConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketNotificationConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketOwnershipControlsResponse putBucketOwnershipControls(
+			software.amazon.awssdk.services.s3.model.PutBucketOwnershipControlsRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketOwnershipControls(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketPolicyResponse putBucketPolicy(
+			software.amazon.awssdk.services.s3.model.PutBucketPolicyRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketPolicy(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketReplicationResponse putBucketReplication(
+			software.amazon.awssdk.services.s3.model.PutBucketReplicationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketReplication(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketRequestPaymentResponse putBucketRequestPayment(
+			software.amazon.awssdk.services.s3.model.PutBucketRequestPaymentRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketRequestPayment(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketTaggingResponse putBucketTagging(
+			software.amazon.awssdk.services.s3.model.PutBucketTaggingRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketTagging(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketVersioningResponse putBucketVersioning(
+			software.amazon.awssdk.services.s3.model.PutBucketVersioningRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketVersioning(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutBucketWebsiteResponse putBucketWebsite(
+			software.amazon.awssdk.services.s3.model.PutBucketWebsiteRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putBucketWebsite(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutObjectResponse putObject(
+			software.amazon.awssdk.services.s3.model.PutObjectRequest p0, java.nio.file.Path p1)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObject(p0, p1));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutObjectResponse putObject(
+			software.amazon.awssdk.services.s3.model.PutObjectRequest p0,
+			software.amazon.awssdk.core.sync.RequestBody p1) throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObject(p0, p1));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutObjectAclResponse putObjectAcl(
+			software.amazon.awssdk.services.s3.model.PutObjectAclRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectAcl(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutObjectLegalHoldResponse putObjectLegalHold(
+			software.amazon.awssdk.services.s3.model.PutObjectLegalHoldRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectLegalHold(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutObjectLockConfigurationResponse putObjectLockConfiguration(
+			software.amazon.awssdk.services.s3.model.PutObjectLockConfigurationRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectLockConfiguration(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutObjectRetentionResponse putObjectRetention(
+			software.amazon.awssdk.services.s3.model.PutObjectRetentionRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectRetention(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutObjectTaggingResponse putObjectTagging(
+			software.amazon.awssdk.services.s3.model.PutObjectTaggingRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putObjectTagging(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.PutPublicAccessBlockResponse putPublicAccessBlock(
+			software.amazon.awssdk.services.s3.model.PutPublicAccessBlockRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.putPublicAccessBlock(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.RestoreObjectResponse restoreObject(
+			software.amazon.awssdk.services.s3.model.RestoreObjectRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.restoreObject(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.UploadPartResponse uploadPart(
+			software.amazon.awssdk.services.s3.model.UploadPartRequest p0, java.nio.file.Path p1)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.uploadPart(p0, p1));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.UploadPartResponse uploadPart(
+			software.amazon.awssdk.services.s3.model.UploadPartRequest p0,
+			software.amazon.awssdk.core.sync.RequestBody p1) throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.uploadPart(p0, p1));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.UploadPartCopyResponse uploadPartCopy(
+			software.amazon.awssdk.services.s3.model.UploadPartCopyRequest p0)
+			throws AwsServiceException, SdkClientException {
+		return executeInBucketRegion(p0.bucket(), s3Client -> s3Client.uploadPartCopy(p0));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.WriteGetObjectResponseResponse writeGetObjectResponse(
+			software.amazon.awssdk.services.s3.model.WriteGetObjectResponseRequest p0, java.nio.file.Path p1)
+			throws AwsServiceException, SdkClientException {
+		return executeInDefaultRegion(s3Client -> s3Client.writeGetObjectResponse(p0, p1));
+	}
+
+	@Override
+	public software.amazon.awssdk.services.s3.model.WriteGetObjectResponseResponse writeGetObjectResponse(
+			software.amazon.awssdk.services.s3.model.WriteGetObjectResponseRequest p0,
+			software.amazon.awssdk.core.sync.RequestBody p1) throws AwsServiceException, SdkClientException {
+		return executeInDefaultRegion(s3Client -> s3Client.writeGetObjectResponse(p0, p1));
+	}
 }
-

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
@@ -159,7 +159,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		}
 		if (options.messageDeduplicationId != null) {
 			builder.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER,
-				options.messageDeduplicationId);
+					options.messageDeduplicationId);
 		}
 		if (options.messageGroupId != null) {
 			builder.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, options.messageGroupId);
@@ -174,7 +174,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 	@Override
 	public <T> Optional<org.springframework.messaging.Message<T>> receive(Consumer<SqsReceiveOptions> from,
-		Class<T> payloadClass) {
+			Class<T> payloadClass) {
 		return unwrapCompletionException(receiveAsync(from, payloadClass));
 	}
 
@@ -185,55 +185,55 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 	@Override
 	public <T> Collection<org.springframework.messaging.Message<T>> receiveMany(Consumer<SqsReceiveOptions> from,
-		Class<T> payloadClass) {
+			Class<T> payloadClass) {
 		return unwrapCompletionException(receiveManyAsync(from, payloadClass));
 	}
 
 	@Override
 	public CompletableFuture<Optional<org.springframework.messaging.Message<?>>> receiveAsync(
-		Consumer<SqsReceiveOptions> from) {
+			Consumer<SqsReceiveOptions> from) {
 		Assert.notNull(from, "from must not be null");
 		SqsReceiveOptionsImpl options = new SqsReceiveOptionsImpl();
 		from.accept(options);
 		Assert.isTrue(options.maxNumberOfMessages == null || options.maxNumberOfMessages == 1,
-			"maxNumberOfMessages must be null or 1. Use receiveMany to receive more messages.");
+				"maxNumberOfMessages must be null or 1. Use receiveMany to receive more messages.");
 		Map<String, Object> additionalHeaders = addAdditionalReceiveHeaders(options);
 		return receiveAsync(options.queue, null, options.pollTimeout, additionalHeaders);
 	}
 
 	@Override
 	public <T> CompletableFuture<Optional<org.springframework.messaging.Message<T>>> receiveAsync(
-		Consumer<SqsReceiveOptions> from, Class<T> payloadClass) {
+			Consumer<SqsReceiveOptions> from, Class<T> payloadClass) {
 		Assert.notNull(from, "from must not be null");
 		Assert.notNull(payloadClass, "payloadClass must not be null");
 		SqsReceiveOptionsImpl options = new SqsReceiveOptionsImpl();
 		from.accept(options);
 		Assert.isTrue(options.maxNumberOfMessages == null || options.maxNumberOfMessages == 1,
-			"maxNumberOfMessages must be null or 1. Use receiveMany to receive more messages.");
+				"maxNumberOfMessages must be null or 1. Use receiveMany to receive more messages.");
 		Map<String, Object> additionalHeaders = addAdditionalReceiveHeaders(options);
 		return receiveAsync(options.queue, payloadClass, options.pollTimeout, additionalHeaders)
-			.thenApply(super::castFromOptional);
+				.thenApply(super::castFromOptional);
 	}
 
 	@Override
 	public CompletableFuture<Collection<org.springframework.messaging.Message<?>>> receiveManyAsync(
-		Consumer<SqsReceiveOptions> from) {
+			Consumer<SqsReceiveOptions> from) {
 		Assert.notNull(from, "from must not be null");
 		SqsReceiveOptionsImpl options = new SqsReceiveOptionsImpl();
 		from.accept(options);
 		return receiveManyAsync(options.queue, null, options.pollTimeout, options.maxNumberOfMessages,
-			addAdditionalReceiveHeaders(options));
+				addAdditionalReceiveHeaders(options));
 	}
 
 	@Override
 	public <T> CompletableFuture<Collection<org.springframework.messaging.Message<T>>> receiveManyAsync(
-		Consumer<SqsReceiveOptions> from, Class<T> payloadClass) {
+			Consumer<SqsReceiveOptions> from, Class<T> payloadClass) {
 		Assert.notNull(from, "from must not be null");
 		Assert.notNull(payloadClass, "payloadClass must not be null");
 		SqsReceiveOptionsImpl options = new SqsReceiveOptionsImpl();
 		from.accept(options);
 		return receiveManyAsync(options.queue, payloadClass, options.pollTimeout, options.maxNumberOfMessages,
-			addAdditionalReceiveHeaders(options)).thenApply(super::castFromCollection);
+				addAdditionalReceiveHeaders(options)).thenApply(super::castFromCollection);
 	}
 
 	private Map<String, Object> addAdditionalReceiveHeaders(SqsReceiveOptionsImpl options) {
@@ -249,25 +249,25 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 	@Override
 	protected <T> org.springframework.messaging.Message<T> preProcessMessageForSend(String endpointToUse,
-		org.springframework.messaging.Message<T> message) {
+			org.springframework.messaging.Message<T> message) {
 		return FifoUtils.isFifo(endpointToUse) ? addMissingFifoSendHeaders(endpointToUse, message) : message;
 	}
 
 	@Override
 	protected <T> Collection<org.springframework.messaging.Message<T>> preProcessMessagesForSend(String endpointToUse,
-		Collection<org.springframework.messaging.Message<T>> messages) {
+			Collection<org.springframework.messaging.Message<T>> messages) {
 		return FifoUtils.isFifo(endpointToUse)
-			? messages.stream().map(message -> addMissingFifoSendHeaders(endpointToUse, message)).toList()
-			: messages;
+				? messages.stream().map(message -> addMissingFifoSendHeaders(endpointToUse, message)).toList()
+				: messages;
 	}
 
 	private <T> org.springframework.messaging.Message<T> addMissingFifoSendHeaders(String endpointName,
-		org.springframework.messaging.Message<T> message) {
+			org.springframework.messaging.Message<T> message) {
 
 		String contentBasedDedupQueueAttribute;
 		try {
 			contentBasedDedupQueueAttribute = getQueueAttributes(endpointName).get()
-				.getQueueAttribute(QueueAttributeName.CONTENT_BASED_DEDUPLICATION);
+					.getQueueAttribute(QueueAttributeName.CONTENT_BASED_DEDUPLICATION);
 		}
 		catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
@@ -283,7 +283,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		}
 		else {
 			defaultHeaders = Map.of(MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, UUID.randomUUID().toString(),
-				MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, UUID.randomUUID().toString());
+					MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, UUID.randomUUID().toString());
 		}
 
 		return MessageHeaderUtils.addHeadersIfAbsent(message, defaultHeaders);
@@ -291,86 +291,86 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 	@Override
 	protected <T> CompletableFuture<SendResult<T>> doSendAsync(String endpointName, Message message,
-		org.springframework.messaging.Message<T> originalMessage) {
+			org.springframework.messaging.Message<T> originalMessage) {
 		return createSendMessageRequest(endpointName, message).thenCompose(this.sqsAsyncClient::sendMessage)
-			.thenApply(response -> createSendResult(UUID.fromString(response.messageId()),
-				response.sequenceNumber(), endpointName, originalMessage));
+				.thenApply(response -> createSendResult(UUID.fromString(response.messageId()),
+						response.sequenceNumber(), endpointName, originalMessage));
 	}
 
 	private <T> SendResult<T> createSendResult(UUID messageId, @Nullable String sequenceNumber, String endpointName,
-		org.springframework.messaging.Message<T> originalMessage) {
+			org.springframework.messaging.Message<T> originalMessage) {
 		return new SendResult<>(messageId, endpointName, originalMessage,
-			sequenceNumber != null
-				? Collections.singletonMap(SqsTemplateParameters.SEQUENCE_NUMBER_PARAMETER_NAME, sequenceNumber)
-				: Collections.emptyMap());
+				sequenceNumber != null
+						? Collections.singletonMap(SqsTemplateParameters.SEQUENCE_NUMBER_PARAMETER_NAME, sequenceNumber)
+						: Collections.emptyMap());
 	}
 
 	private CompletableFuture<SendMessageRequest> createSendMessageRequest(String endpointName, Message message) {
 		return getQueueAttributes(endpointName)
-			.thenApply(queueAttributes -> doCreateSendMessageRequest(message, queueAttributes));
+				.thenApply(queueAttributes -> doCreateSendMessageRequest(message, queueAttributes));
 	}
 
 	private SendMessageRequest doCreateSendMessageRequest(Message message, QueueAttributes queueAttributes) {
 		return SendMessageRequest.builder().queueUrl(queueAttributes.getQueueUrl()).messageBody(message.body())
-			.messageDeduplicationId(message.attributes().get(MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID))
-			.messageGroupId(message.attributes().get(MessageSystemAttributeName.MESSAGE_GROUP_ID))
-			.delaySeconds(getDelaySeconds(message))
-			.messageAttributes(excludeKnownFields(message.messageAttributes()))
-			.messageSystemAttributes(mapMessageSystemAttributes(message)).build();
+				.messageDeduplicationId(message.attributes().get(MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID))
+				.messageGroupId(message.attributes().get(MessageSystemAttributeName.MESSAGE_GROUP_ID))
+				.delaySeconds(getDelaySeconds(message))
+				.messageAttributes(excludeKnownFields(message.messageAttributes()))
+				.messageSystemAttributes(mapMessageSystemAttributes(message)).build();
 	}
 
 	@Override
 	protected <T> CompletableFuture<SendResult.Batch<T>> doSendBatchAsync(String endpointName,
-		Collection<Message> messages, Collection<org.springframework.messaging.Message<T>> originalMessages) {
+			Collection<Message> messages, Collection<org.springframework.messaging.Message<T>> originalMessages) {
 		logger.debug("Sending messages {} to endpoint {}", messages, endpointName);
 		return createSendMessageBatchRequest(endpointName, messages).thenCompose(this.sqsAsyncClient::sendMessageBatch)
-			.thenApply(response -> createSendResultBatch(response, endpointName,
-				originalMessages.stream().collect(Collectors.toMap(MessageHeaderUtils::getId, msg -> msg))));
+				.thenApply(response -> createSendResultBatch(response, endpointName,
+						originalMessages.stream().collect(Collectors.toMap(MessageHeaderUtils::getId, msg -> msg))));
 	}
 
 	private <T> SendResult.Batch<T> createSendResultBatch(SendMessageBatchResponse response, String endpointName,
-		Map<String, org.springframework.messaging.Message<T>> originalMessagesById) {
+			Map<String, org.springframework.messaging.Message<T>> originalMessagesById) {
 		return new SendResult.Batch<>(doCreateSendResultBatch(response, endpointName, originalMessagesById),
-			createSendResultFailed(response, endpointName, originalMessagesById));
+				createSendResultFailed(response, endpointName, originalMessagesById));
 	}
 
 	private <T> Collection<SendResult.Failed<T>> createSendResultFailed(SendMessageBatchResponse response,
-		String endpointName, Map<String, org.springframework.messaging.Message<T>> originalMessagesById) {
+			String endpointName, Map<String, org.springframework.messaging.Message<T>> originalMessagesById) {
 		return response.failed().stream()
-			.map(entry -> new SendResult.Failed<>(entry.message(), endpointName,
-				originalMessagesById.get(entry.id()), Map.of(SqsTemplateParameters.SENDER_FAULT_PARAMETER_NAME,
-				entry.senderFault(), SqsTemplateParameters.ERROR_CODE_PARAMETER_NAME, entry.code())))
-			.toList();
+				.map(entry -> new SendResult.Failed<>(entry.message(), endpointName,
+						originalMessagesById.get(entry.id()), Map.of(SqsTemplateParameters.SENDER_FAULT_PARAMETER_NAME,
+								entry.senderFault(), SqsTemplateParameters.ERROR_CODE_PARAMETER_NAME, entry.code())))
+				.toList();
 	}
 
 	private <T> Collection<SendResult<T>> doCreateSendResultBatch(SendMessageBatchResponse response,
-		String endpointName, Map<String, org.springframework.messaging.Message<T>> originalMessagesById) {
+			String endpointName, Map<String, org.springframework.messaging.Message<T>> originalMessagesById) {
 		return response
-			.successful().stream().map(entry -> createSendResult(UUID.fromString(entry.messageId()),
-				entry.sequenceNumber(), endpointName, getOriginalMessage(originalMessagesById, entry)))
-			.toList();
+				.successful().stream().map(entry -> createSendResult(UUID.fromString(entry.messageId()),
+						entry.sequenceNumber(), endpointName, getOriginalMessage(originalMessagesById, entry)))
+				.toList();
 	}
 
 	private <T> org.springframework.messaging.Message<T> getOriginalMessage(
-		Map<String, org.springframework.messaging.Message<T>> originalMessagesById,
-		SendMessageBatchResultEntry entry) {
+			Map<String, org.springframework.messaging.Message<T>> originalMessagesById,
+			SendMessageBatchResultEntry entry) {
 		org.springframework.messaging.Message<T> originalMessage = originalMessagesById.get(entry.id());
 		Assert.notNull(originalMessage,
-			() -> "Could not correlate send result to original message for id %s. Original messages: %s."
-				.formatted(entry.messageId(), originalMessagesById));
+				() -> "Could not correlate send result to original message for id %s. Original messages: %s."
+						.formatted(entry.messageId(), originalMessagesById));
 		return originalMessage;
 	}
 
 	@Nullable
 	@Override
 	protected <T> MessageConversionContext getReceiveMessageConversionContext(String endpointName,
-		@Nullable Class<T> payloadClass) {
+			@Nullable Class<T> payloadClass) {
 		return this.conversionContextCache.computeIfAbsent(endpointName,
-			newEndpoint -> doGetSqsMessageConversionContext(endpointName, payloadClass));
+				newEndpoint -> doGetSqsMessageConversionContext(endpointName, payloadClass));
 	}
 
 	private <T> SqsMessageConversionContext doGetSqsMessageConversionContext(String newEndpoint,
-		@Nullable Class<T> payloadClass) {
+			@Nullable Class<T> payloadClass) {
 		SqsMessageConversionContext conversionContext = new SqsMessageConversionContext();
 		conversionContext.setSqsAsyncClient(this.sqsAsyncClient);
 		// At this point we'll already have retrieved and cached the queue attributes
@@ -385,52 +385,52 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 	}
 
 	private CompletableFuture<SendMessageBatchRequest> createSendMessageBatchRequest(String endpointName,
-		Collection<Message> messages) {
+			Collection<Message> messages) {
 		return getQueueAttributes(endpointName)
-			.thenApply(queueAttributes -> doCreateSendMessageBatchRequest(messages, queueAttributes));
+				.thenApply(queueAttributes -> doCreateSendMessageBatchRequest(messages, queueAttributes));
 	}
 
 	private SendMessageBatchRequest doCreateSendMessageBatchRequest(Collection<Message> messages,
-		QueueAttributes queueAttributes) {
+			QueueAttributes queueAttributes) {
 		return SendMessageBatchRequest.builder().queueUrl(queueAttributes.getQueueUrl())
-			.entries(messages.stream().map(this::createSendMessageBatchRequestEntry).collect(Collectors.toList()))
-			.build();
+				.entries(messages.stream().map(this::createSendMessageBatchRequestEntry).collect(Collectors.toList()))
+				.build();
 	}
 
 	private SendMessageBatchRequestEntry createSendMessageBatchRequestEntry(Message message) {
 		return SendMessageBatchRequestEntry.builder().id(message.messageId()).messageBody(message.body())
-			.messageDeduplicationId(message.attributes().get(MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID))
-			.messageGroupId(message.attributes().get(MessageSystemAttributeName.MESSAGE_GROUP_ID))
-			.delaySeconds(getDelaySeconds(message))
-			.messageAttributes(excludeKnownFields(message.messageAttributes()))
-			.messageSystemAttributes(mapMessageSystemAttributes(message)).build();
+				.messageDeduplicationId(message.attributes().get(MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID))
+				.messageGroupId(message.attributes().get(MessageSystemAttributeName.MESSAGE_GROUP_ID))
+				.delaySeconds(getDelaySeconds(message))
+				.messageAttributes(excludeKnownFields(message.messageAttributes()))
+				.messageSystemAttributes(mapMessageSystemAttributes(message)).build();
 	}
 
 	private Map<String, MessageAttributeValue> excludeKnownFields(
-		Map<String, MessageAttributeValue> messageAttributes) {
+			Map<String, MessageAttributeValue> messageAttributes) {
 		return messageAttributes.entrySet().stream()
-			.filter(entry -> !SqsHeaders.SQS_DELAY_HEADER.equals(entry.getKey()))
-			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+				.filter(entry -> !SqsHeaders.SQS_DELAY_HEADER.equals(entry.getKey()))
+				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 
 	@Nullable
 	private Integer getDelaySeconds(Message message) {
 		return message.messageAttributes().containsKey(SqsHeaders.SQS_DELAY_HEADER)
-			? Integer.parseInt(message.messageAttributes().get(SqsHeaders.SQS_DELAY_HEADER).stringValue())
-			: null;
+				? Integer.parseInt(message.messageAttributes().get(SqsHeaders.SQS_DELAY_HEADER).stringValue())
+				: null;
 	}
 
 	private Map<MessageSystemAttributeNameForSends, MessageSystemAttributeValue> mapMessageSystemAttributes(
-		Message message) {
+			Message message) {
 		return message.attributes().entrySet().stream().filter(Predicate.not(entry -> isSkipAttribute(entry.getKey())))
-			.collect(Collectors.toMap(entry -> MessageSystemAttributeNameForSends.fromValue(entry.getKey().name()),
-				entry -> MessageSystemAttributeValue.builder().dataType(MessageAttributeDataTypes.STRING)
-					.stringValue(entry.getValue()).build()));
+				.collect(Collectors.toMap(entry -> MessageSystemAttributeNameForSends.fromValue(entry.getKey().name()),
+						entry -> MessageSystemAttributeValue.builder().dataType(MessageAttributeDataTypes.STRING)
+								.stringValue(entry.getValue()).build()));
 	}
 
 	private boolean isSkipAttribute(MessageSystemAttributeName name) {
 		return MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID.equals(name)
-			|| MessageSystemAttributeName.MESSAGE_GROUP_ID.equals(name);
+				|| MessageSystemAttributeName.MESSAGE_GROUP_ID.equals(name);
 	}
 
 	private CompletableFuture<QueueAttributes> getQueueAttributes(String endpointName) {
@@ -439,8 +439,8 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 			Set<QueueAttributeName> namesToRequest = new HashSet<>(queueAttributeNames);
 			namesToRequest.add(QueueAttributeName.CONTENT_BASED_DEDUPLICATION);
 			return QueueAttributesResolver.builder().sqsAsyncClient(this.sqsAsyncClient).queueName(newName)
-				.queueNotFoundStrategy(this.queueNotFoundStrategy).queueAttributeNames(namesToRequest).build()
-				.resolveQueueAttributes();
+					.queueNotFoundStrategy(this.queueNotFoundStrategy).queueAttributeNames(namesToRequest).build()
+					.resolveQueueAttributes();
 		});
 	}
 
@@ -454,18 +454,18 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 	@Override
 	protected CompletableFuture<Void> doAcknowledgeMessages(String endpointName,
-		Collection<org.springframework.messaging.Message<?>> messages) {
+			Collection<org.springframework.messaging.Message<?>> messages) {
 		return deleteMessages(endpointName, messages);
 	}
 
 	@Override
 	protected CompletableFuture<Collection<Message>> doReceiveAsync(String endpointName, Duration pollTimeout,
-		Integer maxNumberOfMessages, Map<String, Object> additionalHeaders) {
+			Integer maxNumberOfMessages, Map<String, Object> additionalHeaders) {
 		logger.trace(
-			"Receiving messages with settings: endpointName - {}, pollTimeout - {}, maxNumberOfMessages - {}, additionalHeaders - {}",
-			endpointName, pollTimeout, maxNumberOfMessages, additionalHeaders);
+				"Receiving messages with settings: endpointName - {}, pollTimeout - {}, maxNumberOfMessages - {}, additionalHeaders - {}",
+				endpointName, pollTimeout, maxNumberOfMessages, additionalHeaders);
 		return createReceiveMessageRequest(endpointName, pollTimeout, maxNumberOfMessages, additionalHeaders)
-			.thenCompose(this.sqsAsyncClient::receiveMessage).thenApply(ReceiveMessageResponse::messages);
+				.thenCompose(this.sqsAsyncClient::receiveMessage).thenApply(ReceiveMessageResponse::messages);
 	}
 
 	@Override
@@ -479,99 +479,99 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 	}
 
 	private CompletableFuture<Void> deleteMessages(String endpointName,
-		Collection<org.springframework.messaging.Message<?>> messages) {
+			Collection<org.springframework.messaging.Message<?>> messages) {
 		logger.trace("Acknowledging in queue {} messages {}", endpointName,
-			MessageHeaderUtils.getId(addTypeToMessages(messages)));
+				MessageHeaderUtils.getId(addTypeToMessages(messages)));
 		return getQueueAttributes(endpointName)
-			.thenCompose(attributes -> this.sqsAsyncClient.deleteMessageBatch(DeleteMessageBatchRequest.builder()
-				.queueUrl(attributes.getQueueUrl()).entries(createDeleteMessageEntries(messages)).build()))
-			.exceptionallyCompose(
-				t -> createAcknowledgementException(endpointName, Collections.emptyList(), messages, t))
-			.thenCompose(response -> !response.failed().isEmpty()
-				? createAcknowledgementException(endpointName,
-				getSuccessfulAckMessages(response, messages, endpointName),
-				getFailedAckMessages(response, messages, endpointName), null)
-				: CompletableFuture.completedFuture(response))
-			.whenComplete((response, t) -> logAcknowledgement(endpointName, messages, response, t)).thenRun(() -> {
-			});
+				.thenCompose(attributes -> this.sqsAsyncClient.deleteMessageBatch(DeleteMessageBatchRequest.builder()
+						.queueUrl(attributes.getQueueUrl()).entries(createDeleteMessageEntries(messages)).build()))
+				.exceptionallyCompose(
+						t -> createAcknowledgementException(endpointName, Collections.emptyList(), messages, t))
+				.thenCompose(response -> !response.failed().isEmpty()
+						? createAcknowledgementException(endpointName,
+								getSuccessfulAckMessages(response, messages, endpointName),
+								getFailedAckMessages(response, messages, endpointName), null)
+						: CompletableFuture.completedFuture(response))
+				.whenComplete((response, t) -> logAcknowledgement(endpointName, messages, response, t)).thenRun(() -> {
+				});
 	}
 
 	private Collection<org.springframework.messaging.Message<?>> getFailedAckMessages(
-		DeleteMessageBatchResponse response, Collection<org.springframework.messaging.Message<?>> messages,
-		String endpointName) {
+			DeleteMessageBatchResponse response, Collection<org.springframework.messaging.Message<?>> messages,
+			String endpointName) {
 		return response.failed().stream().map(BatchResultErrorEntry::id)
-			.map(id -> messages.stream().filter(msg -> MessageHeaderUtils.getId(msg).equals(id)).findFirst()
-				.orElseThrow(() -> new SqsAcknowledgementException(
-					"Could not correlate ids for acknowledgement failure", Collections.emptyList(),
-					messages, endpointName)))
-			.collect(Collectors.toList());
+				.map(id -> messages.stream().filter(msg -> MessageHeaderUtils.getId(msg).equals(id)).findFirst()
+						.orElseThrow(() -> new SqsAcknowledgementException(
+								"Could not correlate ids for acknowledgement failure", Collections.emptyList(),
+								messages, endpointName)))
+				.collect(Collectors.toList());
 	}
 
 	private Collection<org.springframework.messaging.Message<?>> getSuccessfulAckMessages(
-		DeleteMessageBatchResponse response, Collection<org.springframework.messaging.Message<?>> messages,
-		String endpointName) {
+			DeleteMessageBatchResponse response, Collection<org.springframework.messaging.Message<?>> messages,
+			String endpointName) {
 		return response.successful().stream().map(DeleteMessageBatchResultEntry::id)
-			.map(id -> messages.stream().filter(msg -> MessageHeaderUtils.getId(msg).equals(id)).findFirst()
-				.orElseThrow(() -> new SqsAcknowledgementException(
-					"Could not correlate ids for acknowledgement failure", Collections.emptyList(),
-					messages, endpointName)))
-			.collect(Collectors.toList());
+				.map(id -> messages.stream().filter(msg -> MessageHeaderUtils.getId(msg).equals(id)).findFirst()
+						.orElseThrow(() -> new SqsAcknowledgementException(
+								"Could not correlate ids for acknowledgement failure", Collections.emptyList(),
+								messages, endpointName)))
+				.collect(Collectors.toList());
 	}
 
 	private CompletableFuture<DeleteMessageBatchResponse> createAcknowledgementException(String endpointName,
-		Collection<org.springframework.messaging.Message<?>> successfulAckMessages,
-		Collection<org.springframework.messaging.Message<?>> failedAckMessages, @Nullable Throwable t) {
+			Collection<org.springframework.messaging.Message<?>> successfulAckMessages,
+			Collection<org.springframework.messaging.Message<?>> failedAckMessages, @Nullable Throwable t) {
 		return CompletableFuture.failedFuture(new SqsAcknowledgementException("Error acknowledging messages",
-			successfulAckMessages, failedAckMessages, endpointName, t));
+				successfulAckMessages, failedAckMessages, endpointName, t));
 	}
 
 	private void logAcknowledgement(String endpointName, Collection<org.springframework.messaging.Message<?>> messages,
-		DeleteMessageBatchResponse response, @Nullable Throwable t) {
+			DeleteMessageBatchResponse response, @Nullable Throwable t) {
 		if (t != null) {
 			logger.error("Error acknowledging in queue {} messages {}", endpointName,
-				MessageHeaderUtils.getId(addTypeToMessages(messages)));
+					MessageHeaderUtils.getId(addTypeToMessages(messages)));
 		}
 		else if (!response.failed().isEmpty()) {
 			logger.warn("Some messages could not be acknowledged in queue {}: {}", endpointName,
-				response.failed().stream().map(BatchResultErrorEntry::id).toList());
+					response.failed().stream().map(BatchResultErrorEntry::id).toList());
 		}
 		else {
 			logger.trace("Acknowledged messages in queue {}: {}", endpointName,
-				MessageHeaderUtils.getId(addTypeToMessages(messages)));
+					MessageHeaderUtils.getId(addTypeToMessages(messages)));
 		}
 	}
 
 	private Collection<DeleteMessageBatchRequestEntry> createDeleteMessageEntries(
-		Collection<org.springframework.messaging.Message<?>> messages) {
+			Collection<org.springframework.messaging.Message<?>> messages) {
 		return messages.stream()
-			.map(message -> DeleteMessageBatchRequestEntry.builder().id(MessageHeaderUtils.getId(message))
-				.receiptHandle(
-					MessageHeaderUtils.getHeaderAsString(message, SqsHeaders.SQS_RECEIPT_HANDLE_HEADER))
-				.build())
-			.collect(Collectors.toList());
+				.map(message -> DeleteMessageBatchRequestEntry.builder().id(MessageHeaderUtils.getId(message))
+						.receiptHandle(
+								MessageHeaderUtils.getHeaderAsString(message, SqsHeaders.SQS_RECEIPT_HANDLE_HEADER))
+						.build())
+				.collect(Collectors.toList());
 	}
 
 	private CompletableFuture<ReceiveMessageRequest> createReceiveMessageRequest(String endpointName,
-		Duration pollTimeout, Integer maxNumberOfMessages, Map<String, Object> additionalHeaders) {
+			Duration pollTimeout, Integer maxNumberOfMessages, Map<String, Object> additionalHeaders) {
 		return getQueueAttributes(endpointName).thenApply(attributes -> doCreateReceiveMessageRequest(pollTimeout,
-			maxNumberOfMessages, attributes, additionalHeaders));
+				maxNumberOfMessages, attributes, additionalHeaders));
 	}
 
 	private ReceiveMessageRequest doCreateReceiveMessageRequest(Duration pollTimeout, Integer maxNumberOfMessages,
-		QueueAttributes attributes, Map<String, Object> additionalHeaders) {
+			QueueAttributes attributes, Map<String, Object> additionalHeaders) {
 		ReceiveMessageRequest.Builder builder = ReceiveMessageRequest.builder().queueUrl(attributes.getQueueUrl())
-			.maxNumberOfMessages(maxNumberOfMessages).messageAttributeNames(this.messageAttributeNames)
-			.attributeNamesWithStrings(this.messageSystemAttributeNames)
-			.waitTimeSeconds(pollTimeout.toSecondsPart());
+				.maxNumberOfMessages(maxNumberOfMessages).messageAttributeNames(this.messageAttributeNames)
+				.attributeNamesWithStrings(this.messageSystemAttributeNames)
+				.waitTimeSeconds(pollTimeout.toSecondsPart());
 		if (additionalHeaders.containsKey(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER)) {
 			builder.visibilityTimeout(
-				getValueAs(additionalHeaders, SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Duration.class)
-					.toSecondsPart());
+					getValueAs(additionalHeaders, SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Duration.class)
+							.toSecondsPart());
 		}
 		if (additionalHeaders.containsKey(SqsHeaders.SQS_RECEIVE_REQUEST_ATTEMPT_ID_HEADER)) {
 			builder.receiveRequestAttemptId(
-				getValueAs(additionalHeaders, SqsHeaders.SQS_RECEIVE_REQUEST_ATTEMPT_ID_HEADER, UUID.class)
-					.toString());
+					getValueAs(additionalHeaders, SqsHeaders.SQS_RECEIVE_REQUEST_ATTEMPT_ID_HEADER, UUID.class)
+							.toString());
 		}
 		return builder.build();
 	}
@@ -585,7 +585,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 	}
 
 	private static class SqsTemplateOptionsImpl extends AbstractMessagingTemplateOptions<SqsTemplateOptions>
-		implements SqsTemplateOptions {
+			implements SqsTemplateOptions {
 
 		private Collection<QueueAttributeName> queueAttributeNames = Collections.emptyList();
 
@@ -623,9 +623,9 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 		@Override
 		public SqsTemplateOptions messageSystemAttributeNames(
-			Collection<MessageSystemAttributeName> messageSystemAttributeNames) {
+				Collection<MessageSystemAttributeName> messageSystemAttributeNames) {
 			this.messageSystemAttributeNames = messageSystemAttributeNames.stream()
-				.map(MessageSystemAttributeName::name).toList();
+					.map(MessageSystemAttributeName::name).toList();
 			return this;
 		}
 
@@ -660,7 +660,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 		@Override
 		public SqsTemplateBuilder configureDefaultConverter(
-			Consumer<SqsMessagingMessageConverter> messageConverterConfigurer) {
+				Consumer<SqsMessagingMessageConverter> messageConverterConfigurer) {
 			Assert.notNull(messageConverterConfigurer, "messageConverterConfigurer must not be null");
 			Assert.isNull(this.messageConverter, "messageConverter already configured");
 			SqsMessagingMessageConverter defaultMessageConverter = createDefaultMessageConverter();
@@ -812,7 +812,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		public SqsReceiveOptionsImpl maxNumberOfMessages(Integer maxNumberOfMessages) {
 			Assert.notNull(maxNumberOfMessages, "maxNumberOfMessages must not be null");
 			Assert.isTrue(maxNumberOfMessages > 0 && maxNumberOfMessages <= 10,
-				"maxNumberOfMessages must be between 0 and 10");
+					"maxNumberOfMessages must be between 0 and 10");
 			this.maxNumberOfMessages = maxNumberOfMessages;
 			return this;
 		}
@@ -846,17 +846,17 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		@Override
 		public CompletableFuture<Void> onAcknowledge(org.springframework.messaging.Message<T> message) {
 			return deleteMessages(MessageHeaderUtils.getHeaderAsString(message, SqsHeaders.SQS_QUEUE_NAME_HEADER),
-				Collections.singletonList(message));
+					Collections.singletonList(message));
 		}
 
 		@Override
 		public CompletableFuture<Void> onAcknowledge(Collection<org.springframework.messaging.Message<T>> messages) {
 			return messages.isEmpty() ? CompletableFuture.completedFuture(null)
-				: deleteMessages(
-					MessageHeaderUtils.getHeaderAsString(messages.iterator().next(),
-						SqsHeaders.SQS_QUEUE_NAME_HEADER),
-					messages.stream().map(msg -> (org.springframework.messaging.Message<?>) msg)
-						.collect(Collectors.toList()));
+					: deleteMessages(
+							MessageHeaderUtils.getHeaderAsString(messages.iterator().next(),
+									SqsHeaders.SQS_QUEUE_NAME_HEADER),
+							messages.stream().map(msg -> (org.springframework.messaging.Message<?>) msg)
+									.collect(Collectors.toList()));
 		}
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
@@ -15,6 +15,8 @@
  */
 package io.awspring.cloud.sqs.operations;
 
+import static java.text.MessageFormat.format;
+
 import io.awspring.cloud.sqs.FifoUtils;
 import io.awspring.cloud.sqs.MessageHeaderUtils;
 import io.awspring.cloud.sqs.QueueAttributesResolver;
@@ -22,6 +24,7 @@ import io.awspring.cloud.sqs.SqsAcknowledgementException;
 import io.awspring.cloud.sqs.listener.QueueAttributes;
 import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.listener.SqsHeaders.MessageSystemAttributes;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementCallback;
 import io.awspring.cloud.sqs.support.converter.MessageAttributeDataTypes;
 import io.awspring.cloud.sqs.support.converter.MessageConversionContext;
@@ -32,11 +35,14 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -153,7 +159,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		}
 		if (options.messageDeduplicationId != null) {
 			builder.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER,
-					options.messageDeduplicationId);
+				options.messageDeduplicationId);
 		}
 		if (options.messageGroupId != null) {
 			builder.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, options.messageGroupId);
@@ -168,7 +174,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 	@Override
 	public <T> Optional<org.springframework.messaging.Message<T>> receive(Consumer<SqsReceiveOptions> from,
-			Class<T> payloadClass) {
+		Class<T> payloadClass) {
 		return unwrapCompletionException(receiveAsync(from, payloadClass));
 	}
 
@@ -179,55 +185,55 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 	@Override
 	public <T> Collection<org.springframework.messaging.Message<T>> receiveMany(Consumer<SqsReceiveOptions> from,
-			Class<T> payloadClass) {
+		Class<T> payloadClass) {
 		return unwrapCompletionException(receiveManyAsync(from, payloadClass));
 	}
 
 	@Override
 	public CompletableFuture<Optional<org.springframework.messaging.Message<?>>> receiveAsync(
-			Consumer<SqsReceiveOptions> from) {
+		Consumer<SqsReceiveOptions> from) {
 		Assert.notNull(from, "from must not be null");
 		SqsReceiveOptionsImpl options = new SqsReceiveOptionsImpl();
 		from.accept(options);
 		Assert.isTrue(options.maxNumberOfMessages == null || options.maxNumberOfMessages == 1,
-				"maxNumberOfMessages must be null or 1. Use receiveMany to receive more messages.");
+			"maxNumberOfMessages must be null or 1. Use receiveMany to receive more messages.");
 		Map<String, Object> additionalHeaders = addAdditionalReceiveHeaders(options);
 		return receiveAsync(options.queue, null, options.pollTimeout, additionalHeaders);
 	}
 
 	@Override
 	public <T> CompletableFuture<Optional<org.springframework.messaging.Message<T>>> receiveAsync(
-			Consumer<SqsReceiveOptions> from, Class<T> payloadClass) {
+		Consumer<SqsReceiveOptions> from, Class<T> payloadClass) {
 		Assert.notNull(from, "from must not be null");
 		Assert.notNull(payloadClass, "payloadClass must not be null");
 		SqsReceiveOptionsImpl options = new SqsReceiveOptionsImpl();
 		from.accept(options);
 		Assert.isTrue(options.maxNumberOfMessages == null || options.maxNumberOfMessages == 1,
-				"maxNumberOfMessages must be null or 1. Use receiveMany to receive more messages.");
+			"maxNumberOfMessages must be null or 1. Use receiveMany to receive more messages.");
 		Map<String, Object> additionalHeaders = addAdditionalReceiveHeaders(options);
 		return receiveAsync(options.queue, payloadClass, options.pollTimeout, additionalHeaders)
-				.thenApply(super::castFromOptional);
+			.thenApply(super::castFromOptional);
 	}
 
 	@Override
 	public CompletableFuture<Collection<org.springframework.messaging.Message<?>>> receiveManyAsync(
-			Consumer<SqsReceiveOptions> from) {
+		Consumer<SqsReceiveOptions> from) {
 		Assert.notNull(from, "from must not be null");
 		SqsReceiveOptionsImpl options = new SqsReceiveOptionsImpl();
 		from.accept(options);
 		return receiveManyAsync(options.queue, null, options.pollTimeout, options.maxNumberOfMessages,
-				addAdditionalReceiveHeaders(options));
+			addAdditionalReceiveHeaders(options));
 	}
 
 	@Override
 	public <T> CompletableFuture<Collection<org.springframework.messaging.Message<T>>> receiveManyAsync(
-			Consumer<SqsReceiveOptions> from, Class<T> payloadClass) {
+		Consumer<SqsReceiveOptions> from, Class<T> payloadClass) {
 		Assert.notNull(from, "from must not be null");
 		Assert.notNull(payloadClass, "payloadClass must not be null");
 		SqsReceiveOptionsImpl options = new SqsReceiveOptionsImpl();
 		from.accept(options);
 		return receiveManyAsync(options.queue, payloadClass, options.pollTimeout, options.maxNumberOfMessages,
-				addAdditionalReceiveHeaders(options)).thenApply(super::castFromCollection);
+			addAdditionalReceiveHeaders(options)).thenApply(super::castFromCollection);
 	}
 
 	private Map<String, Object> addAdditionalReceiveHeaders(SqsReceiveOptionsImpl options) {
@@ -243,108 +249,128 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 	@Override
 	protected <T> org.springframework.messaging.Message<T> preProcessMessageForSend(String endpointToUse,
-			org.springframework.messaging.Message<T> message) {
-		return FifoUtils.isFifo(endpointToUse) ? addMissingFifoSendHeaders(message) : message;
+		org.springframework.messaging.Message<T> message) {
+		return FifoUtils.isFifo(endpointToUse) ? addMissingFifoSendHeaders(endpointToUse, message) : message;
 	}
 
 	@Override
 	protected <T> Collection<org.springframework.messaging.Message<T>> preProcessMessagesForSend(String endpointToUse,
-			Collection<org.springframework.messaging.Message<T>> messages) {
+		Collection<org.springframework.messaging.Message<T>> messages) {
 		return FifoUtils.isFifo(endpointToUse)
-				? messages.stream().map(this::addMissingFifoSendHeaders).collect(Collectors.toList())
-				: messages;
+			? messages.stream().map(message -> addMissingFifoSendHeaders(endpointToUse, message)).toList()
+			: messages;
 	}
 
-	private <T> org.springframework.messaging.Message<T> addMissingFifoSendHeaders(
-			org.springframework.messaging.Message<T> message) {
-		return MessageHeaderUtils.addHeadersIfAbsent(message,
-				Map.of(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, UUID.randomUUID().toString(),
-						SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER,
-						UUID.randomUUID().toString()));
+	private <T> org.springframework.messaging.Message<T> addMissingFifoSendHeaders(String endpointName,
+		org.springframework.messaging.Message<T> message) {
+
+		String contentBasedDedupQueueAttribute;
+		try {
+			contentBasedDedupQueueAttribute = getQueueAttributes(endpointName).get()
+				.getQueueAttribute(QueueAttributeName.CONTENT_BASED_DEDUPLICATION);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException(format("Failed to get {0} queue attributes", endpointName), e);
+		}
+		catch (ExecutionException e) {
+			throw new IllegalStateException(format("Failed to get {0} queue attributes", endpointName), e);
+		}
+		boolean isContentBasedDedup = Boolean.parseBoolean(contentBasedDedupQueueAttribute);
+		Map<String, Object> defaultHeaders;
+		if (isContentBasedDedup) {
+			defaultHeaders = Map.of(MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, UUID.randomUUID().toString());
+		}
+		else {
+			defaultHeaders = Map.of(MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, UUID.randomUUID().toString(),
+				MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, UUID.randomUUID().toString());
+		}
+
+		return MessageHeaderUtils.addHeadersIfAbsent(message, defaultHeaders);
 	}
 
 	@Override
 	protected <T> CompletableFuture<SendResult<T>> doSendAsync(String endpointName, Message message,
-			org.springframework.messaging.Message<T> originalMessage) {
+		org.springframework.messaging.Message<T> originalMessage) {
 		return createSendMessageRequest(endpointName, message).thenCompose(this.sqsAsyncClient::sendMessage)
-				.thenApply(response -> createSendResult(UUID.fromString(response.messageId()),
-						response.sequenceNumber(), endpointName, originalMessage));
+			.thenApply(response -> createSendResult(UUID.fromString(response.messageId()),
+				response.sequenceNumber(), endpointName, originalMessage));
 	}
 
 	private <T> SendResult<T> createSendResult(UUID messageId, @Nullable String sequenceNumber, String endpointName,
-			org.springframework.messaging.Message<T> originalMessage) {
+		org.springframework.messaging.Message<T> originalMessage) {
 		return new SendResult<>(messageId, endpointName, originalMessage,
-				sequenceNumber != null
-						? Collections.singletonMap(SqsTemplateParameters.SEQUENCE_NUMBER_PARAMETER_NAME, sequenceNumber)
-						: Collections.emptyMap());
+			sequenceNumber != null
+				? Collections.singletonMap(SqsTemplateParameters.SEQUENCE_NUMBER_PARAMETER_NAME, sequenceNumber)
+				: Collections.emptyMap());
 	}
 
 	private CompletableFuture<SendMessageRequest> createSendMessageRequest(String endpointName, Message message) {
 		return getQueueAttributes(endpointName)
-				.thenApply(queueAttributes -> doCreateSendMessageRequest(message, queueAttributes));
+			.thenApply(queueAttributes -> doCreateSendMessageRequest(message, queueAttributes));
 	}
 
 	private SendMessageRequest doCreateSendMessageRequest(Message message, QueueAttributes queueAttributes) {
 		return SendMessageRequest.builder().queueUrl(queueAttributes.getQueueUrl()).messageBody(message.body())
-				.messageDeduplicationId(message.attributes().get(MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID))
-				.messageGroupId(message.attributes().get(MessageSystemAttributeName.MESSAGE_GROUP_ID))
-				.delaySeconds(getDelaySeconds(message))
-				.messageAttributes(excludeKnownFields(message.messageAttributes()))
-				.messageSystemAttributes(mapMessageSystemAttributes(message)).build();
+			.messageDeduplicationId(message.attributes().get(MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID))
+			.messageGroupId(message.attributes().get(MessageSystemAttributeName.MESSAGE_GROUP_ID))
+			.delaySeconds(getDelaySeconds(message))
+			.messageAttributes(excludeKnownFields(message.messageAttributes()))
+			.messageSystemAttributes(mapMessageSystemAttributes(message)).build();
 	}
 
 	@Override
 	protected <T> CompletableFuture<SendResult.Batch<T>> doSendBatchAsync(String endpointName,
-			Collection<Message> messages, Collection<org.springframework.messaging.Message<T>> originalMessages) {
+		Collection<Message> messages, Collection<org.springframework.messaging.Message<T>> originalMessages) {
 		logger.debug("Sending messages {} to endpoint {}", messages, endpointName);
 		return createSendMessageBatchRequest(endpointName, messages).thenCompose(this.sqsAsyncClient::sendMessageBatch)
-				.thenApply(response -> createSendResultBatch(response, endpointName,
-						originalMessages.stream().collect(Collectors.toMap(MessageHeaderUtils::getId, msg -> msg))));
+			.thenApply(response -> createSendResultBatch(response, endpointName,
+				originalMessages.stream().collect(Collectors.toMap(MessageHeaderUtils::getId, msg -> msg))));
 	}
 
 	private <T> SendResult.Batch<T> createSendResultBatch(SendMessageBatchResponse response, String endpointName,
-			Map<String, org.springframework.messaging.Message<T>> originalMessagesById) {
+		Map<String, org.springframework.messaging.Message<T>> originalMessagesById) {
 		return new SendResult.Batch<>(doCreateSendResultBatch(response, endpointName, originalMessagesById),
-				createSendResultFailed(response, endpointName, originalMessagesById));
+			createSendResultFailed(response, endpointName, originalMessagesById));
 	}
 
 	private <T> Collection<SendResult.Failed<T>> createSendResultFailed(SendMessageBatchResponse response,
-			String endpointName, Map<String, org.springframework.messaging.Message<T>> originalMessagesById) {
+		String endpointName, Map<String, org.springframework.messaging.Message<T>> originalMessagesById) {
 		return response.failed().stream()
-				.map(entry -> new SendResult.Failed<>(entry.message(), endpointName,
-						originalMessagesById.get(entry.id()), Map.of(SqsTemplateParameters.SENDER_FAULT_PARAMETER_NAME,
-								entry.senderFault(), SqsTemplateParameters.ERROR_CODE_PARAMETER_NAME, entry.code())))
-				.toList();
+			.map(entry -> new SendResult.Failed<>(entry.message(), endpointName,
+				originalMessagesById.get(entry.id()), Map.of(SqsTemplateParameters.SENDER_FAULT_PARAMETER_NAME,
+				entry.senderFault(), SqsTemplateParameters.ERROR_CODE_PARAMETER_NAME, entry.code())))
+			.toList();
 	}
 
 	private <T> Collection<SendResult<T>> doCreateSendResultBatch(SendMessageBatchResponse response,
-			String endpointName, Map<String, org.springframework.messaging.Message<T>> originalMessagesById) {
+		String endpointName, Map<String, org.springframework.messaging.Message<T>> originalMessagesById) {
 		return response
-				.successful().stream().map(entry -> createSendResult(UUID.fromString(entry.messageId()),
-						entry.sequenceNumber(), endpointName, getOriginalMessage(originalMessagesById, entry)))
-				.toList();
+			.successful().stream().map(entry -> createSendResult(UUID.fromString(entry.messageId()),
+				entry.sequenceNumber(), endpointName, getOriginalMessage(originalMessagesById, entry)))
+			.toList();
 	}
 
 	private <T> org.springframework.messaging.Message<T> getOriginalMessage(
-			Map<String, org.springframework.messaging.Message<T>> originalMessagesById,
-			SendMessageBatchResultEntry entry) {
+		Map<String, org.springframework.messaging.Message<T>> originalMessagesById,
+		SendMessageBatchResultEntry entry) {
 		org.springframework.messaging.Message<T> originalMessage = originalMessagesById.get(entry.id());
 		Assert.notNull(originalMessage,
-				() -> "Could not correlate send result to original message for id %s. Original messages: %s."
-						.formatted(entry.messageId(), originalMessagesById));
+			() -> "Could not correlate send result to original message for id %s. Original messages: %s."
+				.formatted(entry.messageId(), originalMessagesById));
 		return originalMessage;
 	}
 
 	@Nullable
 	@Override
 	protected <T> MessageConversionContext getReceiveMessageConversionContext(String endpointName,
-			@Nullable Class<T> payloadClass) {
+		@Nullable Class<T> payloadClass) {
 		return this.conversionContextCache.computeIfAbsent(endpointName,
-				newEndpoint -> doGetSqsMessageConversionContext(endpointName, payloadClass));
+			newEndpoint -> doGetSqsMessageConversionContext(endpointName, payloadClass));
 	}
 
 	private <T> SqsMessageConversionContext doGetSqsMessageConversionContext(String newEndpoint,
-			@Nullable Class<T> payloadClass) {
+		@Nullable Class<T> payloadClass) {
 		SqsMessageConversionContext conversionContext = new SqsMessageConversionContext();
 		conversionContext.setSqsAsyncClient(this.sqsAsyncClient);
 		// At this point we'll already have retrieved and cached the queue attributes
@@ -359,59 +385,63 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 	}
 
 	private CompletableFuture<SendMessageBatchRequest> createSendMessageBatchRequest(String endpointName,
-			Collection<Message> messages) {
+		Collection<Message> messages) {
 		return getQueueAttributes(endpointName)
-				.thenApply(queueAttributes -> doCreateSendMessageBatchRequest(messages, queueAttributes));
+			.thenApply(queueAttributes -> doCreateSendMessageBatchRequest(messages, queueAttributes));
 	}
 
 	private SendMessageBatchRequest doCreateSendMessageBatchRequest(Collection<Message> messages,
-			QueueAttributes queueAttributes) {
+		QueueAttributes queueAttributes) {
 		return SendMessageBatchRequest.builder().queueUrl(queueAttributes.getQueueUrl())
-				.entries(messages.stream().map(this::createSendMessageBatchRequestEntry).collect(Collectors.toList()))
-				.build();
+			.entries(messages.stream().map(this::createSendMessageBatchRequestEntry).collect(Collectors.toList()))
+			.build();
 	}
 
 	private SendMessageBatchRequestEntry createSendMessageBatchRequestEntry(Message message) {
 		return SendMessageBatchRequestEntry.builder().id(message.messageId()).messageBody(message.body())
-				.messageDeduplicationId(message.attributes().get(MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID))
-				.messageGroupId(message.attributes().get(MessageSystemAttributeName.MESSAGE_GROUP_ID))
-				.delaySeconds(getDelaySeconds(message))
-				.messageAttributes(excludeKnownFields(message.messageAttributes()))
-				.messageSystemAttributes(mapMessageSystemAttributes(message)).build();
+			.messageDeduplicationId(message.attributes().get(MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID))
+			.messageGroupId(message.attributes().get(MessageSystemAttributeName.MESSAGE_GROUP_ID))
+			.delaySeconds(getDelaySeconds(message))
+			.messageAttributes(excludeKnownFields(message.messageAttributes()))
+			.messageSystemAttributes(mapMessageSystemAttributes(message)).build();
 	}
 
 	private Map<String, MessageAttributeValue> excludeKnownFields(
-			Map<String, MessageAttributeValue> messageAttributes) {
+		Map<String, MessageAttributeValue> messageAttributes) {
 		return messageAttributes.entrySet().stream()
-				.filter(entry -> !SqsHeaders.SQS_DELAY_HEADER.equals(entry.getKey()))
-				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+			.filter(entry -> !SqsHeaders.SQS_DELAY_HEADER.equals(entry.getKey()))
+			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 
 	@Nullable
 	private Integer getDelaySeconds(Message message) {
 		return message.messageAttributes().containsKey(SqsHeaders.SQS_DELAY_HEADER)
-				? Integer.parseInt(message.messageAttributes().get(SqsHeaders.SQS_DELAY_HEADER).stringValue())
-				: null;
+			? Integer.parseInt(message.messageAttributes().get(SqsHeaders.SQS_DELAY_HEADER).stringValue())
+			: null;
 	}
 
 	private Map<MessageSystemAttributeNameForSends, MessageSystemAttributeValue> mapMessageSystemAttributes(
-			Message message) {
+		Message message) {
 		return message.attributes().entrySet().stream().filter(Predicate.not(entry -> isSkipAttribute(entry.getKey())))
-				.collect(Collectors.toMap(entry -> MessageSystemAttributeNameForSends.fromValue(entry.getKey().name()),
-						entry -> MessageSystemAttributeValue.builder().dataType(MessageAttributeDataTypes.STRING)
-								.stringValue(entry.getValue()).build()));
+			.collect(Collectors.toMap(entry -> MessageSystemAttributeNameForSends.fromValue(entry.getKey().name()),
+				entry -> MessageSystemAttributeValue.builder().dataType(MessageAttributeDataTypes.STRING)
+					.stringValue(entry.getValue()).build()));
 	}
 
 	private boolean isSkipAttribute(MessageSystemAttributeName name) {
 		return MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID.equals(name)
-				|| MessageSystemAttributeName.MESSAGE_GROUP_ID.equals(name);
+			|| MessageSystemAttributeName.MESSAGE_GROUP_ID.equals(name);
 	}
 
 	private CompletableFuture<QueueAttributes> getQueueAttributes(String endpointName) {
-		return this.queueAttributesCache.computeIfAbsent(endpointName,
-				newName -> QueueAttributesResolver.builder().sqsAsyncClient(this.sqsAsyncClient).queueName(newName)
-						.queueNotFoundStrategy(this.queueNotFoundStrategy).queueAttributeNames(this.queueAttributeNames)
-						.build().resolveQueueAttributes());
+		return this.queueAttributesCache.computeIfAbsent(endpointName, newName -> {
+			// ensure we have the content based dedupe config to determine default fifo send headers
+			Set<QueueAttributeName> namesToRequest = new HashSet<>(queueAttributeNames);
+			namesToRequest.add(QueueAttributeName.CONTENT_BASED_DEDUPLICATION);
+			return QueueAttributesResolver.builder().sqsAsyncClient(this.sqsAsyncClient).queueName(newName)
+				.queueNotFoundStrategy(this.queueNotFoundStrategy).queueAttributeNames(namesToRequest).build()
+				.resolveQueueAttributes();
+		});
 	}
 
 	@Override
@@ -424,18 +454,18 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 	@Override
 	protected CompletableFuture<Void> doAcknowledgeMessages(String endpointName,
-			Collection<org.springframework.messaging.Message<?>> messages) {
+		Collection<org.springframework.messaging.Message<?>> messages) {
 		return deleteMessages(endpointName, messages);
 	}
 
 	@Override
 	protected CompletableFuture<Collection<Message>> doReceiveAsync(String endpointName, Duration pollTimeout,
-			Integer maxNumberOfMessages, Map<String, Object> additionalHeaders) {
+		Integer maxNumberOfMessages, Map<String, Object> additionalHeaders) {
 		logger.trace(
-				"Receiving messages with settings: endpointName - {}, pollTimeout - {}, maxNumberOfMessages - {}, additionalHeaders - {}",
-				endpointName, pollTimeout, maxNumberOfMessages, additionalHeaders);
+			"Receiving messages with settings: endpointName - {}, pollTimeout - {}, maxNumberOfMessages - {}, additionalHeaders - {}",
+			endpointName, pollTimeout, maxNumberOfMessages, additionalHeaders);
 		return createReceiveMessageRequest(endpointName, pollTimeout, maxNumberOfMessages, additionalHeaders)
-				.thenCompose(this.sqsAsyncClient::receiveMessage).thenApply(ReceiveMessageResponse::messages);
+			.thenCompose(this.sqsAsyncClient::receiveMessage).thenApply(ReceiveMessageResponse::messages);
 	}
 
 	@Override
@@ -449,99 +479,99 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 	}
 
 	private CompletableFuture<Void> deleteMessages(String endpointName,
-			Collection<org.springframework.messaging.Message<?>> messages) {
+		Collection<org.springframework.messaging.Message<?>> messages) {
 		logger.trace("Acknowledging in queue {} messages {}", endpointName,
-				MessageHeaderUtils.getId(addTypeToMessages(messages)));
+			MessageHeaderUtils.getId(addTypeToMessages(messages)));
 		return getQueueAttributes(endpointName)
-				.thenCompose(attributes -> this.sqsAsyncClient.deleteMessageBatch(DeleteMessageBatchRequest.builder()
-						.queueUrl(attributes.getQueueUrl()).entries(createDeleteMessageEntries(messages)).build()))
-				.exceptionallyCompose(
-						t -> createAcknowledgementException(endpointName, Collections.emptyList(), messages, t))
-				.thenCompose(response -> !response.failed().isEmpty()
-						? createAcknowledgementException(endpointName,
-								getSuccessfulAckMessages(response, messages, endpointName),
-								getFailedAckMessages(response, messages, endpointName), null)
-						: CompletableFuture.completedFuture(response))
-				.whenComplete((response, t) -> logAcknowledgement(endpointName, messages, response, t)).thenRun(() -> {
-				});
+			.thenCompose(attributes -> this.sqsAsyncClient.deleteMessageBatch(DeleteMessageBatchRequest.builder()
+				.queueUrl(attributes.getQueueUrl()).entries(createDeleteMessageEntries(messages)).build()))
+			.exceptionallyCompose(
+				t -> createAcknowledgementException(endpointName, Collections.emptyList(), messages, t))
+			.thenCompose(response -> !response.failed().isEmpty()
+				? createAcknowledgementException(endpointName,
+				getSuccessfulAckMessages(response, messages, endpointName),
+				getFailedAckMessages(response, messages, endpointName), null)
+				: CompletableFuture.completedFuture(response))
+			.whenComplete((response, t) -> logAcknowledgement(endpointName, messages, response, t)).thenRun(() -> {
+			});
 	}
 
 	private Collection<org.springframework.messaging.Message<?>> getFailedAckMessages(
-			DeleteMessageBatchResponse response, Collection<org.springframework.messaging.Message<?>> messages,
-			String endpointName) {
+		DeleteMessageBatchResponse response, Collection<org.springframework.messaging.Message<?>> messages,
+		String endpointName) {
 		return response.failed().stream().map(BatchResultErrorEntry::id)
-				.map(id -> messages.stream().filter(msg -> MessageHeaderUtils.getId(msg).equals(id)).findFirst()
-						.orElseThrow(() -> new SqsAcknowledgementException(
-								"Could not correlate ids for acknowledgement failure", Collections.emptyList(),
-								messages, endpointName)))
-				.collect(Collectors.toList());
+			.map(id -> messages.stream().filter(msg -> MessageHeaderUtils.getId(msg).equals(id)).findFirst()
+				.orElseThrow(() -> new SqsAcknowledgementException(
+					"Could not correlate ids for acknowledgement failure", Collections.emptyList(),
+					messages, endpointName)))
+			.collect(Collectors.toList());
 	}
 
 	private Collection<org.springframework.messaging.Message<?>> getSuccessfulAckMessages(
-			DeleteMessageBatchResponse response, Collection<org.springframework.messaging.Message<?>> messages,
-			String endpointName) {
+		DeleteMessageBatchResponse response, Collection<org.springframework.messaging.Message<?>> messages,
+		String endpointName) {
 		return response.successful().stream().map(DeleteMessageBatchResultEntry::id)
-				.map(id -> messages.stream().filter(msg -> MessageHeaderUtils.getId(msg).equals(id)).findFirst()
-						.orElseThrow(() -> new SqsAcknowledgementException(
-								"Could not correlate ids for acknowledgement failure", Collections.emptyList(),
-								messages, endpointName)))
-				.collect(Collectors.toList());
+			.map(id -> messages.stream().filter(msg -> MessageHeaderUtils.getId(msg).equals(id)).findFirst()
+				.orElseThrow(() -> new SqsAcknowledgementException(
+					"Could not correlate ids for acknowledgement failure", Collections.emptyList(),
+					messages, endpointName)))
+			.collect(Collectors.toList());
 	}
 
 	private CompletableFuture<DeleteMessageBatchResponse> createAcknowledgementException(String endpointName,
-			Collection<org.springframework.messaging.Message<?>> successfulAckMessages,
-			Collection<org.springframework.messaging.Message<?>> failedAckMessages, @Nullable Throwable t) {
+		Collection<org.springframework.messaging.Message<?>> successfulAckMessages,
+		Collection<org.springframework.messaging.Message<?>> failedAckMessages, @Nullable Throwable t) {
 		return CompletableFuture.failedFuture(new SqsAcknowledgementException("Error acknowledging messages",
-				successfulAckMessages, failedAckMessages, endpointName, t));
+			successfulAckMessages, failedAckMessages, endpointName, t));
 	}
 
 	private void logAcknowledgement(String endpointName, Collection<org.springframework.messaging.Message<?>> messages,
-			DeleteMessageBatchResponse response, @Nullable Throwable t) {
+		DeleteMessageBatchResponse response, @Nullable Throwable t) {
 		if (t != null) {
 			logger.error("Error acknowledging in queue {} messages {}", endpointName,
-					MessageHeaderUtils.getId(addTypeToMessages(messages)));
+				MessageHeaderUtils.getId(addTypeToMessages(messages)));
 		}
 		else if (!response.failed().isEmpty()) {
 			logger.warn("Some messages could not be acknowledged in queue {}: {}", endpointName,
-					response.failed().stream().map(BatchResultErrorEntry::id).toList());
+				response.failed().stream().map(BatchResultErrorEntry::id).toList());
 		}
 		else {
 			logger.trace("Acknowledged messages in queue {}: {}", endpointName,
-					MessageHeaderUtils.getId(addTypeToMessages(messages)));
+				MessageHeaderUtils.getId(addTypeToMessages(messages)));
 		}
 	}
 
 	private Collection<DeleteMessageBatchRequestEntry> createDeleteMessageEntries(
-			Collection<org.springframework.messaging.Message<?>> messages) {
+		Collection<org.springframework.messaging.Message<?>> messages) {
 		return messages.stream()
-				.map(message -> DeleteMessageBatchRequestEntry.builder().id(MessageHeaderUtils.getId(message))
-						.receiptHandle(
-								MessageHeaderUtils.getHeaderAsString(message, SqsHeaders.SQS_RECEIPT_HANDLE_HEADER))
-						.build())
-				.collect(Collectors.toList());
+			.map(message -> DeleteMessageBatchRequestEntry.builder().id(MessageHeaderUtils.getId(message))
+				.receiptHandle(
+					MessageHeaderUtils.getHeaderAsString(message, SqsHeaders.SQS_RECEIPT_HANDLE_HEADER))
+				.build())
+			.collect(Collectors.toList());
 	}
 
 	private CompletableFuture<ReceiveMessageRequest> createReceiveMessageRequest(String endpointName,
-			Duration pollTimeout, Integer maxNumberOfMessages, Map<String, Object> additionalHeaders) {
+		Duration pollTimeout, Integer maxNumberOfMessages, Map<String, Object> additionalHeaders) {
 		return getQueueAttributes(endpointName).thenApply(attributes -> doCreateReceiveMessageRequest(pollTimeout,
-				maxNumberOfMessages, attributes, additionalHeaders));
+			maxNumberOfMessages, attributes, additionalHeaders));
 	}
 
 	private ReceiveMessageRequest doCreateReceiveMessageRequest(Duration pollTimeout, Integer maxNumberOfMessages,
-			QueueAttributes attributes, Map<String, Object> additionalHeaders) {
+		QueueAttributes attributes, Map<String, Object> additionalHeaders) {
 		ReceiveMessageRequest.Builder builder = ReceiveMessageRequest.builder().queueUrl(attributes.getQueueUrl())
-				.maxNumberOfMessages(maxNumberOfMessages).messageAttributeNames(this.messageAttributeNames)
-				.attributeNamesWithStrings(this.messageSystemAttributeNames)
-				.waitTimeSeconds(pollTimeout.toSecondsPart());
+			.maxNumberOfMessages(maxNumberOfMessages).messageAttributeNames(this.messageAttributeNames)
+			.attributeNamesWithStrings(this.messageSystemAttributeNames)
+			.waitTimeSeconds(pollTimeout.toSecondsPart());
 		if (additionalHeaders.containsKey(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER)) {
 			builder.visibilityTimeout(
-					getValueAs(additionalHeaders, SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Duration.class)
-							.toSecondsPart());
+				getValueAs(additionalHeaders, SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Duration.class)
+					.toSecondsPart());
 		}
 		if (additionalHeaders.containsKey(SqsHeaders.SQS_RECEIVE_REQUEST_ATTEMPT_ID_HEADER)) {
 			builder.receiveRequestAttemptId(
-					getValueAs(additionalHeaders, SqsHeaders.SQS_RECEIVE_REQUEST_ATTEMPT_ID_HEADER, UUID.class)
-							.toString());
+				getValueAs(additionalHeaders, SqsHeaders.SQS_RECEIVE_REQUEST_ATTEMPT_ID_HEADER, UUID.class)
+					.toString());
 		}
 		return builder.build();
 	}
@@ -555,7 +585,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 	}
 
 	private static class SqsTemplateOptionsImpl extends AbstractMessagingTemplateOptions<SqsTemplateOptions>
-			implements SqsTemplateOptions {
+		implements SqsTemplateOptions {
 
 		private Collection<QueueAttributeName> queueAttributeNames = Collections.emptyList();
 
@@ -593,9 +623,9 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 		@Override
 		public SqsTemplateOptions messageSystemAttributeNames(
-				Collection<MessageSystemAttributeName> messageSystemAttributeNames) {
+			Collection<MessageSystemAttributeName> messageSystemAttributeNames) {
 			this.messageSystemAttributeNames = messageSystemAttributeNames.stream()
-					.map(MessageSystemAttributeName::name).toList();
+				.map(MessageSystemAttributeName::name).toList();
 			return this;
 		}
 
@@ -630,7 +660,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 		@Override
 		public SqsTemplateBuilder configureDefaultConverter(
-				Consumer<SqsMessagingMessageConverter> messageConverterConfigurer) {
+			Consumer<SqsMessagingMessageConverter> messageConverterConfigurer) {
 			Assert.notNull(messageConverterConfigurer, "messageConverterConfigurer must not be null");
 			Assert.isNull(this.messageConverter, "messageConverter already configured");
 			SqsMessagingMessageConverter defaultMessageConverter = createDefaultMessageConverter();
@@ -782,7 +812,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		public SqsReceiveOptionsImpl maxNumberOfMessages(Integer maxNumberOfMessages) {
 			Assert.notNull(maxNumberOfMessages, "maxNumberOfMessages must not be null");
 			Assert.isTrue(maxNumberOfMessages > 0 && maxNumberOfMessages <= 10,
-					"maxNumberOfMessages must be between 0 and 10");
+				"maxNumberOfMessages must be between 0 and 10");
 			this.maxNumberOfMessages = maxNumberOfMessages;
 			return this;
 		}
@@ -816,17 +846,17 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		@Override
 		public CompletableFuture<Void> onAcknowledge(org.springframework.messaging.Message<T> message) {
 			return deleteMessages(MessageHeaderUtils.getHeaderAsString(message, SqsHeaders.SQS_QUEUE_NAME_HEADER),
-					Collections.singletonList(message));
+				Collections.singletonList(message));
 		}
 
 		@Override
 		public CompletableFuture<Void> onAcknowledge(Collection<org.springframework.messaging.Message<T>> messages) {
 			return messages.isEmpty() ? CompletableFuture.completedFuture(null)
-					: deleteMessages(
-							MessageHeaderUtils.getHeaderAsString(messages.iterator().next(),
-									SqsHeaders.SQS_QUEUE_NAME_HEADER),
-							messages.stream().map(msg -> (org.springframework.messaging.Message<?>) msg)
-									.collect(Collectors.toList()));
+				: deleteMessages(
+					MessageHeaderUtils.getHeaderAsString(messages.iterator().next(),
+						SqsHeaders.SQS_QUEUE_NAME_HEADER),
+					messages.stream().map(msg -> (org.springframework.messaging.Message<?>) msg)
+						.collect(Collectors.toList()));
 		}
 	}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -40,11 +40,9 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
@@ -71,11 +69,14 @@ import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
  * @author Tomaz Fernandes
  */
 @SuppressWarnings("unchecked")
-@ExtendWith(MockitoExtension.class)
 class SqsTemplateTests {
 
-	@Mock
 	SqsAsyncClient mockClient;
+
+	@BeforeEach
+	void beforeEach() {
+		mockClient = mock(SqsAsyncClient.class);
+	}
 
 	@Test
 	void shouldSendWithOptions() {
@@ -774,7 +775,7 @@ class SqsTemplateTests {
 		GetQueueAttributesRequest.Builder getAttributesBuilder = GetQueueAttributesRequest.builder();
 		queueAttributesCaptor.getValue().accept(getAttributesBuilder);
 		GetQueueAttributesRequest attributesRequest = getAttributesBuilder.build();
-		assertThat(attributesRequest.attributeNamesAsStrings()).hasSize(2).contains(queueAttribute.toString());
+		assertThat(attributesRequest.attributeNamesAsStrings()).hasSize(1).first().isEqualTo(queueAttribute.toString());
 		assertThat(attributesRequest.queueUrl()).isEqualTo(queue);
 
 	}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -82,14 +82,14 @@ class SqsTemplateTests {
 		String queue = "test-queue";
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-			.sequenceNumber(sequenceNumber).build();
+				.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(response));
+				.willReturn(CompletableFuture.completedFuture(response));
 		SqsOperations template = SqsTemplate.newTemplate(mockClient);
 		String payload = "test-payload";
 		String testHeaderName = "testHeaderName";
@@ -98,10 +98,10 @@ class SqsTemplateTests {
 		String testHeaderValue2 = "testHeaderValue2";
 		Integer delaySeconds = 5;
 		SendResult<String> result = template.send(to -> to.delaySeconds(delaySeconds).queue(queue).payload(payload)
-			.header(testHeaderName, testHeaderValue).headers(Map.of(testHeaderName2, testHeaderValue2)));
+				.header(testHeaderName, testHeaderValue).headers(Map.of(testHeaderName2, testHeaderValue2)));
 		assertThat(result.endpoint()).isEqualTo(queue);
 		assertThat(result.message().getHeaders()).containsKeys(testHeaderName, testHeaderName2)
-			.containsValues(testHeaderValue, testHeaderValue2);
+				.containsValues(testHeaderValue, testHeaderValue2);
 		assertThat(result.message().getPayload()).isEqualTo(payload);
 		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
 		then(mockClient).should().sendMessage(captor.capture());
@@ -117,24 +117,24 @@ class SqsTemplateTests {
 		String queue = "test-queue";
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-			.sequenceNumber(sequenceNumber).build();
+				.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(response));
+				.willReturn(CompletableFuture.completedFuture(response));
 		var messageGroupId = UUID.randomUUID().toString();
 		var messageDeduplicationId = UUID.randomUUID().toString();
 		SqsOperations template = SqsTemplate.newTemplate(mockClient);
 		String payload = "test-payload";
 		SendResult<String> result = template.send(to -> to.queue(queue).messageGroupId(messageGroupId)
-			.messageDeduplicationId(messageDeduplicationId).payload(payload));
+				.messageDeduplicationId(messageDeduplicationId).payload(payload));
 		assertThat(result.endpoint()).isEqualTo(queue);
 		assertThat(result.message().getHeaders()).containsAllEntriesOf(
-			Map.of(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, messageDeduplicationId,
-				SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId));
+				Map.of(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, messageDeduplicationId,
+						SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId));
 		assertThat(result.message().getPayload()).isEqualTo(payload);
 		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
 		then(mockClient).should().sendMessage(captor.capture());
@@ -150,13 +150,13 @@ class SqsTemplateTests {
 		String queue = "test-queue.fifo";
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-			.sequenceNumber(sequenceNumber).build();
+				.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(response));
+				.willReturn(CompletableFuture.completedFuture(response));
 		mockQueueAttributes(mockClient, Map.of(QueueAttributeName.CONTENT_BASED_DEDUPLICATION, "false"));
 		SqsOperations template = SqsTemplate.newTemplate(mockClient);
 		String payload = "test-payload";
@@ -164,11 +164,11 @@ class SqsTemplateTests {
 		assertThat(result.endpoint()).isEqualTo(queue);
 		MessageHeaders resultHeaders = result.message().getHeaders();
 		assertThat(resultHeaders).containsKeys(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER,
-			SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER);
+				SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER);
 		String messageDeduplicationId = resultHeaders
-			.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, String.class);
+				.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, String.class);
 		String messageGroupId = resultHeaders.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER,
-			String.class);
+				String.class);
 		assertThat(result.message().getPayload()).isEqualTo(payload);
 		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
 		then(mockClient).should().sendMessage(captor.capture());
@@ -181,9 +181,9 @@ class SqsTemplateTests {
 
 	private static void mockQueueAttributes(SqsAsyncClient mockClient, Map<QueueAttributeName, String> attributes) {
 		GetQueueAttributesResponse queueAttributesResponse = GetQueueAttributesResponse.builder().attributes(attributes)
-			.build();
+				.build();
 		given(mockClient.getQueueAttributes(any(Consumer.class)))
-			.willReturn(CompletableFuture.completedFuture(queueAttributesResponse));
+				.willReturn(CompletableFuture.completedFuture(queueAttributesResponse));
 	}
 
 	@Test
@@ -192,13 +192,13 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-			.sequenceNumber(sequenceNumber).build();
+				.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(response));
+				.willReturn(CompletableFuture.completedFuture(response));
 		mockQueueAttributes(mockClient, Map.of(QueueAttributeName.CONTENT_BASED_DEDUPLICATION, "true"));
 		SqsOperations template = SqsTemplate.newTemplate(mockClient);
 		String payload = "test-payload";
@@ -206,11 +206,11 @@ class SqsTemplateTests {
 		assertThat(result.endpoint()).isEqualTo(queue);
 		MessageHeaders resultHeaders = result.message().getHeaders();
 		assertThat(resultHeaders).containsKey(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER)
-			.doesNotContainKey(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER);
+				.doesNotContainKey(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER);
 		String messageDeduplicationId = resultHeaders
-			.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, String.class);
+				.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, String.class);
 		String messageGroupId = resultHeaders.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER,
-			String.class);
+				String.class);
 		assertThat(result.message().getPayload()).isEqualTo(payload);
 		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
 		then(mockClient).should().sendMessage(captor.capture());
@@ -228,17 +228,17 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-			.sequenceNumber(sequenceNumber).build();
+				.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(response));
+				.willReturn(CompletableFuture.completedFuture(response));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-			.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
+				.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
 		SendResult<String> result = template.send(payload);
 		assertThat(result.endpoint()).isEqualTo(queue);
 		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
@@ -254,19 +254,19 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-			.willReturn(CompletableFuture.failedFuture(new RuntimeException("Expected send error")));
+				.willReturn(CompletableFuture.failedFuture(new RuntimeException("Expected send error")));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-			.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
+				.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
 		assertThatThrownBy(() -> template.send(payload)).isInstanceOf(MessagingOperationFailedException.class)
-			.isInstanceOfSatisfying(MessagingOperationFailedException.class, ex -> {
-				assertThat(ex.getEndpoint()).isEqualTo(queue);
-				assertThat(ex.getFailedMessage()).isPresent().hasValueSatisfying(msg -> {
-					assertThat(msg.getPayload()).isEqualTo(payload);
+				.isInstanceOfSatisfying(MessagingOperationFailedException.class, ex -> {
+					assertThat(ex.getEndpoint()).isEqualTo(queue);
+					assertThat(ex.getFailedMessage()).isPresent().hasValueSatisfying(msg -> {
+						assertThat(msg.getPayload()).isEqualTo(payload);
+					});
 				});
-			});
 	}
 
 	@Test
@@ -275,14 +275,14 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-			.sequenceNumber(sequenceNumber).build();
+				.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(response));
+				.willReturn(CompletableFuture.completedFuture(response));
 
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		SendResult<String> result = template.send(queue, payload);
@@ -304,14 +304,14 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-			.sequenceNumber(sequenceNumber).build();
+				.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(response));
+				.willReturn(CompletableFuture.completedFuture(response));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		SendResult<String> result = template.send(queue, message);
 		assertThat(result.endpoint()).isEqualTo(queue);
@@ -338,15 +338,15 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 
 		SendMessageBatchResponse response = SendMessageBatchResponse.builder().successful(
 				builder -> builder.id(message1.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()),
 				builder -> builder.id(message2.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()))
-			.build();
+				.build();
 		given(mockClient.sendMessageBatch(any(SendMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(response));
+				.willReturn(CompletableFuture.completedFuture(response));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		SendResult.Batch<String> results = template.sendMany(queue, messages);
 		assertThat(results.successful()).hasSize(2);
@@ -381,21 +381,21 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		String testErrorMessage = "test error message";
 		String code = "BC01";
 		boolean senderFault = true;
 		SendMessageBatchResponse response = SendMessageBatchResponse.builder().successful(
 				builder -> builder.id(message1.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()))
-			.failed(builder -> builder.id(message2.getHeaders().getId().toString()).message(testErrorMessage)
-				.code(code).senderFault(senderFault))
-			.build();
+				.failed(builder -> builder.id(message2.getHeaders().getId().toString()).message(testErrorMessage)
+						.code(code).senderFault(senderFault))
+				.build();
 		given(mockClient.sendMessageBatch(any(SendMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(response));
+				.willReturn(CompletableFuture.completedFuture(response));
 		SqsOperations template = SqsTemplate.builder().configure(
 				options -> options.sendBatchFailureHandlingStrategy(SendBatchFailureHandlingStrategy.DO_NOT_THROW))
-			.sqsAsyncClient(mockClient).buildSyncTemplate();
+				.sqsAsyncClient(mockClient).buildSyncTemplate();
 		SendResult.Batch<String> results = template.sendMany(queue, messages);
 		assertThat(results.successful()).isNotEmpty();
 		assertThat(results.failed()).isNotEmpty();
@@ -406,9 +406,9 @@ class SqsTemplateTests {
 		assertThat(failedResult.errorMessage()).isEqualTo(testErrorMessage);
 		assertThat(failedResult.message().getPayload()).isEqualTo(payload2);
 		assertThat(failedResult.additionalInformation().get(SqsTemplateParameters.ERROR_CODE_PARAMETER_NAME))
-			.isEqualTo(code);
+				.isEqualTo(code);
 		assertThat(failedResult.additionalInformation().get(SqsTemplateParameters.SENDER_FAULT_PARAMETER_NAME))
-			.isEqualTo(senderFault);
+				.isEqualTo(senderFault);
 	}
 
 	@Test
@@ -422,38 +422,38 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		String testErrorMessage = "test error message";
 		String code = "BC01";
 		boolean senderFault = true;
 		SendMessageBatchResponse response = SendMessageBatchResponse.builder().successful(
 				builder -> builder.id(message1.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()))
-			.failed(builder -> builder.id(message2.getHeaders().getId().toString()).message(testErrorMessage)
-				.code(code).senderFault(senderFault))
-			.build();
+				.failed(builder -> builder.id(message2.getHeaders().getId().toString()).message(testErrorMessage)
+						.code(code).senderFault(senderFault))
+				.build();
 		given(mockClient.sendMessageBatch(any(SendMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(response));
+				.willReturn(CompletableFuture.completedFuture(response));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		assertThatThrownBy(() -> template.sendMany(queue, messages))
-			.isInstanceOf(SendBatchOperationFailedException.class)
-			.isInstanceOfSatisfying(SendBatchOperationFailedException.class, ex -> {
-				assertThat(ex.getFailedMessages().iterator().next().getPayload()).isEqualTo(payload2);
-				assertThat(ex.getEndpoint()).isEqualTo(queue);
-				SendResult.Batch<String> sendBatchResult = ex.getSendBatchResult(String.class);
-				SendResult<String> successful = sendBatchResult.successful().iterator().next();
-				assertThat(successful.message().getPayload()).isEqualTo(payload1);
-				assertThat(successful.endpoint()).isEqualTo(queue);
-				SendResult.Failed<String> failedResult = sendBatchResult.failed().iterator().next();
-				assertThat(failedResult.errorMessage()).isEqualTo(testErrorMessage);
-				assertThat(failedResult.message().getPayload()).isEqualTo(payload2);
-				assertThat(
-					failedResult.additionalInformation().get(SqsTemplateParameters.ERROR_CODE_PARAMETER_NAME))
-					.isEqualTo(code);
-				assertThat(
-					failedResult.additionalInformation().get(SqsTemplateParameters.SENDER_FAULT_PARAMETER_NAME))
-					.isEqualTo(senderFault);
-			});
+				.isInstanceOf(SendBatchOperationFailedException.class)
+				.isInstanceOfSatisfying(SendBatchOperationFailedException.class, ex -> {
+					assertThat(ex.getFailedMessages().iterator().next().getPayload()).isEqualTo(payload2);
+					assertThat(ex.getEndpoint()).isEqualTo(queue);
+					SendResult.Batch<String> sendBatchResult = ex.getSendBatchResult(String.class);
+					SendResult<String> successful = sendBatchResult.successful().iterator().next();
+					assertThat(successful.message().getPayload()).isEqualTo(payload1);
+					assertThat(successful.endpoint()).isEqualTo(queue);
+					SendResult.Failed<String> failedResult = sendBatchResult.failed().iterator().next();
+					assertThat(failedResult.errorMessage()).isEqualTo(testErrorMessage);
+					assertThat(failedResult.message().getPayload()).isEqualTo(payload2);
+					assertThat(
+							failedResult.additionalInformation().get(SqsTemplateParameters.ERROR_CODE_PARAMETER_NAME))
+									.isEqualTo(code);
+					assertThat(
+							failedResult.additionalInformation().get(SqsTemplateParameters.SENDER_FAULT_PARAMETER_NAME))
+									.isEqualTo(senderFault);
+				});
 	}
 
 	@Test
@@ -463,15 +463,15 @@ class SqsTemplateTests {
 
 		mockQueueAttributes(mockClient, Map.of());
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture
-			.failedFuture(QueueDoesNotExistException.builder().message("test queue not found").build()));
+				.failedFuture(QueueDoesNotExistException.builder().message("test queue not found").build()));
 		given(mockClient.createQueue(any(Consumer.class)))
-			.willReturn(CompletableFuture.completedFuture(CreateQueueResponse.builder().queueUrl(queue).build()));
+				.willReturn(CompletableFuture.completedFuture(CreateQueueResponse.builder().queueUrl(queue).build()));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-			.sequenceNumber(sequenceNumber).build();
+				.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(response));
+				.willReturn(CompletableFuture.completedFuture(response));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		SendResult<String> result = template.send(to -> to.queue(queue).payload(payload));
 		assertThat(result.endpoint()).isEqualTo(queue);
@@ -487,14 +487,14 @@ class SqsTemplateTests {
 		String payload = "test-payload";
 
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture
-			.failedFuture(QueueDoesNotExistException.builder().message("test queue not found").build()));
+				.failedFuture(QueueDoesNotExistException.builder().message("test queue not found").build()));
 
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-			.configure(options -> options.queueNotFoundStrategy(QueueNotFoundStrategy.FAIL)).buildSyncTemplate();
+				.configure(options -> options.queueNotFoundStrategy(QueueNotFoundStrategy.FAIL)).buildSyncTemplate();
 		assertThatThrownBy(() -> template.send(to -> to.queue(queue).payload(payload)))
-			.isInstanceOf(MessagingOperationFailedException.class).cause().isInstanceOf(CompletionException.class)
-			.cause().isInstanceOf(QueueAttributesResolvingException.class).cause()
-			.isInstanceOf(QueueDoesNotExistException.class);
+				.isInstanceOf(MessagingOperationFailedException.class).cause().isInstanceOf(CompletionException.class)
+				.cause().isInstanceOf(QueueAttributesResolvingException.class).cause()
+				.isInstanceOf(QueueDoesNotExistException.class);
 	}
 
 	@Test
@@ -503,13 +503,13 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-			.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
+				.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
 		Optional<Message<?>> receivedMessage = template.receive();
 		assertThat(receivedMessage).isEmpty();
 	}
@@ -521,22 +521,22 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
-			.build();
+				.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(deleteResponse));
+				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-			.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
+				.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
 		Optional<Message<?>> receivedMessage = template.receive();
 		assertThat(receivedMessage).isPresent()
-			.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
+				.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
 	}
 
 	@Test
@@ -547,24 +547,24 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-			.messages(builder -> builder.messageId(UUID.randomUUID().toString())
-				.receiptHandle("test-receipt-handle").body(payloadString).build())
-			.build();
+				.messages(builder -> builder.messageId(UUID.randomUUID().toString())
+						.receiptHandle("test-receipt-handle").body(payloadString).build())
+				.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(deleteResponse));
+				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		Optional<Message<SampleRecord>> receivedMessage = template.receive(from -> from.queue(queue),
-			SampleRecord.class);
+				SampleRecord.class);
 		assertThat(receivedMessage).isPresent()
-			.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
+				.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
 	}
 
 	@Test
@@ -575,20 +575,20 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-			.messages(builder -> builder.messageId(UUID.randomUUID().toString())
-				.receiptHandle("test-receipt-handle").body(payloadString).build())
-			.build();
+				.messages(builder -> builder.messageId(UUID.randomUUID().toString())
+						.receiptHandle("test-receipt-handle").body(payloadString).build())
+				.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(deleteResponse));
+				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-			.configure(options -> options.defaultPayloadClass(SampleRecord.class)).buildSyncTemplate();
+				.configure(options -> options.defaultPayloadClass(SampleRecord.class)).buildSyncTemplate();
 		Optional<Message<?>> receivedMessage = template.receive(from -> from.queue(queue));
 		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> {
 			SampleRecord receivedPayload = (SampleRecord) message.getPayload();
@@ -609,28 +609,28 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		ContextAwareMessagingMessageConverter<software.amazon.awssdk.services.sqs.model.Message> converter = mock(
-			ContextAwareMessagingMessageConverter.class);
+				ContextAwareMessagingMessageConverter.class);
 		String receiptHandle = "test-receipt-handle";
 		Message message = MessageBuilder.withPayload(payload)
-			.setHeader(SqsHeaders.SQS_RECEIPT_HANDLE_HEADER, receiptHandle).build();
+				.setHeader(SqsHeaders.SQS_RECEIPT_HANDLE_HEADER, receiptHandle).build();
 		given(converter.toMessagingMessage(any(software.amazon.awssdk.services.sqs.model.Message.class), any()))
-			.willReturn(message);
+				.willReturn(message);
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
-			.messageId(UUID.randomUUID().toString()).receiptHandle(receiptHandle).body(payload).build()).build();
+				.messageId(UUID.randomUUID().toString()).receiptHandle(receiptHandle).body(payload).build()).build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(deleteResponse));
+				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient).messageConverter(converter)
-			.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
+				.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
 		Optional<Message<String>> receivedMessage = template.receive(queue, String.class);
 		assertThat(receivedMessage).isPresent()
-			.hasValueSatisfying(msg -> assertThat(msg.getPayload()).isEqualTo(payload));
+				.hasValueSatisfying(msg -> assertThat(msg.getPayload()).isEqualTo(payload));
 	}
 
 	@Test
@@ -641,19 +641,19 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
-			.messageId(UUID.randomUUID().toString()).receiptHandle(receiptHandle).body(payload).build()).build();
+				.messageId(UUID.randomUUID().toString()).receiptHandle(receiptHandle).body(payload).build()).build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-			.configure(
-				options -> options.defaultQueue(queue).acknowledgementMode(TemplateAcknowledgementMode.MANUAL))
-			.buildSyncTemplate();
+				.configure(
+						options -> options.defaultQueue(queue).acknowledgementMode(TemplateAcknowledgementMode.MANUAL))
+				.buildSyncTemplate();
 		Optional<Message<?>> receivedMessage = template.receive();
 		assertThat(receivedMessage).isPresent()
-			.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
+				.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
 		then(mockClient).should(never()).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
 	}
 
@@ -664,24 +664,24 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
-			.build();
+				.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.failedFuture(new RuntimeException("Expected ack error")));
+				.willReturn(CompletableFuture.failedFuture(new RuntimeException("Expected ack error")));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		assertThatThrownBy(() -> template.receive(from -> from.queue(queue)))
-			.isInstanceOf(MessagingOperationFailedException.class).cause()
-			.isInstanceOf(SqsAcknowledgementException.class)
-			.isInstanceOfSatisfying(SqsAcknowledgementException.class, ex -> {
-				assertThat(ex.getFailedAcknowledgementMessages()).hasSize(1).allSatisfy(message -> {
-					assertThat(message.getPayload()).isEqualTo(payload);
+				.isInstanceOf(MessagingOperationFailedException.class).cause()
+				.isInstanceOf(SqsAcknowledgementException.class)
+				.isInstanceOfSatisfying(SqsAcknowledgementException.class, ex -> {
+					assertThat(ex.getFailedAcknowledgementMessages()).hasSize(1).allSatisfy(message -> {
+						assertThat(message.getPayload()).isEqualTo(payload);
+					});
 				});
-			});
 	}
 
 	@Test
@@ -692,30 +692,30 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		String messageId1 = UUID.randomUUID().toString();
 		String messageId2 = UUID.randomUUID().toString();
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(
 				builder -> builder.messageId(messageId1).receiptHandle("test-receipt-handle").body(payload1),
 				builder -> builder.messageId(messageId2).receiptHandle("test-receipt-handle").body(payload2).build())
-			.build();
+				.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-			.successful(builder -> builder.id(messageId1)).failed(builder -> builder.id(messageId2)).build();
+				.successful(builder -> builder.id(messageId1)).failed(builder -> builder.id(messageId2)).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(deleteResponse));
+				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		assertThatThrownBy(() -> template.receive(from -> from.queue(queue)))
-			.isInstanceOf(MessagingOperationFailedException.class).cause()
-			.isInstanceOf(SqsAcknowledgementException.class)
-			.isInstanceOfSatisfying(SqsAcknowledgementException.class, ex -> {
-				assertThat(ex.getSuccessfullyAcknowledgedMessages()).hasSize(1)
-					.allSatisfy(message -> assertThat(message.getPayload()).isEqualTo(payload1));
-				assertThat(ex.getFailedAcknowledgementMessages()).hasSize(1)
-					.allSatisfy(message -> assertThat(message.getPayload()).isEqualTo(payload2));
-			});
+				.isInstanceOf(MessagingOperationFailedException.class).cause()
+				.isInstanceOf(SqsAcknowledgementException.class)
+				.isInstanceOfSatisfying(SqsAcknowledgementException.class, ex -> {
+					assertThat(ex.getSuccessfullyAcknowledgedMessages()).hasSize(1)
+							.allSatisfy(message -> assertThat(message.getPayload()).isEqualTo(payload1));
+					assertThat(ex.getFailedAcknowledgementMessages()).hasSize(1)
+							.allSatisfy(message -> assertThat(message.getPayload()).isEqualTo(payload2));
+				});
 	}
 
 	@Test
@@ -729,28 +729,28 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
-			.build();
+				.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		mockQueueAttributes(mockClient, Map.of(QueueAttributeName.QUEUE_ARN, "queue-arn"));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(deleteResponse));
+				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		String testMessageAttributes = "test-message-attributes";
 		MessageSystemAttributeName systemAttribute = MessageSystemAttributeName.MESSAGE_GROUP_ID;
 		QueueAttributeName queueAttribute = QueueAttributeName.QUEUE_ARN;
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-			.configure(options -> options.defaultQueue(queue).defaultPollTimeout(Duration.ofSeconds(1))
-				.messageAttributeNames(Collections.singletonList(testMessageAttributes))
-				.messageSystemAttributeNames(Collections.singletonList(systemAttribute))
-				.queueAttributeNames(Collections.singletonList(queueAttribute))
-				.additionalHeaderForReceive(headerName1, headerValue1)
-				.additionalHeadersForReceive(Map.of(headerName2, headerValue2)))
-			.buildSyncTemplate();
+				.configure(options -> options.defaultQueue(queue).defaultPollTimeout(Duration.ofSeconds(1))
+						.messageAttributeNames(Collections.singletonList(testMessageAttributes))
+						.messageSystemAttributeNames(Collections.singletonList(systemAttribute))
+						.queueAttributeNames(Collections.singletonList(queueAttribute))
+						.additionalHeaderForReceive(headerName1, headerValue1)
+						.additionalHeadersForReceive(Map.of(headerName2, headerValue2)))
+				.buildSyncTemplate();
 		Optional<Message<?>> receivedMessage = template.receive();
 		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> {
 			assertThat(message.getPayload()).isEqualTo(payload);
@@ -769,7 +769,7 @@ class SqsTemplateTests {
 		GetQueueUrlRequest capturedUrlRequest = queueCaptor.getValue();
 		assertThat(capturedUrlRequest.queueName()).isEqualTo(queue);
 		ArgumentCaptor<Consumer<GetQueueAttributesRequest.Builder>> queueAttributesCaptor = ArgumentCaptor
-			.forClass(Consumer.class);
+				.forClass(Consumer.class);
 		then(mockClient).should().getQueueAttributes(queueAttributesCaptor.capture());
 		GetQueueAttributesRequest.Builder getAttributesBuilder = GetQueueAttributesRequest.builder();
 		queueAttributesCaptor.getValue().accept(getAttributesBuilder);
@@ -790,23 +790,23 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
-			.build();
+				.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(deleteResponse));
+				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		Optional<Message<String>> receivedMessage = template.receive(from -> from.queue(queue)
 				.pollTimeout(Duration.ofSeconds(1)).visibilityTimeout(Duration.ofSeconds(5))
 				.additionalHeader(headerName1, headerValue1).additionalHeaders(Map.of(headerName2, headerValue2)),
-			String.class);
+				String.class);
 		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> {
 			assertThat(message.getPayload()).isEqualTo(payload);
 			assertThat(message.getHeaders()).containsEntry(headerName1, headerValue1);
@@ -827,32 +827,32 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		String messageGroupId = UUID.randomUUID().toString();
 		String deduplicationId = UUID.randomUUID().toString();
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-			.messages(builder -> builder.messageId(UUID.randomUUID().toString())
-				.attributes(Map.of(MessageSystemAttributeName.MESSAGE_GROUP_ID, messageGroupId,
-					MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID, deduplicationId))
-				.receiptHandle("test-receipt-handle").body(payload).build())
-			.build();
+				.messages(builder -> builder.messageId(UUID.randomUUID().toString())
+						.attributes(Map.of(MessageSystemAttributeName.MESSAGE_GROUP_ID, messageGroupId,
+								MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID, deduplicationId))
+						.receiptHandle("test-receipt-handle").body(payload).build())
+				.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(deleteResponse));
+				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		UUID attemptId = UUID.randomUUID();
 		Optional<Message<String>> receivedMessage = template
-			.receive(from -> from.queue(queue).receiveRequestAttemptId(attemptId), String.class);
+				.receive(from -> from.queue(queue).receiveRequestAttemptId(attemptId), String.class);
 		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> {
 			assertThat(message.getPayload()).isEqualTo(payload);
 			assertThat(message.getHeaders())
-				.containsEntry(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId);
+					.containsEntry(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId);
 			assertThat(message.getHeaders()).containsEntry(
-				SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, deduplicationId);
+					SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, deduplicationId);
 		});
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
 		then(mockClient).should().receiveMessage(captor.capture());
@@ -868,30 +868,30 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of(QueueAttributeName.CONTENT_BASED_DEDUPLICATION, "false"));
 		String messageGroupId = UUID.randomUUID().toString();
 		String deduplicationId = UUID.randomUUID().toString();
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-			.messages(builder -> builder.messageId(UUID.randomUUID().toString())
-				.attributes(Map.of(MessageSystemAttributeName.MESSAGE_GROUP_ID, messageGroupId,
-					MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID, deduplicationId))
-				.receiptHandle("test-receipt-handle").body(payload).build())
-			.build();
+				.messages(builder -> builder.messageId(UUID.randomUUID().toString())
+						.attributes(Map.of(MessageSystemAttributeName.MESSAGE_GROUP_ID, messageGroupId,
+								MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID, deduplicationId))
+						.receiptHandle("test-receipt-handle").body(payload).build())
+				.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(deleteResponse));
+				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		Optional<Message<String>> receivedMessage = template.receive(from -> from.queue(queue), String.class);
 		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> {
 			assertThat(message.getPayload()).isEqualTo(payload);
 			assertThat(message.getHeaders())
-				.containsEntry(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId);
+					.containsEntry(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId);
 			assertThat(message.getHeaders()).containsEntry(
-				SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, deduplicationId);
+					SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, deduplicationId);
 		});
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
 		then(mockClient).should().receiveMessage(captor.capture());
@@ -907,30 +907,30 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-			.messages(
-				builder -> builder.messageId(UUID.randomUUID().toString())
-					.receiptHandle("test-receipt-handle-1").body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString())
-					.receiptHandle("test-receipt-handle-2").body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString())
-					.receiptHandle("test-receipt-handle-3").body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString())
-					.receiptHandle("test-receipt-handle-4").body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString())
-					.receiptHandle("test-receipt-handle-5").body(payload).build())
-			.build();
+				.messages(
+						builder -> builder.messageId(UUID.randomUUID().toString())
+								.receiptHandle("test-receipt-handle-1").body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString())
+								.receiptHandle("test-receipt-handle-2").body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString())
+								.receiptHandle("test-receipt-handle-3").body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString())
+								.receiptHandle("test-receipt-handle-4").body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString())
+								.receiptHandle("test-receipt-handle-5").body(payload).build())
+				.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(deleteResponse));
+				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient).configure(options -> options
 				.defaultQueue(queue).defaultPollTimeout(Duration.ofSeconds(5)).defaultMaxNumberOfMessages(6))
-			.buildSyncTemplate();
+				.buildSyncTemplate();
 		Collection<Message<?>> receivedMessages = template.receiveMany();
 		assertThat(receivedMessages).hasSize(5);
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
@@ -949,35 +949,35 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-			.messages(
-				builder -> builder.messageId(UUID.randomUUID().toString())
-					.receiptHandle("test-receipt-handle-1").body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString())
-					.receiptHandle("test-receipt-handle-2").body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString())
-					.receiptHandle("test-receipt-handle-3").body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString())
-					.receiptHandle("test-receipt-handle-4").body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString())
-					.receiptHandle("test-receipt-handle-5").body(payload).build())
-			.build();
+				.messages(
+						builder -> builder.messageId(UUID.randomUUID().toString())
+								.receiptHandle("test-receipt-handle-1").body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString())
+								.receiptHandle("test-receipt-handle-2").body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString())
+								.receiptHandle("test-receipt-handle-3").body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString())
+								.receiptHandle("test-receipt-handle-4").body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString())
+								.receiptHandle("test-receipt-handle-5").body(payload).build())
+				.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(deleteResponse));
+				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		int defaultPollTimeout = 5;
 		int defaultMaxNumberOfMessages = 6;
 		SqsAsyncOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-			.configure(options -> options.defaultQueue(queue)
-				.defaultPollTimeout(Duration.ofSeconds(defaultPollTimeout))
-				.defaultMaxNumberOfMessages(defaultMaxNumberOfMessages))
-			.buildAsyncTemplate();
+				.configure(options -> options.defaultQueue(queue)
+						.defaultPollTimeout(Duration.ofSeconds(defaultPollTimeout))
+						.defaultMaxNumberOfMessages(defaultMaxNumberOfMessages))
+				.buildAsyncTemplate();
 		Collection<Message<String>> receivedMessages = template.receiveManyAsync(queue, String.class).join();
 		assertThat(receivedMessages).hasSize(5);
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
@@ -999,31 +999,31 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-			.messages(
-				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-					.body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-					.body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-					.body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-					.body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-					.body(payload).build())
-			.build();
+				.messages(
+						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+								.body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+								.body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+								.body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+								.body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+								.body(payload).build())
+				.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(deleteResponse));
+				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		Collection<Message<String>> receivedMessages = template.receiveMany(from -> from.queue(queue)
 				.maxNumberOfMessages(6).visibilityTimeout(Duration.ofSeconds(3)).pollTimeout(Duration.ofSeconds(5)),
-			String.class);
+				String.class);
 		assertThat(receivedMessages).hasSize(5);
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
 		then(mockClient).should().receiveMessage(captor.capture());
@@ -1041,31 +1041,31 @@ class SqsTemplateTests {
 
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(urlResponse));
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
 		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-			.messages(
-				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-					.body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-					.body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-					.body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-					.body(payload).build(),
-				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-					.body(payload).build())
-			.build();
+				.messages(
+						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+								.body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+								.body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+								.body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+								.body(payload).build(),
+						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+								.body(payload).build())
+				.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-			.willReturn(CompletableFuture.completedFuture(deleteResponse));
+				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		UUID attemptId = UUID.randomUUID();
 		Collection<Message<?>> receivedMessages = template
-			.receiveMany(from -> from.queue(queue).receiveRequestAttemptId(attemptId));
+				.receiveMany(from -> from.queue(queue).receiveRequestAttemptId(attemptId));
 		assertThat(receivedMessages).hasSize(5);
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
 		then(mockClient).should().receiveMessage(captor.capture());

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -41,7 +41,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
@@ -68,21 +71,25 @@ import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
  * @author Tomaz Fernandes
  */
 @SuppressWarnings("unchecked")
+@ExtendWith(MockitoExtension.class)
 class SqsTemplateTests {
+
+	@Mock
+	SqsAsyncClient mockClient;
 
 	@Test
 	void shouldSendWithOptions() {
 		String queue = "test-queue";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-				.sequenceNumber(sequenceNumber).build();
+			.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(response));
+			.willReturn(CompletableFuture.completedFuture(response));
 		SqsOperations template = SqsTemplate.newTemplate(mockClient);
 		String payload = "test-payload";
 		String testHeaderName = "testHeaderName";
@@ -91,10 +98,10 @@ class SqsTemplateTests {
 		String testHeaderValue2 = "testHeaderValue2";
 		Integer delaySeconds = 5;
 		SendResult<String> result = template.send(to -> to.delaySeconds(delaySeconds).queue(queue).payload(payload)
-				.header(testHeaderName, testHeaderValue).headers(Map.of(testHeaderName2, testHeaderValue2)));
+			.header(testHeaderName, testHeaderValue).headers(Map.of(testHeaderName2, testHeaderValue2)));
 		assertThat(result.endpoint()).isEqualTo(queue);
 		assertThat(result.message().getHeaders()).containsKeys(testHeaderName, testHeaderName2)
-				.containsValues(testHeaderValue, testHeaderValue2);
+			.containsValues(testHeaderValue, testHeaderValue2);
 		assertThat(result.message().getPayload()).isEqualTo(payload);
 		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
 		then(mockClient).should().sendMessage(captor.capture());
@@ -108,26 +115,26 @@ class SqsTemplateTests {
 	@Test
 	void shouldSendFifoWithOptions() {
 		String queue = "test-queue";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-				.sequenceNumber(sequenceNumber).build();
+			.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(response));
+			.willReturn(CompletableFuture.completedFuture(response));
 		var messageGroupId = UUID.randomUUID().toString();
 		var messageDeduplicationId = UUID.randomUUID().toString();
 		SqsOperations template = SqsTemplate.newTemplate(mockClient);
 		String payload = "test-payload";
 		SendResult<String> result = template.send(to -> to.queue(queue).messageGroupId(messageGroupId)
-				.messageDeduplicationId(messageDeduplicationId).payload(payload));
+			.messageDeduplicationId(messageDeduplicationId).payload(payload));
 		assertThat(result.endpoint()).isEqualTo(queue);
 		assertThat(result.message().getHeaders()).containsAllEntriesOf(
-				Map.of(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, messageDeduplicationId,
-						SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId));
+			Map.of(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, messageDeduplicationId,
+				SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId));
 		assertThat(result.message().getPayload()).isEqualTo(payload);
 		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
 		then(mockClient).should().sendMessage(captor.capture());
@@ -141,27 +148,69 @@ class SqsTemplateTests {
 	@Test
 	void shouldAddFifoHeadersToSend() {
 		String queue = "test-queue.fifo";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-				.sequenceNumber(sequenceNumber).build();
+			.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(response));
+			.willReturn(CompletableFuture.completedFuture(response));
+		mockQueueAttributes(mockClient, Map.of(QueueAttributeName.CONTENT_BASED_DEDUPLICATION, "false"));
 		SqsOperations template = SqsTemplate.newTemplate(mockClient);
 		String payload = "test-payload";
 		SendResult<String> result = template.send(queue, payload);
 		assertThat(result.endpoint()).isEqualTo(queue);
 		MessageHeaders resultHeaders = result.message().getHeaders();
 		assertThat(resultHeaders).containsKeys(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER,
-				SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER);
+			SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER);
 		String messageDeduplicationId = resultHeaders
-				.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, String.class);
+			.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, String.class);
 		String messageGroupId = resultHeaders.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER,
-				String.class);
+			String.class);
+		assertThat(result.message().getPayload()).isEqualTo(payload);
+		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+		then(mockClient).should().sendMessage(captor.capture());
+		SendMessageRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.queueUrl()).isEqualTo(queue);
+		assertThat(capturedRequest.messageBody()).isEqualTo(payload);
+		assertThat(capturedRequest.messageGroupId()).isEqualTo(messageGroupId);
+		assertThat(capturedRequest.messageDeduplicationId()).isEqualTo(messageDeduplicationId);
+	}
+
+	private static void mockQueueAttributes(SqsAsyncClient mockClient, Map<QueueAttributeName, String> attributes) {
+		GetQueueAttributesResponse queueAttributesResponse = GetQueueAttributesResponse.builder().attributes(attributes)
+			.build();
+		given(mockClient.getQueueAttributes(any(Consumer.class)))
+			.willReturn(CompletableFuture.completedFuture(queueAttributesResponse));
+	}
+
+	@Test
+	void shouldAddFifoHeadersToSendWithContentBasedDeduplicationQueueConfig() {
+		String queue = "test-queue.fifo";
+
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		UUID uuid = UUID.randomUUID();
+		String sequenceNumber = "1234";
+		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
+			.sequenceNumber(sequenceNumber).build();
+		given(mockClient.sendMessage(any(SendMessageRequest.class)))
+			.willReturn(CompletableFuture.completedFuture(response));
+		mockQueueAttributes(mockClient, Map.of(QueueAttributeName.CONTENT_BASED_DEDUPLICATION, "true"));
+		SqsOperations template = SqsTemplate.newTemplate(mockClient);
+		String payload = "test-payload";
+		SendResult<String> result = template.send(queue, payload);
+		assertThat(result.endpoint()).isEqualTo(queue);
+		MessageHeaders resultHeaders = result.message().getHeaders();
+		assertThat(resultHeaders).containsKey(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER)
+			.doesNotContainKey(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER);
+		String messageDeduplicationId = resultHeaders
+			.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, String.class);
+		String messageGroupId = resultHeaders.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER,
+			String.class);
 		assertThat(result.message().getPayload()).isEqualTo(payload);
 		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
 		then(mockClient).should().sendMessage(captor.capture());
@@ -176,18 +225,20 @@ class SqsTemplateTests {
 	void shouldSendWithDefaultEndpoint() {
 		String queue = "test-queue";
 		String payload = "test-payload";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
+
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-				.sequenceNumber(sequenceNumber).build();
+			.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(response));
+			.willReturn(CompletableFuture.completedFuture(response));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-				.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
+			.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
 		SendResult<String> result = template.send(payload);
 		assertThat(result.endpoint()).isEqualTo(queue);
 		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
@@ -200,37 +251,39 @@ class SqsTemplateTests {
 	void shouldWrapSendError() {
 		String queue = "test-queue";
 		String payload = "test-payload";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-				.willReturn(CompletableFuture.failedFuture(new RuntimeException("Expected send error")));
+			.willReturn(CompletableFuture.failedFuture(new RuntimeException("Expected send error")));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-				.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
+			.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
 		assertThatThrownBy(() -> template.send(payload)).isInstanceOf(MessagingOperationFailedException.class)
-				.isInstanceOfSatisfying(MessagingOperationFailedException.class, ex -> {
-					assertThat(ex.getEndpoint()).isEqualTo(queue);
-					assertThat(ex.getFailedMessage()).isPresent().hasValueSatisfying(msg -> {
-						assertThat(msg.getPayload()).isEqualTo(payload);
-					});
+			.isInstanceOfSatisfying(MessagingOperationFailedException.class, ex -> {
+				assertThat(ex.getEndpoint()).isEqualTo(queue);
+				assertThat(ex.getFailedMessage()).isPresent().hasValueSatisfying(msg -> {
+					assertThat(msg.getPayload()).isEqualTo(payload);
 				});
+			});
 	}
 
 	@Test
 	void shouldSendWithQueueAndPayload() {
 		String queue = "test-queue";
 		String payload = "test-payload";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-				.sequenceNumber(sequenceNumber).build();
+			.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(response));
+			.willReturn(CompletableFuture.completedFuture(response));
+
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		SendResult<String> result = template.send(queue, payload);
 		assertThat(result.endpoint()).isEqualTo(queue);
@@ -248,16 +301,17 @@ class SqsTemplateTests {
 		String headerName = "headerName";
 		String headerValue = "headerValue";
 		Message<String> message = MessageBuilder.withPayload(payload).setHeader(headerName, headerValue).build();
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-				.sequenceNumber(sequenceNumber).build();
+			.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(response));
+			.willReturn(CompletableFuture.completedFuture(response));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		SendResult<String> result = template.send(queue, message);
 		assertThat(result.endpoint()).isEqualTo(queue);
@@ -281,16 +335,18 @@ class SqsTemplateTests {
 		Message<String> message1 = MessageBuilder.withPayload(payload1).setHeader(headerName1, headerValue1).build();
 		Message<String> message2 = MessageBuilder.withPayload(payload2).setHeader(headerName2, headerValue2).build();
 		List<Message<String>> messages = List.of(message1, message2);
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
+
 		SendMessageBatchResponse response = SendMessageBatchResponse.builder().successful(
 				builder -> builder.id(message1.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()),
 				builder -> builder.id(message2.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()))
-				.build();
+			.build();
 		given(mockClient.sendMessageBatch(any(SendMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(response));
+			.willReturn(CompletableFuture.completedFuture(response));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		SendResult.Batch<String> results = template.sendMany(queue, messages);
 		assertThat(results.successful()).hasSize(2);
@@ -322,23 +378,24 @@ class SqsTemplateTests {
 		Message<String> message1 = MessageBuilder.withPayload(payload1).build();
 		Message<String> message2 = MessageBuilder.withPayload(payload2).build();
 		List<Message<String>> messages = List.of(message1, message2);
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		String testErrorMessage = "test error message";
 		String code = "BC01";
 		boolean senderFault = true;
 		SendMessageBatchResponse response = SendMessageBatchResponse.builder().successful(
 				builder -> builder.id(message1.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()))
-				.failed(builder -> builder.id(message2.getHeaders().getId().toString()).message(testErrorMessage)
-						.code(code).senderFault(senderFault))
-				.build();
+			.failed(builder -> builder.id(message2.getHeaders().getId().toString()).message(testErrorMessage)
+				.code(code).senderFault(senderFault))
+			.build();
 		given(mockClient.sendMessageBatch(any(SendMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(response));
+			.willReturn(CompletableFuture.completedFuture(response));
 		SqsOperations template = SqsTemplate.builder().configure(
 				options -> options.sendBatchFailureHandlingStrategy(SendBatchFailureHandlingStrategy.DO_NOT_THROW))
-				.sqsAsyncClient(mockClient).buildSyncTemplate();
+			.sqsAsyncClient(mockClient).buildSyncTemplate();
 		SendResult.Batch<String> results = template.sendMany(queue, messages);
 		assertThat(results.successful()).isNotEmpty();
 		assertThat(results.failed()).isNotEmpty();
@@ -349,9 +406,9 @@ class SqsTemplateTests {
 		assertThat(failedResult.errorMessage()).isEqualTo(testErrorMessage);
 		assertThat(failedResult.message().getPayload()).isEqualTo(payload2);
 		assertThat(failedResult.additionalInformation().get(SqsTemplateParameters.ERROR_CODE_PARAMETER_NAME))
-				.isEqualTo(code);
+			.isEqualTo(code);
 		assertThat(failedResult.additionalInformation().get(SqsTemplateParameters.SENDER_FAULT_PARAMETER_NAME))
-				.isEqualTo(senderFault);
+			.isEqualTo(senderFault);
 	}
 
 	@Test
@@ -362,57 +419,59 @@ class SqsTemplateTests {
 		Message<String> message1 = MessageBuilder.withPayload(payload1).build();
 		Message<String> message2 = MessageBuilder.withPayload(payload2).build();
 		List<Message<String>> messages = List.of(message1, message2);
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		String testErrorMessage = "test error message";
 		String code = "BC01";
 		boolean senderFault = true;
 		SendMessageBatchResponse response = SendMessageBatchResponse.builder().successful(
 				builder -> builder.id(message1.getHeaders().getId().toString()).messageId(UUID.randomUUID().toString()))
-				.failed(builder -> builder.id(message2.getHeaders().getId().toString()).message(testErrorMessage)
-						.code(code).senderFault(senderFault))
-				.build();
+			.failed(builder -> builder.id(message2.getHeaders().getId().toString()).message(testErrorMessage)
+				.code(code).senderFault(senderFault))
+			.build();
 		given(mockClient.sendMessageBatch(any(SendMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(response));
+			.willReturn(CompletableFuture.completedFuture(response));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		assertThatThrownBy(() -> template.sendMany(queue, messages))
-				.isInstanceOf(SendBatchOperationFailedException.class)
-				.isInstanceOfSatisfying(SendBatchOperationFailedException.class, ex -> {
-					assertThat(ex.getFailedMessages().iterator().next().getPayload()).isEqualTo(payload2);
-					assertThat(ex.getEndpoint()).isEqualTo(queue);
-					SendResult.Batch<String> sendBatchResult = ex.getSendBatchResult(String.class);
-					SendResult<String> successful = sendBatchResult.successful().iterator().next();
-					assertThat(successful.message().getPayload()).isEqualTo(payload1);
-					assertThat(successful.endpoint()).isEqualTo(queue);
-					SendResult.Failed<String> failedResult = sendBatchResult.failed().iterator().next();
-					assertThat(failedResult.errorMessage()).isEqualTo(testErrorMessage);
-					assertThat(failedResult.message().getPayload()).isEqualTo(payload2);
-					assertThat(
-							failedResult.additionalInformation().get(SqsTemplateParameters.ERROR_CODE_PARAMETER_NAME))
-									.isEqualTo(code);
-					assertThat(
-							failedResult.additionalInformation().get(SqsTemplateParameters.SENDER_FAULT_PARAMETER_NAME))
-									.isEqualTo(senderFault);
-				});
+			.isInstanceOf(SendBatchOperationFailedException.class)
+			.isInstanceOfSatisfying(SendBatchOperationFailedException.class, ex -> {
+				assertThat(ex.getFailedMessages().iterator().next().getPayload()).isEqualTo(payload2);
+				assertThat(ex.getEndpoint()).isEqualTo(queue);
+				SendResult.Batch<String> sendBatchResult = ex.getSendBatchResult(String.class);
+				SendResult<String> successful = sendBatchResult.successful().iterator().next();
+				assertThat(successful.message().getPayload()).isEqualTo(payload1);
+				assertThat(successful.endpoint()).isEqualTo(queue);
+				SendResult.Failed<String> failedResult = sendBatchResult.failed().iterator().next();
+				assertThat(failedResult.errorMessage()).isEqualTo(testErrorMessage);
+				assertThat(failedResult.message().getPayload()).isEqualTo(payload2);
+				assertThat(
+					failedResult.additionalInformation().get(SqsTemplateParameters.ERROR_CODE_PARAMETER_NAME))
+					.isEqualTo(code);
+				assertThat(
+					failedResult.additionalInformation().get(SqsTemplateParameters.SENDER_FAULT_PARAMETER_NAME))
+					.isEqualTo(senderFault);
+			});
 	}
 
 	@Test
 	void shouldCreateByDefaultIfQueueNotFound() {
 		String queue = "test-queue";
 		String payload = "test-payload";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
+		mockQueueAttributes(mockClient, Map.of());
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture
-				.failedFuture(QueueDoesNotExistException.builder().message("test queue not found").build()));
+			.failedFuture(QueueDoesNotExistException.builder().message("test queue not found").build()));
 		given(mockClient.createQueue(any(Consumer.class)))
-				.willReturn(CompletableFuture.completedFuture(CreateQueueResponse.builder().queueUrl(queue).build()));
+			.willReturn(CompletableFuture.completedFuture(CreateQueueResponse.builder().queueUrl(queue).build()));
 		UUID uuid = UUID.randomUUID();
 		String sequenceNumber = "1234";
 		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-				.sequenceNumber(sequenceNumber).build();
+			.sequenceNumber(sequenceNumber).build();
 		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(response));
+			.willReturn(CompletableFuture.completedFuture(response));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		SendResult<String> result = template.send(to -> to.queue(queue).payload(payload));
 		assertThat(result.endpoint()).isEqualTo(queue);
@@ -426,35 +485,31 @@ class SqsTemplateTests {
 	void shouldThrowIfQueueNotFound() {
 		String queue = "test-queue";
 		String payload = "test-payload";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture
-				.failedFuture(QueueDoesNotExistException.builder().message("test queue not found").build()));
-		UUID uuid = UUID.randomUUID();
-		String sequenceNumber = "1234";
-		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
-				.sequenceNumber(sequenceNumber).build();
-		given(mockClient.sendMessage(any(SendMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(response));
+			.failedFuture(QueueDoesNotExistException.builder().message("test queue not found").build()));
+
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-				.configure(options -> options.queueNotFoundStrategy(QueueNotFoundStrategy.FAIL)).buildSyncTemplate();
+			.configure(options -> options.queueNotFoundStrategy(QueueNotFoundStrategy.FAIL)).buildSyncTemplate();
 		assertThatThrownBy(() -> template.send(to -> to.queue(queue).payload(payload)))
-				.isInstanceOf(MessagingOperationFailedException.class).cause().isInstanceOf(CompletionException.class)
-				.cause().isInstanceOf(QueueAttributesResolvingException.class).cause()
-				.isInstanceOf(QueueDoesNotExistException.class);
+			.isInstanceOf(MessagingOperationFailedException.class).cause().isInstanceOf(CompletionException.class)
+			.cause().isInstanceOf(QueueAttributesResolvingException.class).cause()
+			.isInstanceOf(QueueDoesNotExistException.class);
 	}
 
 	@Test
 	void shouldReceiveEmpty() {
 		String queue = "test-queue";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-				.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
+			.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
 		Optional<Message<?>> receivedMessage = template.receive();
 		assertThat(receivedMessage).isEmpty();
 	}
@@ -463,24 +518,25 @@ class SqsTemplateTests {
 	void shouldReceiveFromDefaultEndpoint() {
 		String queue = "test-queue";
 		String payload = "test-payload";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
-				.build();
+			.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(deleteResponse));
+			.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-				.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
+			.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
 		Optional<Message<?>> receivedMessage = template.receive();
 		assertThat(receivedMessage).isPresent()
-				.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
+			.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
 	}
 
 	@Test
@@ -488,25 +544,27 @@ class SqsTemplateTests {
 		String queue = "test-queue";
 		SampleRecord payload = new SampleRecord("first-prop", "second-prop");
 		String payloadString = new ObjectMapper().writeValueAsString(payload);
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
+
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-				.messages(builder -> builder.messageId(UUID.randomUUID().toString())
-						.receiptHandle("test-receipt-handle").body(payloadString).build())
-				.build();
+			.messages(builder -> builder.messageId(UUID.randomUUID().toString())
+				.receiptHandle("test-receipt-handle").body(payloadString).build())
+			.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(deleteResponse));
+			.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		Optional<Message<SampleRecord>> receivedMessage = template.receive(from -> from.queue(queue),
-				SampleRecord.class);
+			SampleRecord.class);
 		assertThat(receivedMessage).isPresent()
-				.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
+			.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
 	}
 
 	@Test
@@ -514,22 +572,23 @@ class SqsTemplateTests {
 		String queue = "test-queue";
 		SampleRecord payload = new SampleRecord("first-prop", "second-prop");
 		String payloadString = new ObjectMapper().writeValueAsString(payload);
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-				.messages(builder -> builder.messageId(UUID.randomUUID().toString())
-						.receiptHandle("test-receipt-handle").body(payloadString).build())
-				.build();
+			.messages(builder -> builder.messageId(UUID.randomUUID().toString())
+				.receiptHandle("test-receipt-handle").body(payloadString).build())
+			.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(deleteResponse));
+			.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-				.configure(options -> options.defaultPayloadClass(SampleRecord.class)).buildSyncTemplate();
+			.configure(options -> options.defaultPayloadClass(SampleRecord.class)).buildSyncTemplate();
 		Optional<Message<?>> receivedMessage = template.receive(from -> from.queue(queue));
 		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> {
 			SampleRecord receivedPayload = (SampleRecord) message.getPayload();
@@ -547,30 +606,31 @@ class SqsTemplateTests {
 	void shouldUseCustomConverter() {
 		String queue = "test-queue";
 		String payload = "test-payload";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		ContextAwareMessagingMessageConverter<software.amazon.awssdk.services.sqs.model.Message> converter = mock(
-				ContextAwareMessagingMessageConverter.class);
+			ContextAwareMessagingMessageConverter.class);
 		String receiptHandle = "test-receipt-handle";
 		Message message = MessageBuilder.withPayload(payload)
-				.setHeader(SqsHeaders.SQS_RECEIPT_HANDLE_HEADER, receiptHandle).build();
+			.setHeader(SqsHeaders.SQS_RECEIPT_HANDLE_HEADER, receiptHandle).build();
 		given(converter.toMessagingMessage(any(software.amazon.awssdk.services.sqs.model.Message.class), any()))
-				.willReturn(message);
+			.willReturn(message);
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
-				.messageId(UUID.randomUUID().toString()).receiptHandle(receiptHandle).body(payload).build()).build();
+			.messageId(UUID.randomUUID().toString()).receiptHandle(receiptHandle).body(payload).build()).build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(deleteResponse));
+			.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient).messageConverter(converter)
-				.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
+			.configure(options -> options.defaultQueue(queue)).buildSyncTemplate();
 		Optional<Message<String>> receivedMessage = template.receive(queue, String.class);
 		assertThat(receivedMessage).isPresent()
-				.hasValueSatisfying(msg -> assertThat(msg.getPayload()).isEqualTo(payload));
+			.hasValueSatisfying(msg -> assertThat(msg.getPayload()).isEqualTo(payload));
 	}
 
 	@Test
@@ -578,21 +638,22 @@ class SqsTemplateTests {
 		String queue = "test-queue";
 		String payload = "test-payload";
 		String receiptHandle = "test-receipt-handle";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
-				.messageId(UUID.randomUUID().toString()).receiptHandle(receiptHandle).body(payload).build()).build();
+			.messageId(UUID.randomUUID().toString()).receiptHandle(receiptHandle).body(payload).build()).build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-				.configure(
-						options -> options.defaultQueue(queue).acknowledgementMode(TemplateAcknowledgementMode.MANUAL))
-				.buildSyncTemplate();
+			.configure(
+				options -> options.defaultQueue(queue).acknowledgementMode(TemplateAcknowledgementMode.MANUAL))
+			.buildSyncTemplate();
 		Optional<Message<?>> receivedMessage = template.receive();
 		assertThat(receivedMessage).isPresent()
-				.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
+			.hasValueSatisfying(message -> assertThat(message.getPayload()).isEqualTo(payload));
 		then(mockClient).should(never()).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
 	}
 
@@ -600,26 +661,27 @@ class SqsTemplateTests {
 	void shouldWrapFullAcknowledgementError() {
 		String queue = "test-queue";
 		String payload = "test-payload";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
-				.build();
+			.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.failedFuture(new RuntimeException("Expected ack error")));
+			.willReturn(CompletableFuture.failedFuture(new RuntimeException("Expected ack error")));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		assertThatThrownBy(() -> template.receive(from -> from.queue(queue)))
-				.isInstanceOf(MessagingOperationFailedException.class).cause()
-				.isInstanceOf(SqsAcknowledgementException.class)
-				.isInstanceOfSatisfying(SqsAcknowledgementException.class, ex -> {
-					assertThat(ex.getFailedAcknowledgementMessages()).hasSize(1).allSatisfy(message -> {
-						assertThat(message.getPayload()).isEqualTo(payload);
-					});
+			.isInstanceOf(MessagingOperationFailedException.class).cause()
+			.isInstanceOf(SqsAcknowledgementException.class)
+			.isInstanceOfSatisfying(SqsAcknowledgementException.class, ex -> {
+				assertThat(ex.getFailedAcknowledgementMessages()).hasSize(1).allSatisfy(message -> {
+					assertThat(message.getPayload()).isEqualTo(payload);
 				});
+			});
 	}
 
 	@Test
@@ -627,32 +689,33 @@ class SqsTemplateTests {
 		String queue = "test-queue";
 		String payload1 = "test-payload-1";
 		String payload2 = "test-payload-2";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		String messageId1 = UUID.randomUUID().toString();
 		String messageId2 = UUID.randomUUID().toString();
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(
 				builder -> builder.messageId(messageId1).receiptHandle("test-receipt-handle").body(payload1),
 				builder -> builder.messageId(messageId2).receiptHandle("test-receipt-handle").body(payload2).build())
-				.build();
+			.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-				.successful(builder -> builder.id(messageId1)).failed(builder -> builder.id(messageId2)).build();
+			.successful(builder -> builder.id(messageId1)).failed(builder -> builder.id(messageId2)).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(deleteResponse));
+			.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		assertThatThrownBy(() -> template.receive(from -> from.queue(queue)))
-				.isInstanceOf(MessagingOperationFailedException.class).cause()
-				.isInstanceOf(SqsAcknowledgementException.class)
-				.isInstanceOfSatisfying(SqsAcknowledgementException.class, ex -> {
-					assertThat(ex.getSuccessfullyAcknowledgedMessages()).hasSize(1)
-							.allSatisfy(message -> assertThat(message.getPayload()).isEqualTo(payload1));
-					assertThat(ex.getFailedAcknowledgementMessages()).hasSize(1)
-							.allSatisfy(message -> assertThat(message.getPayload()).isEqualTo(payload2));
-				});
+			.isInstanceOf(MessagingOperationFailedException.class).cause()
+			.isInstanceOf(SqsAcknowledgementException.class)
+			.isInstanceOfSatisfying(SqsAcknowledgementException.class, ex -> {
+				assertThat(ex.getSuccessfullyAcknowledgedMessages()).hasSize(1)
+					.allSatisfy(message -> assertThat(message.getPayload()).isEqualTo(payload1));
+				assertThat(ex.getFailedAcknowledgementMessages()).hasSize(1)
+					.allSatisfy(message -> assertThat(message.getPayload()).isEqualTo(payload2));
+			});
 	}
 
 	@Test
@@ -663,34 +726,31 @@ class SqsTemplateTests {
 		String headerValue1 = "headerValue";
 		String headerName2 = "headerName2";
 		String headerValue2 = "headerValue2";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
-				.build();
+			.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
-		GetQueueAttributesResponse attributesResponse = GetQueueAttributesResponse.builder()
-				.attributes(Map.of(QueueAttributeName.QUEUE_ARN, "queue-arn")).build();
-		given(mockClient.getQueueAttributes(any(Consumer.class)))
-				.willReturn(CompletableFuture.completedFuture(attributesResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+		mockQueueAttributes(mockClient, Map.of(QueueAttributeName.QUEUE_ARN, "queue-arn"));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(deleteResponse));
+			.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		String testMessageAttributes = "test-message-attributes";
 		MessageSystemAttributeName systemAttribute = MessageSystemAttributeName.MESSAGE_GROUP_ID;
 		QueueAttributeName queueAttribute = QueueAttributeName.QUEUE_ARN;
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-				.configure(options -> options.defaultQueue(queue).defaultPollTimeout(Duration.ofSeconds(1))
-						.messageAttributeNames(Collections.singletonList(testMessageAttributes))
-						.messageSystemAttributeNames(Collections.singletonList(systemAttribute))
-						.queueAttributeNames(Collections.singletonList(queueAttribute))
-						.additionalHeaderForReceive(headerName1, headerValue1)
-						.additionalHeadersForReceive(Map.of(headerName2, headerValue2)))
-				.buildSyncTemplate();
+			.configure(options -> options.defaultQueue(queue).defaultPollTimeout(Duration.ofSeconds(1))
+				.messageAttributeNames(Collections.singletonList(testMessageAttributes))
+				.messageSystemAttributeNames(Collections.singletonList(systemAttribute))
+				.queueAttributeNames(Collections.singletonList(queueAttribute))
+				.additionalHeaderForReceive(headerName1, headerValue1)
+				.additionalHeadersForReceive(Map.of(headerName2, headerValue2)))
+			.buildSyncTemplate();
 		Optional<Message<?>> receivedMessage = template.receive();
 		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> {
 			assertThat(message.getPayload()).isEqualTo(payload);
@@ -709,12 +769,12 @@ class SqsTemplateTests {
 		GetQueueUrlRequest capturedUrlRequest = queueCaptor.getValue();
 		assertThat(capturedUrlRequest.queueName()).isEqualTo(queue);
 		ArgumentCaptor<Consumer<GetQueueAttributesRequest.Builder>> queueAttributesCaptor = ArgumentCaptor
-				.forClass(Consumer.class);
+			.forClass(Consumer.class);
 		then(mockClient).should().getQueueAttributes(queueAttributesCaptor.capture());
 		GetQueueAttributesRequest.Builder getAttributesBuilder = GetQueueAttributesRequest.builder();
 		queueAttributesCaptor.getValue().accept(getAttributesBuilder);
 		GetQueueAttributesRequest attributesRequest = getAttributesBuilder.build();
-		assertThat(attributesRequest.attributeNamesAsStrings()).hasSize(1).first().isEqualTo(queueAttribute.toString());
+		assertThat(attributesRequest.attributeNamesAsStrings()).hasSize(2).contains(queueAttribute.toString());
 		assertThat(attributesRequest.queueUrl()).isEqualTo(queue);
 
 	}
@@ -727,24 +787,26 @@ class SqsTemplateTests {
 		String headerValue1 = "headerValue";
 		String headerName2 = "headerName2";
 		String headerValue2 = "headerValue2";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
+
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder().messages(builder -> builder
 				.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle").body(payload).build())
-				.build();
+			.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(deleteResponse));
+			.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		Optional<Message<String>> receivedMessage = template.receive(from -> from.queue(queue)
 				.pollTimeout(Duration.ofSeconds(1)).visibilityTimeout(Duration.ofSeconds(5))
 				.additionalHeader(headerName1, headerValue1).additionalHeaders(Map.of(headerName2, headerValue2)),
-				String.class);
+			String.class);
 		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> {
 			assertThat(message.getPayload()).isEqualTo(payload);
 			assertThat(message.getHeaders()).containsEntry(headerName1, headerValue1);
@@ -762,34 +824,35 @@ class SqsTemplateTests {
 	void shouldReceiveFifoWithGivenAttemptId() {
 		String queue = "test-queue";
 		String payload = "test-payload";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		String messageGroupId = UUID.randomUUID().toString();
 		String deduplicationId = UUID.randomUUID().toString();
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-				.messages(builder -> builder.messageId(UUID.randomUUID().toString())
-						.attributes(Map.of(MessageSystemAttributeName.MESSAGE_GROUP_ID, messageGroupId,
-								MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID, deduplicationId))
-						.receiptHandle("test-receipt-handle").body(payload).build())
-				.build();
+			.messages(builder -> builder.messageId(UUID.randomUUID().toString())
+				.attributes(Map.of(MessageSystemAttributeName.MESSAGE_GROUP_ID, messageGroupId,
+					MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID, deduplicationId))
+				.receiptHandle("test-receipt-handle").body(payload).build())
+			.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(deleteResponse));
+			.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		UUID attemptId = UUID.randomUUID();
 		Optional<Message<String>> receivedMessage = template
-				.receive(from -> from.queue(queue).receiveRequestAttemptId(attemptId), String.class);
+			.receive(from -> from.queue(queue).receiveRequestAttemptId(attemptId), String.class);
 		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> {
 			assertThat(message.getPayload()).isEqualTo(payload);
 			assertThat(message.getHeaders())
-					.containsEntry(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId);
+				.containsEntry(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId);
 			assertThat(message.getHeaders()).containsEntry(
-					SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, deduplicationId);
+				SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, deduplicationId);
 		});
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
 		then(mockClient).should().receiveMessage(captor.capture());
@@ -802,32 +865,33 @@ class SqsTemplateTests {
 	void shouldReceiveFifoWithRandomAttemptId() {
 		String queue = "test-queue.fifo";
 		String payload = "test-payload";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of(QueueAttributeName.CONTENT_BASED_DEDUPLICATION, "false"));
 		String messageGroupId = UUID.randomUUID().toString();
 		String deduplicationId = UUID.randomUUID().toString();
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-				.messages(builder -> builder.messageId(UUID.randomUUID().toString())
-						.attributes(Map.of(MessageSystemAttributeName.MESSAGE_GROUP_ID, messageGroupId,
-								MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID, deduplicationId))
-						.receiptHandle("test-receipt-handle").body(payload).build())
-				.build();
+			.messages(builder -> builder.messageId(UUID.randomUUID().toString())
+				.attributes(Map.of(MessageSystemAttributeName.MESSAGE_GROUP_ID, messageGroupId,
+					MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID, deduplicationId))
+				.receiptHandle("test-receipt-handle").body(payload).build())
+			.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(deleteResponse));
+			.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		Optional<Message<String>> receivedMessage = template.receive(from -> from.queue(queue), String.class);
 		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> {
 			assertThat(message.getPayload()).isEqualTo(payload);
 			assertThat(message.getHeaders())
-					.containsEntry(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId);
+				.containsEntry(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, messageGroupId);
 			assertThat(message.getHeaders()).containsEntry(
-					SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, deduplicationId);
+				SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, deduplicationId);
 		});
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
 		then(mockClient).should().receiveMessage(captor.capture());
@@ -840,32 +904,33 @@ class SqsTemplateTests {
 	void shouldReceiveBatchWithDefaultValues() {
 		String queue = "test-queue";
 		String payload = "test-payload";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-				.messages(
-						builder -> builder.messageId(UUID.randomUUID().toString())
-								.receiptHandle("test-receipt-handle-1").body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString())
-								.receiptHandle("test-receipt-handle-2").body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString())
-								.receiptHandle("test-receipt-handle-3").body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString())
-								.receiptHandle("test-receipt-handle-4").body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString())
-								.receiptHandle("test-receipt-handle-5").body(payload).build())
-				.build();
+			.messages(
+				builder -> builder.messageId(UUID.randomUUID().toString())
+					.receiptHandle("test-receipt-handle-1").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString())
+					.receiptHandle("test-receipt-handle-2").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString())
+					.receiptHandle("test-receipt-handle-3").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString())
+					.receiptHandle("test-receipt-handle-4").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString())
+					.receiptHandle("test-receipt-handle-5").body(payload).build())
+			.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(deleteResponse));
+			.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient).configure(options -> options
 				.defaultQueue(queue).defaultPollTimeout(Duration.ofSeconds(5)).defaultMaxNumberOfMessages(6))
-				.buildSyncTemplate();
+			.buildSyncTemplate();
 		Collection<Message<?>> receivedMessages = template.receiveMany();
 		assertThat(receivedMessages).hasSize(5);
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
@@ -881,36 +946,38 @@ class SqsTemplateTests {
 	void shouldReceiveBatchWithQueueAndPayload() {
 		String queue = "test-queue";
 		String payload = "test-payload";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
+
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-				.messages(
-						builder -> builder.messageId(UUID.randomUUID().toString())
-								.receiptHandle("test-receipt-handle-1").body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString())
-								.receiptHandle("test-receipt-handle-2").body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString())
-								.receiptHandle("test-receipt-handle-3").body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString())
-								.receiptHandle("test-receipt-handle-4").body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString())
-								.receiptHandle("test-receipt-handle-5").body(payload).build())
-				.build();
+			.messages(
+				builder -> builder.messageId(UUID.randomUUID().toString())
+					.receiptHandle("test-receipt-handle-1").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString())
+					.receiptHandle("test-receipt-handle-2").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString())
+					.receiptHandle("test-receipt-handle-3").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString())
+					.receiptHandle("test-receipt-handle-4").body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString())
+					.receiptHandle("test-receipt-handle-5").body(payload).build())
+			.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(deleteResponse));
+			.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		int defaultPollTimeout = 5;
 		int defaultMaxNumberOfMessages = 6;
 		SqsAsyncOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient)
-				.configure(options -> options.defaultQueue(queue)
-						.defaultPollTimeout(Duration.ofSeconds(defaultPollTimeout))
-						.defaultMaxNumberOfMessages(defaultMaxNumberOfMessages))
-				.buildAsyncTemplate();
+			.configure(options -> options.defaultQueue(queue)
+				.defaultPollTimeout(Duration.ofSeconds(defaultPollTimeout))
+				.defaultMaxNumberOfMessages(defaultMaxNumberOfMessages))
+			.buildAsyncTemplate();
 		Collection<Message<String>> receivedMessages = template.receiveManyAsync(queue, String.class).join();
 		assertThat(receivedMessages).hasSize(5);
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
@@ -929,33 +996,34 @@ class SqsTemplateTests {
 	void shouldReceiveBatchWithOptions() {
 		String queue = "test-queue";
 		String payload = "test-payload";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-				.messages(
-						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-								.body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-								.body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-								.body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-								.body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-								.body(payload).build())
-				.build();
+			.messages(
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+					.body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+					.body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+					.body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+					.body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+					.body(payload).build())
+			.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(deleteResponse));
+			.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		Collection<Message<String>> receivedMessages = template.receiveMany(from -> from.queue(queue)
 				.maxNumberOfMessages(6).visibilityTimeout(Duration.ofSeconds(3)).pollTimeout(Duration.ofSeconds(5)),
-				String.class);
+			String.class);
 		assertThat(receivedMessages).hasSize(5);
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
 		then(mockClient).should().receiveMessage(captor.capture());
@@ -970,33 +1038,34 @@ class SqsTemplateTests {
 	void shouldReceiveBatchFifo() {
 		String queue = "test-queue";
 		String payload = "test-payload";
-		SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
 		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
 		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(urlResponse));
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
 		ReceiveMessageResponse receiveMessageResponse = ReceiveMessageResponse.builder()
-				.messages(
-						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-								.body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-								.body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-								.body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-								.body(payload).build(),
-						builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
-								.body(payload).build())
-				.build();
+			.messages(
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+					.body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+					.body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+					.body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+					.body(payload).build(),
+				builder -> builder.messageId(UUID.randomUUID().toString()).receiptHandle("test-receipt-handle")
+					.body(payload).build())
+			.build();
 		given(mockClient.receiveMessage(any(ReceiveMessageRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
+			.willReturn(CompletableFuture.completedFuture(receiveMessageResponse));
 		DeleteMessageBatchResponse deleteResponse = DeleteMessageBatchResponse.builder()
-				.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
+			.successful(builder -> builder.id(UUID.randomUUID().toString())).build();
 		given(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
-				.willReturn(CompletableFuture.completedFuture(deleteResponse));
+			.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		UUID attemptId = UUID.randomUUID();
 		Collection<Message<?>> receivedMessages = template
-				.receiveMany(from -> from.queue(queue).receiveRequestAttemptId(attemptId));
+			.receiveMany(from -> from.queue(queue).receiveRequestAttemptId(attemptId));
 		assertThat(receivedMessages).hasSize(5);
 		ArgumentCaptor<ReceiveMessageRequest> captor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
 		then(mockClient).should().receiveMessage(captor.capture());


### PR DESCRIPTION


## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Conditionally add a random UUID dedup ID if the queue isn't configured for content based deduplication to allow consumers who are using AWS SQS's content based deduplication functionality to let AWS decide what's a duplicate.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes an issue with the same content being delivered via a FIFO queue configured with content based deduplication.


## :green_heart: How did you test it?
Added unit test.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [X ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
