### PR TITLE
Ability to set SmartLifecycle.phase to SqsMessageListenerContainer/DefaultListenerContainerRegistry

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -955,6 +955,8 @@ MessageListenerContainer<Object> listenerContainer(SqsAsyncClient sqsAsyncClient
 }
 ----
 
+NOTE: You can also specify the `SmartLifecycle.phase`, using `SqsMessageListenerContainer.builder()`, if you are interested on overriding the default value defined in `MessageListenerContainer.DEFAULT_PHASE`
+
 ===== Retrieving Containers from the Registry
 
 Containers can be retrieved by fetching the `MessageListenerContainer` bean from the container and using the `getListenerContainers` and `getContainerById` methods.

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -927,7 +927,7 @@ The `MessageListenerContainer` interface extends `SmartLifecycle`, which provide
 Containers created from `@SqsListener` annotations are registered in a `MessageListenerContainerRegistry` bean that is registered by the framework.
 The containers themselves are not Spring-managed beans, and the registry is responsible for managing these containers` lifecycle in application startup and shutdown.
 
-NOTE: The framework offers the `DefaultListenerContainerRegistry` implementation, where you can override the `SmartLifecycle.phase`. By default, the `phase` value is `MessageListenerContainer.DEFAULT_PHASE`
+NOTE: The `DefaultListenerContainerRegistry ` implementation provided by the framework allows the phase value to be set through the `setPhase` method. The default value is `MessageListenerContainer.DEFAULT_PHASE`.
 
 At startup, the containers will make requests to `SQS` to retrieve the queues` urls for the provided queue names or ARNs, and for retrieving `QueueAttributes` if so configured.
 Providing queue urls instead of names and not requesting queue attributes can result in slightly better startup times since there's no need for such requests.
@@ -957,7 +957,7 @@ MessageListenerContainer<Object> listenerContainer(SqsAsyncClient sqsAsyncClient
 }
 ----
 
-NOTE: You can also specify the `SmartLifecycle.phase`, using `SqsMessageListenerContainer.builder()`, if you are interested on overriding the default value defined in `MessageListenerContainer.DEFAULT_PHASE`
+NOTE: The `SqsMessageListenerContainer.builder()` allows to specify the `SmartLifecycle.phase`, to override the default value defined in `MessageListenerContainer.DEFAULT_PHASE`
 
 ===== Retrieving Containers from the Registry
 

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -927,6 +927,8 @@ The `MessageListenerContainer` interface extends `SmartLifecycle`, which provide
 Containers created from `@SqsListener` annotations are registered in a `MessageListenerContainerRegistry` bean that is registered by the framework.
 The containers themselves are not Spring-managed beans, and the registry is responsible for managing these containers` lifecycle in application startup and shutdown.
 
+NOTE: The framework offers the `DefaultListenerContainerRegistry` implementation, where you can override the `SmartLifecycle.phase`. By default, the `phase` value is `MessageListenerContainer.DEFAULT_PHASE`
+
 At startup, the containers will make requests to `SQS` to retrieve the queues` urls for the provided queue names or ARNs, and for retrieving `QueueAttributes` if so configured.
 Providing queue urls instead of names and not requesting queue attributes can result in slightly better startup times since there's no need for such requests.
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
@@ -69,6 +69,8 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 	private AsyncAcknowledgementResultCallback<T> acknowledgementResultCallback = new AsyncAcknowledgementResultCallback<T>() {
 	};
 
+	private int phase;
+
 	/**
 	 * Create an instance with the provided {@link ContainerOptions}
 	 * @param containerOptions the options instance.
@@ -163,6 +165,14 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 	}
 
 	/**
+	 * Set the phase for the SmartLifecycle for this container instance.
+	 * @param phase the phase.
+	 */
+	public void setPhase(int phase) {
+		this.phase = phase;
+	}
+
+	/**
 	 * Returns the {@link ContainerOptions} instance for this container. Changed options will take effect on container
 	 * restart.
 	 */
