### PR TITLE
Add Validator setter in EndpointRegistrar

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -1500,6 +1500,7 @@ The following attributes can be configured in the registrar:
 - `setMessageListenerContainerRegistryBeanName` - provide a different bean name to be used to retrieve the `MessageListenerContainerRegistry`
 - `setObjectMapper` - set the `ObjectMapper` instance that will be used to deserialize payloads in listener methods.
 See <<Message Conversion and Payload Deserialization>> for more information on where this is used.
+- `setValidator` - set the `Validator` instance that will be used for payload validation in listener methods.
 - `manageMessageConverters` - gives access to the list of message converters that will be used to convert messages.
 By default, `StringMessageConverter`, `SimpleMessageConverter` and `MappingJackson2MessageConverter` are used.
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
@@ -288,9 +288,9 @@ public abstract class AbstractListenerAnnotationBeanPostProcessor<A extends Anno
 				new BatchAcknowledgmentArgumentResolver(),
 				new HeaderMethodArgumentResolver(new DefaultConversionService(), getConfigurableBeanFactory()),
 				new HeadersMethodArgumentResolver(),
-				new BatchPayloadMethodArgumentResolver(messageConverter),
+				new BatchPayloadMethodArgumentResolver(messageConverter, this.endpointRegistrar.getValidator()),
 				new MessageMethodArgumentResolver(messageConverter),
-				new PayloadMethodArgumentResolver(messageConverter));
+				new PayloadMethodArgumentResolver(messageConverter,  this.endpointRegistrar.getValidator()));
 	}
 	// @formatter:on
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/EndpointRegistrar.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/EndpointRegistrar.java
@@ -35,6 +35,7 @@ import org.springframework.messaging.handler.annotation.support.MessageHandlerMe
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import org.springframework.validation.Validator;
 
 /**
  * Processes the registered {@link Endpoint} instances using the appropriate {@link MessageListenerContainerFactory}.
@@ -70,6 +71,7 @@ public class EndpointRegistrar implements BeanFactoryAware, SmartInitializingSin
 	};
 
 	private ObjectMapper objectMapper;
+	private Validator validator = null;
 
 	/**
 	 * Set a custom {@link MessageHandlerMethodFactory} implementation.
@@ -116,6 +118,14 @@ public class EndpointRegistrar implements BeanFactoryAware, SmartInitializingSin
 	public void setObjectMapper(ObjectMapper objectMapper) {
 		Assert.notNull(objectMapper, "objectMapper cannot be null.");
 		this.objectMapper = objectMapper;
+	}
+
+	/**
+	 * Set the {@link Validator} instance used for payload validating in {@link HandlerMethodArgumentResolver} instances.
+	 * @param validator payload validator.
+	 */
+	public void setValidator(Validator validator) {
+		this.validator = validator;
 	}
 
 	/**
@@ -167,6 +177,14 @@ public class EndpointRegistrar implements BeanFactoryAware, SmartInitializingSin
 	 */
 	public MessageHandlerMethodFactory getMessageHandlerMethodFactory() {
 		return this.messageHandlerMethodFactory;
+	}
+
+	/**
+	 * Return the {@link Validator} instance used for payload validating in {@link HandlerMethodArgumentResolver} instances.
+	 * @return the payload validator.
+	 */
+	public Validator getValidator() {
+		return this.validator;
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessorTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessorTests.java
@@ -33,6 +33,7 @@ import io.awspring.cloud.sqs.config.SqsListenerConfigurer;
 import io.awspring.cloud.sqs.listener.DefaultListenerContainerRegistry;
 import io.awspring.cloud.sqs.listener.MessageListenerContainer;
 import io.awspring.cloud.sqs.listener.MessageListenerContainerRegistry;
+import io.awspring.cloud.sqs.support.resolver.BatchPayloadMethodArgumentResolver;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -50,6 +51,7 @@ import org.springframework.messaging.handler.annotation.support.MessageHandlerMe
 import org.springframework.messaging.handler.annotation.support.PayloadMethodArgumentResolver;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.util.StringValueResolver;
+import org.springframework.validation.Validator;
 
 /**
  * Tests for {@link SqsListenerAnnotationBeanPostProcessor}.
@@ -71,6 +73,7 @@ class SqsListenerAnnotationBeanPostProcessorTests {
 		String factoryName = "otherFactory";
 		MessageConverter converter = mock(MessageConverter.class);
 		HandlerMethodArgumentResolver resolver = mock(HandlerMethodArgumentResolver.class);
+        Validator validator = mock(Validator.class);
 
 		SqsListenerConfigurer customizer = registrar -> {
 			registrar.setDefaultListenerContainerFactoryBeanName(factoryName);
@@ -79,6 +82,7 @@ class SqsListenerAnnotationBeanPostProcessorTests {
 			registrar.setObjectMapper(objectMapper);
 			registrar.manageMessageConverters(converters -> converters.add(converter));
 			registrar.manageMethodArgumentResolvers(resolvers -> resolvers.add(resolver));
+            registrar.setValidator(validator);
 		};
 
 		when(beanFactory.getBeansOfType(SqsListenerConfigurer.class))
@@ -115,13 +119,15 @@ class SqsListenerAnnotationBeanPostProcessorTests {
 		assertThat(endpoint).extracting("handlerMethodFactory").extracting("delegate").isEqualTo(methodFactory)
 				.extracting("argumentResolvers").extracting("argumentResolvers")
 				.asInstanceOf(list(HandlerMethodArgumentResolver.class)).hasSizeGreaterThan(1).contains(resolver)
-				.filteredOn(thisResolver -> thisResolver instanceof PayloadMethodArgumentResolver).element(0)
-				.extracting("converter").asInstanceOf(type(CompositeMessageConverter.class))
-				.extracting(CompositeMessageConverter::getConverters).asInstanceOf(list(MessageConverter.class))
-				.contains(converter)
-				.filteredOn(thisConverter -> thisConverter instanceof MappingJackson2MessageConverter).element(0)
-				.extracting("objectMapper").isEqualTo(objectMapper);
-
+                .filteredOn(thisResolver -> thisResolver instanceof PayloadMethodArgumentResolver || thisResolver instanceof BatchPayloadMethodArgumentResolver)
+                .allSatisfy(thisResolver -> {
+                    assertThat(thisResolver).extracting("validator").isEqualTo(validator);
+                    assertThat(thisResolver).extracting("converter").asInstanceOf(type(CompositeMessageConverter.class))
+                            .extracting(CompositeMessageConverter::getConverters).asInstanceOf(list(MessageConverter.class))
+                            .contains(converter)
+                            .filteredOn(thisConverter -> thisConverter instanceof MappingJackson2MessageConverter).element(0)
+                            .extracting("objectMapper").isEqualTo(objectMapper);
+                });
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Add `Validator` setter to `EndpointRegistrar` that is propagated to the `HandlerMethodArgumentResolver` instances configured in `AbstractListenerAnnotationBeanPostProcessor`.

## :bulb: Motivation and Context
Discussed in https://github.com/awspring/spring-cloud-aws/discussions/854.

Currently, there is no easy way to set up validation for payload in the listener methods. The `PayloadMethodArgumentResolver` and `BatchPayloadMethodArgumentResolver` have set `null` for the `validator` field which means they never will validate the payload. This change will propagate the `Validator` set in `EndpointRegistrar`.

## :green_heart: How did you test it?

- Unit test
- Manual test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ x I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
