### PR TITLE
Add S3Client listObjects support in S3Template

### DIFF
--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Operations.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Operations.java
@@ -18,6 +18,7 @@ package io.awspring.cloud.s3;
 import java.io.InputStream;
 import java.net.URL;
 import java.time.Duration;
+import java.util.List;
 import org.springframework.lang.Nullable;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
@@ -60,7 +61,17 @@ public interface S3Operations {
 	 * @param s3Url - the S3 url s3://bucket/key
 	 */
 	void deleteObject(String s3Url);
-
+	
+	/**
+	 * Returns some or all (up to 1,000) of the objects in a bucket.
+	 * Does not handle pagination. If you need pagination you should use {@link S3PathMatchingResourcePatternResolver} or {@link S3Client}
+	 *
+	 * @param bucketName - the bucket name
+	 * @param prefix - objects prefix
+	 * @return list of {@link S3Resource}
+	 */
+	List<S3Resource> listObjects(String bucketName, String prefix);
+	
 	/**
 	 * Stores a Java object in a S3 bucket. Uses {@link S3ObjectConverter} for serialization.
 	 *

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
@@ -157,15 +157,10 @@ class S3TemplateIntegrationTests {
 		
 		List<S3Resource> resources = s3Template.listObjects(BUCKET_NAME, "hello");
 		assertThat(resources.size()).isEqualTo(2);
-		
+
 		// According to the S3Client doc : "Objects are returned sorted in an ascending order of the respective key names in the list."
-		try (InputStream is = resources.get(0).getInputStream(); InputStream is2 = resources.get(1).getInputStream()) {
-			String result = StreamUtils.copyToString(is, StandardCharsets.UTF_8);
-			assertThat(result).isEqualTo("hello");
-			
-			String result2 = StreamUtils.copyToString(is2, StandardCharsets.UTF_8);
-			assertThat(result2).isEqualTo("bonjour");
-		}
+		assertThat(resources).extracting(S3Resource::getInputStream).map(is -> new String(is.readAllBytes(), StandardCharsets.UTF_8))
+			.containsExactly("hello", "bonjour");
 	}
 	
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
I've added the listObjects operation in S3Template.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It fixes the issue : https://github.com/awspring/spring-cloud-aws/issues/767


## :green_heart: How did you test it?
I added an integration test in S3TemplateIntegrationTests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
