### PR TITLE
Add support for autoStartup

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -803,6 +803,13 @@ See AWS documentation for more information.
 After that period, the framework will try to perform a partial acquire with the available permits, resulting in a poll for less than `maxMessagesPerPoll` messages, unless otherwise configured.
 See <<Message Processing Throughput>>.
 
+|`autoStartup`
+|true, false
+|true
+|Determines wherever container should start automatically. When set to false the
+container will not launch on startup, requiring manual intervention to start it.
+See <<Container Lifecycle>>.
+
 |`listenerShutdownTimeout`
 |0 - undefined
 |10 seconds

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractContainerOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractContainerOptions.java
@@ -37,6 +37,8 @@ public abstract class AbstractContainerOptions<O extends ContainerOptions<O, B>,
 
 	private final int maxMessagesPerPoll;
 
+	private final boolean autoStartup;
+
 	private final Duration pollTimeout;
 
 	private final Duration maxDelayBetweenPolls;
@@ -71,6 +73,7 @@ public abstract class AbstractContainerOptions<O extends ContainerOptions<O, B>,
 	protected AbstractContainerOptions(Builder<?, ?> builder) {
 		this.maxConcurrentMessages = builder.maxConcurrentMessages;
 		this.maxMessagesPerPoll = builder.maxMessagesPerPoll;
+		this.autoStartup = builder.autoStartup;
 		this.pollTimeout = builder.pollTimeout;
 		this.maxDelayBetweenPolls = builder.maxDelayBetweenPolls;
 		this.listenerShutdownTimeout = builder.listenerShutdownTimeout;
@@ -97,6 +100,11 @@ public abstract class AbstractContainerOptions<O extends ContainerOptions<O, B>,
 	@Override
 	public int getMaxMessagesPerPoll() {
 		return this.maxMessagesPerPoll;
+	}
+
+	@Override
+	public boolean isAutoStartup() {
+		return this.autoStartup;
 	}
 
 	@Override
@@ -176,6 +184,8 @@ public abstract class AbstractContainerOptions<O extends ContainerOptions<O, B>,
 
 		private static final int DEFAULT_MAX_MESSAGES_PER_POLL = 10;
 
+		private static final boolean DEFAULT_AUTO_STARTUP = true;
+		
 		private static final Duration DEFAULT_POLL_TIMEOUT = Duration.ofSeconds(10);
 
 		private static final Duration DEFAULT_SEMAPHORE_TIMEOUT = Duration.ofSeconds(10);
@@ -195,6 +205,8 @@ public abstract class AbstractContainerOptions<O extends ContainerOptions<O, B>,
 		private int maxConcurrentMessages = DEFAULT_MAX_INFLIGHT_MSG_PER_QUEUE;
 
 		private int maxMessagesPerPoll = DEFAULT_MAX_MESSAGES_PER_POLL;
+
+		private boolean autoStartup = DEFAULT_AUTO_STARTUP;
 
 		private Duration pollTimeout = DEFAULT_POLL_TIMEOUT;
 
@@ -233,6 +245,7 @@ public abstract class AbstractContainerOptions<O extends ContainerOptions<O, B>,
 		protected Builder(AbstractContainerOptions<?, ?> options) {
 			this.maxConcurrentMessages = options.maxConcurrentMessages;
 			this.maxMessagesPerPoll = options.maxMessagesPerPoll;
+			this.autoStartup = options.autoStartup;
 			this.pollTimeout = options.pollTimeout;
 			this.maxDelayBetweenPolls = options.maxDelayBetweenPolls;
 			this.listenerShutdownTimeout = options.listenerShutdownTimeout;
@@ -258,6 +271,12 @@ public abstract class AbstractContainerOptions<O extends ContainerOptions<O, B>,
 		@Override
 		public B maxMessagesPerPoll(int maxMessagesPerPoll) {
 			this.maxMessagesPerPoll = maxMessagesPerPoll;
+			return self();
+		}
+
+		@Override
+		public B autoStartup(boolean autoStartup) {
+			this.autoStartup = autoStartup;
 			return self();
 		}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
@@ -253,6 +253,11 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 	}
 
 	@Override
+	public boolean isAutoStartup() {
+		return containerOptions.isAutoStartup();
+	}
+
+	@Override
 	public void start() {
 		if (this.isRunning) {
 			return;

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptions.java
@@ -51,6 +51,13 @@ public interface ContainerOptions<O extends ContainerOptions<O, B>, B extends Co
 	int getMaxMessagesPerPoll();
 
 	/**
+	 * Checks whether the container should be started automatically or manually. Default is true.
+	 *
+	 * @return true if the container starts automatically, false if it should be started manually
+	 */
+	boolean isAutoStartup();
+
+	/**
 	 * Set the maximum time the polling thread should wait for a full batch of permits to be available before trying to
 	 * acquire a partial batch if so configured. A poll is only actually executed if at least one permit is available.
 	 * Default is 10 seconds.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptionsBuilder.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptionsBuilder.java
@@ -47,6 +47,15 @@ public interface ContainerOptionsBuilder<B extends ContainerOptionsBuilder<B, O>
 	B maxMessagesPerPoll(int maxMessagesPerPoll);
 
 	/**
+	 * Set whether the container should be started automatically or manually. By default, the container is set to start
+	 * automatically.
+	 *
+	 * @param autoStartup true if the container is set to start automatically, false if it should be started manually
+	 * @return this instance.
+	 */
+	B autoStartup(boolean autoStartup);
+
+	/**
 	 * Set the maximum time the polling thread should wait for a full batch of permits to be available before trying to
 	 * acquire a partial batch if so configured. A poll is only actually executed if at least one permit is available.
 	 * Default is 10 seconds.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistry.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistry.java
@@ -18,10 +18,13 @@ package io.awspring.cloud.sqs.listener;
 import io.awspring.cloud.sqs.LifecycleHandler;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -75,7 +78,9 @@ public class DefaultListenerContainerRegistry implements MessageListenerContaine
 	public void start() {
 		synchronized (this.lifecycleMonitor) {
 			logger.debug("Starting {}", getClass().getSimpleName());
-			LifecycleHandler.get().start(this.listenerContainers.values());
+			List<MessageListenerContainer<?>> containersToStart = this.listenerContainers.values().stream()
+					.filter(SmartLifecycle::isAutoStartup).collect(Collectors.toList());
+			LifecycleHandler.get().start(containersToStart);
 			this.running = true;
 			logger.debug("{} started", getClass().getSimpleName());
 		}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistryTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistryTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 
 import org.junit.jupiter.api.Test;
 
@@ -78,8 +79,11 @@ class DefaultListenerContainerRegistryTests {
 		String id2 = "test-container-id-2";
 		String id3 = "test-container-id-3";
 		given(container1.getId()).willReturn(id1);
+		given(container1.isAutoStartup()).willReturn(true);
 		given(container2.getId()).willReturn(id2);
+		given(container2.isAutoStartup()).willReturn(true);
 		given(container3.getId()).willReturn(id3);
+		given(container3.isAutoStartup()).willReturn(true);
 		DefaultListenerContainerRegistry registry = new DefaultListenerContainerRegistry();
 		registry.registerListenerContainer(container1);
 		registry.registerListenerContainer(container2);
@@ -94,6 +98,21 @@ class DefaultListenerContainerRegistryTests {
 		then(container2).should().stop();
 		then(container3).should().start();
 		then(container3).should().stop();
+	}
+
+	@Test
+	void shouldNotStartContainerWithAutoStartupFalse() {
+		MessageListenerContainer<Object> container1 = mock(MessageListenerContainer.class);
+		String id1 = "test-container-id-1";
+		given(container1.getId()).willReturn(id1);
+		DefaultListenerContainerRegistry registry = new DefaultListenerContainerRegistry();
+		registry.registerListenerContainer(container1);
+		registry.start();
+		assertThat(registry.isRunning()).isTrue();
+		registry.stop();
+		assertThat(registry.isRunning()).isFalse();
+		then(container1).should(times(0)).start();
+		then(container1).should().stop();
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
I added a new SqsContainerOption `autoStartup` boolean which is used to override the method `isAutoStartup()` from the `SmartLifeCycle` interface.



## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#818 
It is needed in my service where Listener may not have to be active on the startup.


## :green_heart: How did you test it?
- Junit
- Integration Tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
