### PR TITLE
Fixed the order of importing properties

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLocationResolver.java
@@ -24,10 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.logging.Log;
 import org.springframework.boot.BootstrapContext;
-import org.springframework.boot.context.config.ConfigDataLocation;
-import org.springframework.boot.context.config.ConfigDataLocationNotFoundException;
-import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
-import org.springframework.boot.context.config.Profiles;
+import org.springframework.boot.context.config.*;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.logging.DeferredLogFactory;
@@ -62,9 +59,9 @@ public class SecretsManagerConfigDataLocationResolver
 	}
 
 	@Override
-	public List<SecretsManagerConfigDataResource> resolveProfileSpecific(
-			ConfigDataLocationResolverContext resolverContext, ConfigDataLocation location, Profiles profiles)
-			throws ConfigDataLocationNotFoundException {
+	public List<SecretsManagerConfigDataResource> resolve(ConfigDataLocationResolverContext resolverContext,
+			ConfigDataLocation location)
+			throws ConfigDataLocationNotFoundException, ConfigDataResourceNotFoundException {
 		registerBean(resolverContext, AwsProperties.class, loadAwsProperties(resolverContext.getBinder()));
 		registerBean(resolverContext, SecretsManagerProperties.class, loadProperties(resolverContext.getBinder()));
 		registerBean(resolverContext, CredentialsProperties.class,

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
@@ -46,6 +46,8 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.PropertySource;
+import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -168,6 +170,17 @@ class SecretsManagerConfigDataLoaderIntegrationTests {
 		try (ConfigurableApplicationContext context = runApplication(application,
 				"aws-secretsmanager:fn_certificate")) {
 			assertThat(context.getEnvironment().getProperty("fn_certificate")).isEqualTo("=== my cert should be here");
+		}
+	}
+
+	@Test
+	void respectsImportOrder() {
+		SpringApplication application = new SpringApplication(App.class);
+		application.setWebApplicationType(WebApplicationType.NONE);
+
+		try (ConfigurableApplicationContext context = runApplication(application,
+			"classpath:config.properties")) {
+			assertThat(context.getEnvironment().getProperty("another-parameter")).isEqualTo("from properties file");
 		}
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/test/resources/config.properties
+++ b/spring-cloud-aws-autoconfigure/src/test/resources/config.properties
@@ -1,0 +1,1 @@
+spring.config.import=aws-secretsmanager:/config/spring,classpath:config_second.properties

--- a/spring-cloud-aws-autoconfigure/src/test/resources/config_second.properties
+++ b/spring-cloud-aws-autoconfigure/src/test/resources/config_second.properties
@@ -1,0 +1,1 @@
+another-parameter=from properties file


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Change the Secrets Manager resolver to use resolve instead of resolveProfileSpecific to fix the import order bug.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/awspring/spring-cloud-aws/issues/881

## :green_heart: How did you test it?
Build locally and run application with 
`spring.config.import=aws-secretsmanager:${ENV}/config,optional:classpath:config.properties`
and verified that the properties are overridden correctly. Also tested with profile-specific application-local.properties.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
