### PR TITLE
apply path-style-access-enabled config to CRT client

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfiguration.java
@@ -66,6 +66,7 @@ public class S3CrtAsyncClientAutoConfiguration {
 				.region(this.awsClientBuilderConfigurer.resolveRegion(this.properties));
 		Optional.ofNullable(this.awsProperties.getEndpoint()).ifPresent(builder::endpointOverride);
 		Optional.ofNullable(this.properties.getEndpoint()).ifPresent(builder::endpointOverride);
+		Optional.ofNullable(this.properties.getPathStyleAccessEnabled()).ifPresent(builder::forcePathStyle);
 
 		if (this.properties.getCrt() != null) {
 			S3CrtClientProperties crt = this.properties.getCrt();

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfigurationTests.java
@@ -27,9 +27,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.endpoints.S3ClientContextParams;
 import software.amazon.awssdk.services.s3.internal.crt.S3NativeClientConfiguration;
+import software.amazon.awssdk.utils.AttributeMap;
 
 /**
  * Tests for {@link S3CrtAsyncClientAutoConfiguration}.
@@ -75,6 +79,17 @@ class S3CrtAsyncClientAutoConfigurationTests {
 						assertThat(configuredClient.isEndpointOverridden()).isTrue();
 					});
 		}
+	}
+
+	@Test
+	void withPathStyleAccessEnabled() {
+		contextRunner.withPropertyValues("spring.cloud.aws.s3.path-style-access-enabled:true").run(context -> {
+			S3AsyncClient client = context.getBean(S3AsyncClient.class);
+			S3AsyncClient delegate = (S3AsyncClient) ReflectionTestUtils.getField(client, "delegate");
+			SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(delegate, "clientConfiguration");
+			AttributeMap contextParams = clientConfiguration.option(SdkClientOption.CLIENT_CONTEXT_PARAMS);
+			assertThat(contextParams.get(S3ClientContextParams.FORCE_PATH_STYLE)).isTrue();
+		});
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Apply the `path-style-access-enabled` S3 config property in the `S3CrtAsyncClientAutoConfiguration`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The [standard S3 configuration](https://github.com/awspring/spring-cloud-aws/blob/main/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/properties/S3Properties.java#L159) allows you to configure "path style access" via property config. AWS has added this to the CRT client configuration as of version `2.20.42` per [this thread](https://github.com/aws/aws-sdk-java-v2/issues/3817). It would be great to have this option available in the auto configuration for the CRT client.

## :green_heart: How did you test it?
Reflection-driven unit test and empirical localhost testing.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
