### PR TITLE
Update docs and labels to use correct casing for LocalStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For a deep dive into the project, refer to the Spring Cloud AWS documentation:
 
 ## Sponsors
 
-Big thanks to [Localstack](https://localstack.cloud) for providing PRO licenses to the development team!
+Big thanks to [LocalStack](https://localstack.cloud) for providing PRO licenses to the development team!
 
 <a href="https://localstack.cloud"><img src="https://user-images.githubusercontent.com/47351025/215054012-f5af0761-0bd5-49c6-bd3e-c6b2a6844f53.png" height="100" /></a>
 

--- a/docs/src/main/asciidoc/core.adoc
+++ b/docs/src/main/asciidoc/core.adoc
@@ -199,7 +199,7 @@ class CustomRegionProviderConfiguration {
 
 === Endpoint
 
-To simplify using services with AWS compatible APIs, or running applications against https://localstack.cloud/[Localstack], it is possible to configure an endpoint set on all auto-configured AWS clients:
+To simplify using services with AWS compatible APIs, or running applications against https://localstack.cloud/[LocalStack], it is possible to configure an endpoint set on all auto-configured AWS clients:
 
 [cols="3*", options="header"]
 |===

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/test/java/io/awspring/cloud/s3/crossregion/CrossRegionS3ClientTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3-cross-region-client/src/test/java/io/awspring/cloud/s3/crossregion/CrossRegionS3ClientTests.java
@@ -45,7 +45,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.waiters.S3Waiter;
 
 /**
- * Unit tests for {@link CrossRegionS3Client}. Integration testing with Localstack is not possible due to:
+ * Unit tests for {@link CrossRegionS3Client}. Integration testing with LocalStack is not possible due to:
  * <a href="https://github.com/localstack/localstack/issues/5748">...</a>
  *
  * @author Maciej Walkowiak

--- a/spring-cloud-aws-samples/readme.md
+++ b/spring-cloud-aws-samples/readme.md
@@ -1,8 +1,8 @@
 # Spring Cloud AWS Samples
 
-Samples are prepared to run on Localstack - a local equivalent of AWS. 
+Samples are prepared to run on LocalStack - a local equivalent of AWS. 
 
-To start Localstack locally:
+To start LocalStack locally:
 
 ```
 $ docker-compose up
@@ -30,7 +30,7 @@ Samples are regular Spring Boot applications. The best way to run them is to run
 
 ## How to destroy infrastructure?
 
-Infrastructure is destroyed once Localstack container shuts down. If you want to destroy infrastructure manually, run:
+Infrastructure is destroyed once LocalStack container shuts down. If you want to destroy infrastructure manually, run:
 
 ```
 $ cdklocal destroy

--- a/spring-cloud-aws-samples/spring-cloud-aws-dynamodb-sample/src/main/resources/application.properties
+++ b/spring-cloud-aws-samples/spring-cloud-aws-dynamodb-sample/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-# Localstack configuration
+# LocalStack configuration
 spring.cloud.aws.endpoint=http://localhost:4566
 spring.cloud.aws.region.static=us-east-1
 spring.cloud.aws.credentials.access-key=noop

--- a/spring-cloud-aws-samples/spring-cloud-aws-parameter-store-sample/src/main/resources/application.properties
+++ b/spring-cloud-aws-samples/spring-cloud-aws-parameter-store-sample/src/main/resources/application.properties
@@ -2,7 +2,7 @@
 spring.config.import=aws-parameterstore:/config/spring/
 logging.level.io.awspring.cloud=debug
 
-# Localstack configuration
+# LocalStack configuration
 spring.cloud.aws.endpoint=http://localhost:4566
 spring.cloud.aws.region.static=us-east-1
 spring.cloud.aws.credentials.access-key=noop

--- a/spring-cloud-aws-samples/spring-cloud-aws-s3-sample/src/main/resources/application.properties
+++ b/spring-cloud-aws-samples/spring-cloud-aws-s3-sample/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-# Localstack configuration
+# LocalStack configuration
 spring.cloud.aws.endpoint=http://localhost:4566
 spring.cloud.aws.region.static=us-east-1
 spring.cloud.aws.credentials.access-key=noop

--- a/spring-cloud-aws-samples/spring-cloud-aws-secrets-manager-sample/src/main/resources/application.yml
+++ b/spring-cloud-aws-samples/spring-cloud-aws-secrets-manager-sample/src/main/resources/application.yml
@@ -2,7 +2,7 @@
 spring.config.import: aws-secretsmanager:/secrets/spring-cloud-aws-sample-app
 logging.level.io.awspring.cloud.secretsmanager: debug
 
-# Localstack configuration
+# LocalStack configuration
 spring.cloud.aws.endpoint: http://localhost:4566
 spring.cloud.aws.region.static: us-east-1
 spring.cloud.aws.credentials.access-key: noop

--- a/spring-cloud-aws-samples/spring-cloud-aws-ses-sample/src/main/resources/application.properties
+++ b/spring-cloud-aws-samples/spring-cloud-aws-ses-sample/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-# Localstack configuration
+# LocalStack configuration
 spring.cloud.aws.endpoint=http://localhost:4566
 spring.cloud.aws.region.static=us-east-1
 spring.cloud.aws.credentials.access-key=noop

--- a/spring-cloud-aws-samples/spring-cloud-aws-sns-sample/src/main/resources/application.properties
+++ b/spring-cloud-aws-samples/spring-cloud-aws-sns-sample/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-# Localstack configuration
+# LocalStack configuration
 spring.cloud.aws.endpoint=http://localhost:4566
 spring.cloud.aws.region.static=us-east-1
 spring.cloud.aws.credentials.access-key=noop

--- a/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/main/resources/application.properties
+++ b/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-# Localstack configuration
+# LocalStack configuration
 spring.cloud.aws.endpoint=http://localhost:4566
 spring.cloud.aws.region.static=us-east-1
 spring.cloud.aws.credentials.access-key=noop

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/BaseSqsIntegrationTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/BaseSqsIntegrationTest.java
@@ -65,7 +65,7 @@ abstract class BaseSqsIntegrationTest {
 
 	@DynamicPropertySource
 	static void registerSqsProperties(DynamicPropertyRegistry registry) {
-		// overwrite SQS endpoint with one provided by Localstack
+		// overwrite SQS endpoint with one provided by LocalStack
 		registry.add("spring.cloud.aws.endpoint", () -> localstack.getEndpointOverride(SQS).toString());
 	}
 

--- a/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/BaseSqsIntegrationTest.java
+++ b/spring-cloud-aws-test/src/test/java/io/awspring/cloud/test/sqs/BaseSqsIntegrationTest.java
@@ -42,7 +42,7 @@ abstract class BaseSqsIntegrationTest {
 
 	@DynamicPropertySource
 	static void registerSqsProperties(DynamicPropertyRegistry registry) {
-		// overwrite SQS endpoint with one provided by Localstack
+		// overwrite SQS endpoint with one provided by LocalStack
 		registry.add("spring.cloud.aws.sqs.endpoint", () -> localstack.getEndpointOverride(SQS).toString());
 	}
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
These are a few minor cosmetic changes in the docs and the labels in the code - using the CamelCase spelling LocalStack that we use for the product (instead of Localstack).


## :bulb: Motivation and Context
We would like to have consistent product naming across the board; hence, we're raising PRs to adjust these references.


## :green_heart: How did you test it?
It does not require testing.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Thank you for your support for LocalStack!