@@ -250,6 +260,11 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 	@Override
 	public boolean isRunning() {
 		return this.isRunning;
+	}
+
+	@Override
+	public int getPhase() {
+		return this.phase;
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
@@ -69,7 +69,7 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 	private AsyncAcknowledgementResultCallback<T> acknowledgementResultCallback = new AsyncAcknowledgementResultCallback<T>() {
 	};
 
-	private int phase;
+	private int phase = DEFAULT_PHASE;
 
 	/**
 	 * Create an instance with the provided {@link ContainerOptions}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
@@ -264,6 +264,7 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 
 	public int getPhase() {
 		return this.phase;
+	}
 
 	@Override
 	public boolean isAutoStartup() {

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistry.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistry.java
@@ -50,6 +50,8 @@ public class DefaultListenerContainerRegistry implements MessageListenerContaine
 
 	private volatile boolean running = false;
 
+	private int phase = MessageListenerContainer.DEFAULT_PHASE;
+
 	@Override
 	public void registerListenerContainer(MessageListenerContainer<?> listenerContainer) {
 		Assert.notNull(listenerContainer, "listenerContainer cannot be null");
@@ -95,4 +97,12 @@ public class DefaultListenerContainerRegistry implements MessageListenerContaine
 		return this.running;
 	}
 
+	@Override
+	public int getPhase() {
+		return phase;
+	}
+
+	public void setPhase(int phase) {
+		this.phase = phase;
+	}
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/MessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/MessageListenerContainer.java
@@ -28,6 +28,8 @@ import org.springframework.messaging.Message;
  */
 public interface MessageListenerContainer<T> extends SmartLifecycle {
 
+	int DEFAULT_PHASE = Integer.MAX_VALUE;
+
 	/**
 	 * Get the container id.
 	 * @return the id.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainer.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
@@ -177,6 +178,8 @@ public class SqsMessageListenerContainer<T>
 
 		private AcknowledgementResultCallback<T> acknowledgementResultCallback;
 
+		private Integer phase;
+
 		public Builder<T> id(String id) {
 			this.id = id;
 			return this;
@@ -250,6 +253,11 @@ public class SqsMessageListenerContainer<T>
 			return this;
 		}
 
+		public Builder<T> phase(Integer phase) {
+			this.phase = phase;
+			return this;
+		}
+
 		// @formatter:off
 		public SqsMessageListenerContainer<T> build() {
 			SqsMessageListenerContainer<T> container = new SqsMessageListenerContainer<>(this.sqsAsyncClient);
@@ -262,9 +270,11 @@ public class SqsMessageListenerContainer<T>
 					.acceptIfNotNull(this.acknowledgementResultCallback, container::setAcknowledgementResultCallback)
 					.acceptIfNotNull(this.asyncAcknowledgementResultCallback, container::setAcknowledgementResultCallback)
 					.acceptIfNotNull(this.containerComponentFactories, container::setComponentFactories)
-					.acceptIfNotEmpty(this.queueNames, container::setQueueNames);
+					.acceptIfNotEmpty(this.queueNames, container::setQueueNames)
+					.acceptIfNotNullOrElse(container::setPhase, this.phase, SmartLifecycle.DEFAULT_PHASE);
 			this.messageInterceptors.forEach(container::addMessageInterceptor);
 			this.asyncMessageInterceptors.forEach(container::addMessageInterceptor);
+
 			container.configure(this.optionsConsumer);
 			return container;
 		}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainer.java
@@ -271,7 +271,7 @@ public class SqsMessageListenerContainer<T>
 					.acceptIfNotNull(this.asyncAcknowledgementResultCallback, container::setAcknowledgementResultCallback)
 					.acceptIfNotNull(this.containerComponentFactories, container::setComponentFactories)
 					.acceptIfNotEmpty(this.queueNames, container::setQueueNames)
-					.acceptIfNotNullOrElse(container::setPhase, this.phase, SmartLifecycle.DEFAULT_PHASE);
+					.acceptIfNotNullOrElse(container::setPhase, this.phase, DEFAULT_PHASE);
 			this.messageInterceptors.forEach(container::addMessageInterceptor);
 			this.asyncMessageInterceptors.forEach(container::addMessageInterceptor);
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainerTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainerTests.java
@@ -27,6 +27,7 @@ import io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.SmartLifecycle;
 
 /**
  * Tests for {@link AbstractMessageListenerContainer}.
@@ -73,6 +74,7 @@ class AbstractMessageListenerContainerTests {
 				.isInstanceOf(AsyncComponentAdapters.AbstractThreadingComponentAdapter.class)
 				.extracting("blockingMessageInterceptor").isEqualTo(interceptor);
 
+		assertThat(container.getPhase()).isEqualTo(SmartLifecycle.DEFAULT_PHASE);
 	}
 
 	@Test
@@ -101,6 +103,7 @@ class AbstractMessageListenerContainerTests {
 		assertThat(container.getAcknowledgementResultCallback()).isEqualTo(callback);
 		assertThat(container.getContainerComponentFactories()).containsExactlyElementsOf(componentFactories);
 		assertThat(container.getMessageInterceptors()).containsExactly(interceptor);
+		assertThat(container.getPhase()).isEqualTo(SmartLifecycle.DEFAULT_PHASE);
 
 	}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainerTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainerTests.java
@@ -27,7 +27,6 @@ import io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.springframework.context.SmartLifecycle;
 
 /**
  * Tests for {@link AbstractMessageListenerContainer}.
@@ -74,7 +73,7 @@ class AbstractMessageListenerContainerTests {
 				.isInstanceOf(AsyncComponentAdapters.AbstractThreadingComponentAdapter.class)
 				.extracting("blockingMessageInterceptor").isEqualTo(interceptor);
 
-		assertThat(container.getPhase()).isEqualTo(SmartLifecycle.DEFAULT_PHASE);
+		assertThat(container.getPhase()).isEqualTo(MessageListenerContainer.DEFAULT_PHASE);
 	}
 
 	@Test
@@ -103,7 +102,7 @@ class AbstractMessageListenerContainerTests {
 		assertThat(container.getAcknowledgementResultCallback()).isEqualTo(callback);
 		assertThat(container.getContainerComponentFactories()).containsExactlyElementsOf(componentFactories);
 		assertThat(container.getMessageInterceptors()).containsExactly(interceptor);
-		assertThat(container.getPhase()).isEqualTo(SmartLifecycle.DEFAULT_PHASE);
+		assertThat(container.getPhase()).isEqualTo(MessageListenerContainer.DEFAULT_PHASE);
 
 	}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistryTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistryTests.java
@@ -38,6 +38,7 @@ class DefaultListenerContainerRegistryTests {
 		given(container.getId()).willReturn(id);
 		DefaultListenerContainerRegistry registry = new DefaultListenerContainerRegistry();
 		registry.registerListenerContainer(container);
+		assertThat(registry.getPhase()).isEqualTo(MessageListenerContainer.DEFAULT_PHASE);
 	}
 
 	@Test
@@ -46,9 +47,11 @@ class DefaultListenerContainerRegistryTests {
 		String id = "test-container-id";
 		given(container.getId()).willReturn(id);
 		DefaultListenerContainerRegistry registry = new DefaultListenerContainerRegistry();
+		registry.setPhase(2);
 		registry.registerListenerContainer(container);
 		MessageListenerContainer<?> containerFromRegistry = registry.getContainerById(id);
 		assertThat(containerFromRegistry).isEqualTo(container);
+		assertThat(registry.getPhase()).isEqualTo(2);
 	}
 
 	@Test

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainerTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainerTests.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
@@ -61,11 +62,12 @@ class SqsMessageListenerContainerTests {
 		List<ContainerComponentFactory<Object, SqsContainerOptions>> componentFactories = Collections
 				.singletonList(componentFactory);
 		List<String> queueNames = Arrays.asList("test-queue-name-1", "test-queue-name-2");
+		Integer phase = 2;
 
 		SqsMessageListenerContainer<Object> container = SqsMessageListenerContainer.builder().messageListener(listener)
 				.sqsAsyncClient(client).errorHandler(errorHandler).componentFactories(componentFactories)
 				.acknowledgementResultCallback(callback).messageInterceptor(interceptor1)
-				.messageInterceptor(interceptor2).queueNames(queueNames).build();
+				.messageInterceptor(interceptor2).queueNames(queueNames).phase(phase).build();
 
 		assertThat(container.getMessageListener())
 				.isInstanceOf(AsyncComponentAdapters.AbstractThreadingComponentAdapter.class)
@@ -90,6 +92,8 @@ class SqsMessageListenerContainerTests {
 		assertThat(container).extracting("sqsAsyncClient").isEqualTo(client);
 
 		assertThat(container.getQueueNames()).containsExactlyElementsOf(queueNames);
+
+		assertThat(container.getPhase()).isEqualTo(phase);
 	}
 
 	@Test
@@ -114,6 +118,7 @@ class SqsMessageListenerContainerTests {
 		assertThat(container.getErrorHandler()).isEqualTo(errorHandler);
 		assertThat(container.getAcknowledgementResultCallback()).isEqualTo(callback);
 		assertThat(container.getMessageInterceptors()).containsExactly(interceptor1, interceptor2);
+		assertThat(container.getPhase()).isEqualTo(SmartLifecycle.DEFAULT_PHASE);
 	}
 
 	@Test

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainerTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainerTests.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import org.junit.jupiter.api.Test;
-import org.springframework.context.SmartLifecycle;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
@@ -118,7 +117,7 @@ class SqsMessageListenerContainerTests {
 		assertThat(container.getErrorHandler()).isEqualTo(errorHandler);
 		assertThat(container.getAcknowledgementResultCallback()).isEqualTo(callback);
 		assertThat(container.getMessageInterceptors()).containsExactly(interceptor1, interceptor2);
-		assertThat(container.getPhase()).isEqualTo(SmartLifecycle.DEFAULT_PHASE);
+		assertThat(container.getPhase()).isEqualTo(MessageListenerContainer.DEFAULT_PHASE);
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

- Adding the ability to set the `SmartLifecycle.phase` on `SqsMessageListenerContainer` using the builder
- Adding the ability to set the `SmartLifecycle.phase` on `AbstractMessageListenerContainer` using the `setPhase` method
- Adding the ability to set the `SmartLifecycle.phase` on `DefaultListenerContainerRegistry` using the `setPhase` method
- Update unit tests on `SqsMessageListenerContainerTests`,  `AbstractMessageListenerContainerTests` and `DefaultListenerContainerRegistryTests`


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Details on https://github.com/awspring/spring-cloud-aws/issues/693

## :green_heart: How did you test it?

- Update unit tests on `SqsMessageListenerContainerTests` and `AbstractMessageListenerContainerTests`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
