### PR TITLE
Add Validator setter in EndpointRegistrar

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -1500,6 +1500,7 @@ The following attributes can be configured in the registrar:
 - `setMessageListenerContainerRegistryBeanName` - provide a different bean name to be used to retrieve the `MessageListenerContainerRegistry`
 - `setObjectMapper` - set the `ObjectMapper` instance that will be used to deserialize payloads in listener methods.
 See <<Message Conversion and Payload Deserialization>> for more information on where this is used.
+- `setValidator` - set the `Validator` instance that will be used for payload validation in listener methods.
 - `manageMessageConverters` - gives access to the list of message converters that will be used to convert messages.
 By default, `StringMessageConverter`, `SimpleMessageConverter` and `MappingJackson2MessageConverter` are used.
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
@@ -288,9 +288,9 @@ public abstract class AbstractListenerAnnotationBeanPostProcessor<A extends Anno
 				new BatchAcknowledgmentArgumentResolver(),
 				new HeaderMethodArgumentResolver(new DefaultConversionService(), getConfigurableBeanFactory()),
 				new HeadersMethodArgumentResolver(),
-				new BatchPayloadMethodArgumentResolver(messageConverter),
+				new BatchPayloadMethodArgumentResolver(messageConverter, this.endpointRegistrar.getValidator()),
 				new MessageMethodArgumentResolver(messageConverter),
-				new PayloadMethodArgumentResolver(messageConverter));
+				new PayloadMethodArgumentResolver(messageConverter,  this.endpointRegistrar.getValidator()));
 	}
 	// @formatter:on
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/EndpointRegistrar.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/EndpointRegistrar.java
@@ -35,6 +35,7 @@ import org.springframework.messaging.handler.annotation.support.MessageHandlerMe
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import org.springframework.validation.Validator;
 
 /**
  * Processes the registered {@link Endpoint} instances using the appropriate {@link MessageListenerContainerFactory}.
@@ -70,6 +71,7 @@ public class EndpointRegistrar implements BeanFactoryAware, SmartInitializingSin
 	};
 
 	private ObjectMapper objectMapper;
+	private Validator validator;
 
 	/**
 	 * Set a custom {@link MessageHandlerMethodFactory} implementation.
@@ -116,6 +118,14 @@ public class EndpointRegistrar implements BeanFactoryAware, SmartInitializingSin
 	public void setObjectMapper(ObjectMapper objectMapper) {
 		Assert.notNull(objectMapper, "objectMapper cannot be null.");
 		this.objectMapper = objectMapper;
+	}
+
+	/**
+	 * Set the {@link Validator} instance used for payload validating in {@link HandlerMethodArgumentResolver} instances.
+	 * @param validator payload validator.
+	 */
+	public void setValidator(Validator validator) {
+		this.validator = validator;
 	}
 
 	/**
@@ -167,6 +177,14 @@ public class EndpointRegistrar implements BeanFactoryAware, SmartInitializingSin
 	 */
 	public MessageHandlerMethodFactory getMessageHandlerMethodFactory() {
 		return this.messageHandlerMethodFactory;
+	}
+
+	/**
+	 * Return the {@link Validator} instance used for payload validating in {@link HandlerMethodArgumentResolver} instances.
+	 * @return the payload validator.
+	 */
+	public Validator getValidator() {
+		return this.validator;
 	}
 
 	@Override


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Add `Validator` setter to `EndpointRegistrar` that is propagated to the `HandlerMethodArgumentResolver` instances configured in `AbstractListenerAnnotationBeanPostProcessor`.

## :bulb: Motivation and Context
Discussed in https://github.com/awspring/spring-cloud-aws/discussions/854.

Currently, there is no easy way to set up validation for payload in the listener methods. The `PayloadMethodArgumentResolver` and `BatchPayloadMethodArgumentResolver` have set `null` for the `validator` field which means they never will validate the payload. This change will propagate the `Validator` set in `EndpointRegistrar`.

## :green_heart: How did you test it?

- Unit test
- Manual test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
