### PR TITLE
Add `SnsMessageConverter` and `NotificationMessageArgumentResolver` to allow reading SNS messages on SQS

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -611,6 +611,19 @@ Any number of `@SqsListener` annotations can be used in a bean class, and each a
 
 NOTE: Queues declared in the same annotation will share the container, though each will have separate throughput and acknowledgement controls.
 
+===== Annotation-driven SqsListener
+
+The default payload of `@SqsListener` includes all the attributes within the SQS Object; However if you only need the `Message` part of the payload, you can utilize the `@SnsNotificationMessage` annotation.
+[source, java]
+----
+@SqsListener("my-queue")
+public void listen(@SnsNotificationMessage Pojo pojo) {
+	System.out.println(pojo.field);
+}
+----
+
+NOTE: You will need to configure an `ObjectMapper` with `SqsListenerConfigurer` in order to utilize this annotation.
+
 ===== Specifying a MessageListenerContainerFactory
 A `MessageListenerContainerFactory` can be specified through the `factory` property.
 Such factory will then be used to create the container for the annotated method.

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -611,9 +611,9 @@ Any number of `@SqsListener` annotations can be used in a bean class, and each a
 
 NOTE: Queues declared in the same annotation will share the container, though each will have separate throughput and acknowledgement controls.
 
-===== Annotation-driven SqsListener
+===== SNS Messages
 
-The default payload of `@SqsListener` includes all the attributes within the SQS Object; However if you only need the `Message` part of the payload, you can utilize the `@SnsNotificationMessage` annotation.
+When receiving SNS messages through the `@SqsListener`, the message includes all attributes of the `SnsNotification`. To only receive need the `Message` part of the payload, you can utilize the `@SnsNotificationMessage` annotation.
 [source, java]
 ----
 @SqsListener("my-queue")

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -613,7 +613,7 @@ NOTE: Queues declared in the same annotation will share the container, though ea
 
 ===== SNS Messages
 
-When receiving SNS messages through the `@SqsListener`, the message includes all attributes of the `SnsNotification`. To only receive need the `Message` part of the payload, you can utilize the `@SnsNotificationMessage` annotation.
+Since 3.1.1, when receiving SNS messages through the `@SqsListener`, the message includes all attributes of the `SnsNotification`. To only receive need the `Message` part of the payload, you can utilize the `@SnsNotificationMessage` annotation.
 [source, java]
 ----
 @SqsListener("my-queue")

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -622,8 +622,6 @@ public void listen(@SnsNotificationMessage Pojo pojo) {
 }
 ----
 
-NOTE: You will need to configure an `ObjectMapper` with `SqsListenerConfigurer` in order to utilize this annotation.
-
 ===== Specifying a MessageListenerContainerFactory
 A `MessageListenerContainerFactory` can be specified through the `factory` property.
 Such factory will then be used to create the container for the annotated method.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
@@ -26,6 +26,7 @@ import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementMod
 import io.awspring.cloud.sqs.support.resolver.AcknowledgmentHandlerMethodArgumentResolver;
 import io.awspring.cloud.sqs.support.resolver.BatchAcknowledgmentArgumentResolver;
 import io.awspring.cloud.sqs.support.resolver.BatchPayloadMethodArgumentResolver;
+import io.awspring.cloud.sqs.support.resolver.NotificationMessageArgumentResolver;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -303,6 +304,7 @@ public abstract class AbstractListenerAnnotationBeanPostProcessor<A extends Anno
 				new HeadersMethodArgumentResolver(),
 				new BatchPayloadMethodArgumentResolver(messageConverter, this.endpointRegistrar.getValidator()),
 				new MessageMethodArgumentResolver(messageConverter),
+				new NotificationMessageArgumentResolver(messageConverter),
 				new PayloadMethodArgumentResolver(messageConverter,  this.endpointRegistrar.getValidator()));
 	}
 	// @formatter:on

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
@@ -285,6 +285,9 @@ public abstract class AbstractListenerAnnotationBeanPostProcessor<A extends Anno
 			MessageConverter messageConverter, ObjectMapper objectMapper) {
 		return Collections.emptyList();
 	}
+	protected Collection<HandlerMethodArgumentResolver> createAdditionalArgumentResolvers() {
+		return createAdditionalArgumentResolvers(null, null);
+	}
 
 	protected CompositeMessageConverter createCompositeMessageConverter() {
 		List<MessageConverter> messageConverters = new ArrayList<>();

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
@@ -283,10 +283,10 @@ public abstract class AbstractListenerAnnotationBeanPostProcessor<A extends Anno
 
 	protected Collection<HandlerMethodArgumentResolver> createAdditionalArgumentResolvers(
 			MessageConverter messageConverter, ObjectMapper objectMapper) {
-		return Collections.emptyList();
+		return createAdditionalArgumentResolvers();
 	}
 	protected Collection<HandlerMethodArgumentResolver> createAdditionalArgumentResolvers() {
-		return createAdditionalArgumentResolvers(null, null);
+		return Collections.emptyList();
 	}
 
 	protected CompositeMessageConverter createCompositeMessageConverter() {

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
@@ -26,7 +26,6 @@ import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementMod
 import io.awspring.cloud.sqs.support.resolver.AcknowledgmentHandlerMethodArgumentResolver;
 import io.awspring.cloud.sqs.support.resolver.BatchAcknowledgmentArgumentResolver;
 import io.awspring.cloud.sqs.support.resolver.BatchPayloadMethodArgumentResolver;
-import io.awspring.cloud.sqs.support.resolver.NotificationMessageArgumentResolver;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -275,14 +274,15 @@ public abstract class AbstractListenerAnnotationBeanPostProcessor<A extends Anno
 		CompositeMessageConverter compositeMessageConverter = createCompositeMessageConverter();
 
 		List<HandlerMethodArgumentResolver> methodArgumentResolvers = new ArrayList<>(
-				createAdditionalArgumentResolvers());
+				createAdditionalArgumentResolvers(compositeMessageConverter, this.endpointRegistrar.getObjectMapper()));
 		methodArgumentResolvers.addAll(createArgumentResolvers(compositeMessageConverter));
 		this.endpointRegistrar.getMethodArgumentResolversConsumer().accept(methodArgumentResolvers);
 		handlerMethodFactory.setArgumentResolvers(methodArgumentResolvers);
 		handlerMethodFactory.afterPropertiesSet();
 	}
 
-	protected Collection<HandlerMethodArgumentResolver> createAdditionalArgumentResolvers() {
+	protected Collection<HandlerMethodArgumentResolver> createAdditionalArgumentResolvers(
+			MessageConverter messageConverter, ObjectMapper objectMapper) {
 		return Collections.emptyList();
 	}
 
@@ -304,7 +304,6 @@ public abstract class AbstractListenerAnnotationBeanPostProcessor<A extends Anno
 				new HeadersMethodArgumentResolver(),
 				new BatchPayloadMethodArgumentResolver(messageConverter, this.endpointRegistrar.getValidator()),
 				new MessageMethodArgumentResolver(messageConverter),
-				new NotificationMessageArgumentResolver(messageConverter),
 				new PayloadMethodArgumentResolver(messageConverter,  this.endpointRegistrar.getValidator()));
 	}
 	// @formatter:on

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SnsNotificationMessage.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SnsNotificationMessage.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Target;
  * Controllers method for handling/receiving SQS notifications.
  *
  * @author Michael Sosa
+ * @since 3.1.1
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SnsNotificationMessage.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SnsNotificationMessage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that is used to map SNS notification value on an SQS Queue to a variable that is annotated.
+ * Used in Controllers method for handling/receiving SQS notifications.
+ *
+ * @author Michael Sosa
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface SnsNotificationMessage {
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SnsNotificationMessage.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SnsNotificationMessage.java
@@ -21,8 +21,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation that is used to map SNS notification value on an SQS Queue to a variable that is annotated.
- * Used in Controllers method for handling/receiving SQS notifications.
+ * Annotation that is used to map SNS notification value on an SQS Queue to a variable that is annotated. Used in
+ * Controllers method for handling/receiving SQS notifications.
  *
  * @author Michael Sosa
  */

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
@@ -27,6 +27,7 @@ import io.awspring.cloud.sqs.support.resolver.VisibilityHandlerMethodArgumentRes
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 
@@ -70,15 +71,17 @@ public class SqsListenerAnnotationBeanPostProcessor extends AbstractListenerAnno
 	}
 
 	@Override
+	protected Collection<HandlerMethodArgumentResolver> createAdditionalArgumentResolvers() {
+		return Arrays.asList(new VisibilityHandlerMethodArgumentResolver(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER),
+			new SqsMessageMethodArgumentResolver(), new QueueAttributesMethodArgumentResolver());
+	}
+
+	@Override
 	protected Collection<HandlerMethodArgumentResolver> createAdditionalArgumentResolvers(
 			MessageConverter messageConverter, ObjectMapper objectMapper) {
-		var additionalArgumentResolvers = Arrays.asList(new VisibilityHandlerMethodArgumentResolver(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER),
-				new SqsMessageMethodArgumentResolver(), new QueueAttributesMethodArgumentResolver());
-		if (messageConverter != null && objectMapper != null) {
-			additionalArgumentResolvers = new ArrayList<>(additionalArgumentResolvers);
-			additionalArgumentResolvers.add(new NotificationMessageArgumentResolver(messageConverter, objectMapper));
-		}
-		return additionalArgumentResolvers;
+		List<HandlerMethodArgumentResolver> argumentResolvers = new ArrayList<>(createAdditionalArgumentResolvers());
+		argumentResolvers.add(new NotificationMessageArgumentResolver(messageConverter, objectMapper));
+		return argumentResolvers;
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
@@ -24,6 +24,7 @@ import io.awspring.cloud.sqs.support.resolver.NotificationMessageArgumentResolve
 import io.awspring.cloud.sqs.support.resolver.QueueAttributesMethodArgumentResolver;
 import io.awspring.cloud.sqs.support.resolver.SqsMessageMethodArgumentResolver;
 import io.awspring.cloud.sqs.support.resolver.VisibilityHandlerMethodArgumentResolver;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import org.springframework.messaging.converter.MessageConverter;
@@ -71,9 +72,13 @@ public class SqsListenerAnnotationBeanPostProcessor extends AbstractListenerAnno
 	@Override
 	protected Collection<HandlerMethodArgumentResolver> createAdditionalArgumentResolvers(
 			MessageConverter messageConverter, ObjectMapper objectMapper) {
-		return Arrays.asList(new VisibilityHandlerMethodArgumentResolver(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER),
-				new SqsMessageMethodArgumentResolver(), new QueueAttributesMethodArgumentResolver(),
-				new NotificationMessageArgumentResolver(messageConverter, objectMapper));
+		var additionalArgumentResolvers = Arrays.asList(new VisibilityHandlerMethodArgumentResolver(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER),
+				new SqsMessageMethodArgumentResolver(), new QueueAttributesMethodArgumentResolver());
+		if (messageConverter != null && objectMapper != null) {
+			additionalArgumentResolvers = new ArrayList<>(additionalArgumentResolvers);
+			additionalArgumentResolvers.add(new NotificationMessageArgumentResolver(messageConverter, objectMapper));
+		}
+		return additionalArgumentResolvers;
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
@@ -80,7 +80,9 @@ public class SqsListenerAnnotationBeanPostProcessor extends AbstractListenerAnno
 	protected Collection<HandlerMethodArgumentResolver> createAdditionalArgumentResolvers(
 			MessageConverter messageConverter, ObjectMapper objectMapper) {
 		List<HandlerMethodArgumentResolver> argumentResolvers = new ArrayList<>(createAdditionalArgumentResolvers());
-		argumentResolvers.add(new NotificationMessageArgumentResolver(messageConverter, objectMapper));
+		if (objectMapper != null) {
+			argumentResolvers.add(new NotificationMessageArgumentResolver(messageConverter, objectMapper));
+		}
 		return argumentResolvers;
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
@@ -15,15 +15,18 @@
  */
 package io.awspring.cloud.sqs.annotation;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.sqs.config.Endpoint;
 import io.awspring.cloud.sqs.config.SqsBeanNames;
 import io.awspring.cloud.sqs.config.SqsEndpoint;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.support.resolver.NotificationMessageArgumentResolver;
 import io.awspring.cloud.sqs.support.resolver.QueueAttributesMethodArgumentResolver;
 import io.awspring.cloud.sqs.support.resolver.SqsMessageMethodArgumentResolver;
 import io.awspring.cloud.sqs.support.resolver.VisibilityHandlerMethodArgumentResolver;
 import java.util.Arrays;
 import java.util.Collection;
+import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 
 /**
@@ -66,9 +69,11 @@ public class SqsListenerAnnotationBeanPostProcessor extends AbstractListenerAnno
 	}
 
 	@Override
-	protected Collection<HandlerMethodArgumentResolver> createAdditionalArgumentResolvers() {
+	protected Collection<HandlerMethodArgumentResolver> createAdditionalArgumentResolvers(
+			MessageConverter messageConverter, ObjectMapper objectMapper) {
 		return Arrays.asList(new VisibilityHandlerMethodArgumentResolver(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER),
-				new SqsMessageMethodArgumentResolver(), new QueueAttributesMethodArgumentResolver());
+				new SqsMessageMethodArgumentResolver(), new QueueAttributesMethodArgumentResolver(),
+				new NotificationMessageArgumentResolver(messageConverter, objectMapper));
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/NotificationRequestConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/NotificationRequestConverter.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.sqs.support.converter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.util.Assert;
+
+/**
+ * @author Michael Sosa
+ */
+public class NotificationRequestConverter implements MessageConverter {
+
+	private final ObjectMapper jsonMapper = new ObjectMapper();
+
+	private final MessageConverter payloadConverter;
+
+	public NotificationRequestConverter(MessageConverter payloadConverter) {
+		this.payloadConverter = payloadConverter;
+	}
+	@Override
+	public Object fromMessage(Message<?> message, Class<?> targetClass) {
+		Assert.notNull(message, "message must not be null");
+		Assert.notNull(targetClass, "target class must not be null");
+
+		JsonNode jsonNode;
+		try {
+			jsonNode = this.jsonMapper.readTree(message.getPayload().toString());
+		}
+		catch (Exception e) {
+			throw new MessageConversionException("Could not read JSON", e);
+		}
+		if (!jsonNode.has("Type")) {
+			throw new MessageConversionException(
+				"Payload: '" + message.getPayload() + "' does not contain a Type attribute", null);
+		}
+
+		if (!"Notification".equals(jsonNode.get("Type").asText())) {
+			throw new MessageConversionException("Payload: '" + message.getPayload() + "' is not a valid notification",
+				null);
+		}
+
+		if (!jsonNode.has("Message")) {
+			throw new MessageConversionException("Payload: '" + message.getPayload() + "' does not contain a message",
+				null);
+		}
+
+		String messagePayload = jsonNode.get("Message").asText();
+		GenericMessage<String> genericMessage = new GenericMessage<>(messagePayload);
+		return new NotificationRequest(jsonNode.path("Subject").asText(),
+			this.payloadConverter.fromMessage(genericMessage, targetClass));
+	}
+
+	@Override
+	public Message<?> toMessage(Object payload, MessageHeaders headers) {
+		throw new UnsupportedOperationException(
+			"This converter only supports reading a SNS notification and not writing them");
+	}
+
+	/**
+	 * Notification request wrapper.
+	 */
+	public static class NotificationRequest {
+
+		private final String subject;
+
+		private final Object message;
+
+		public NotificationRequest(String subject, Object message) {
+			this.subject = subject;
+			this.message = message;
+		}
+
+		public String getSubject() {
+			return this.subject;
+		}
+
+		public Object getMessage() {
+			return this.message;
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsMessageConverter.java
@@ -34,6 +34,8 @@ public class SnsMessageConverter implements MessageConverter {
 	private final MessageConverter payloadConverter;
 
 	public SnsMessageConverter(MessageConverter payloadConverter, ObjectMapper jsonMapper) {
+		Assert.notNull(payloadConverter, "payloadConverter must not be null");
+		Assert.notNull(jsonMapper, "jsonMapper must not be null");
 		this.payloadConverter = payloadConverter;
 		this.jsonMapper = jsonMapper;
 	}
@@ -67,7 +69,7 @@ public class SnsMessageConverter implements MessageConverter {
 
 		String messagePayload = jsonNode.get("Message").asText();
 		GenericMessage<String> genericMessage = new GenericMessage<>(messagePayload);
-		return new SnsMessage(jsonNode.path("Subject").asText(),
+		return new SnsMessageWrapper(jsonNode.path("Subject").asText(),
 				this.payloadConverter.fromMessage(genericMessage, targetClass));
 	}
 
@@ -78,9 +80,9 @@ public class SnsMessageConverter implements MessageConverter {
 	}
 
 	/**
-	 * Notification request wrapper.
+	 * SNS Message wrapper.
 	 */
-	public record SnsMessage(String subject, Object message) {
+	public record SnsMessageWrapper(String subject, Object message) {
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsMessageConverter.java
@@ -27,15 +27,15 @@ import org.springframework.util.Assert;
 /**
  * @author Michael Sosa
  */
-public class NotificationRequestConverter implements MessageConverter {
+public class SnsMessageConverter implements MessageConverter {
 
 	private final ObjectMapper jsonMapper;
 
 	private final MessageConverter payloadConverter;
 
-	public NotificationRequestConverter(MessageConverter payloadConverter, ObjectMapper jsonMapper) {
+	public SnsMessageConverter(MessageConverter payloadConverter, ObjectMapper jsonMapper) {
 		this.payloadConverter = payloadConverter;
-		this.jsonMapper = jsonMapper == null ? new ObjectMapper() :jsonMapper;
+		this.jsonMapper = jsonMapper;
 	}
 
 	@Override
@@ -67,7 +67,7 @@ public class NotificationRequestConverter implements MessageConverter {
 
 		String messagePayload = jsonNode.get("Message").asText();
 		GenericMessage<String> genericMessage = new GenericMessage<>(messagePayload);
-		return new NotificationRequest(jsonNode.path("Subject").asText(),
+		return new SnsMessage(jsonNode.path("Subject").asText(),
 				this.payloadConverter.fromMessage(genericMessage, targetClass));
 	}
 
@@ -80,25 +80,7 @@ public class NotificationRequestConverter implements MessageConverter {
 	/**
 	 * Notification request wrapper.
 	 */
-	public static class NotificationRequest {
-
-		private final String subject;
-
-		private final Object message;
-
-		public NotificationRequest(String subject, Object message) {
-			this.subject = subject;
-			this.message = message;
-		}
-
-		public String getSubject() {
-			return this.subject;
-		}
-
-		public Object getMessage() {
-			return this.message;
-		}
-
+	public record SnsMessage(String subject, Object message) {
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsMessageConverter.java
@@ -28,6 +28,8 @@ import org.springframework.util.Assert;
 
 /**
  * @author Michael Sosa
+ * @author gustavomonarin
+ * @since 3.1.1
  */
 public class SnsMessageConverter implements SmartMessageConverter {
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/NotificationMessageArgumentResolver.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/NotificationMessageArgumentResolver.java
@@ -43,8 +43,8 @@ public class NotificationMessageArgumentResolver implements HandlerMethodArgumen
 	@Override
 	public Object resolveArgument(MethodParameter par, Message<?> msg) throws Exception {
 		Object object = this.converter.fromMessage(msg, par.getParameterType());
-		Assert.isInstanceOf(SnsMessageConverter.SnsMessage.class, object);
-		SnsMessageConverter.SnsMessage nr = (SnsMessageConverter.SnsMessage) object;
+		Assert.isInstanceOf(SnsMessageConverter.SnsMessageWrapper.class, object);
+		SnsMessageConverter.SnsMessageWrapper nr = (SnsMessageConverter.SnsMessageWrapper) object;
 		return nr.message();
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/NotificationMessageArgumentResolver.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/NotificationMessageArgumentResolver.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.sqs.support.resolver;
+
+import io.awspring.cloud.sqs.annotation.SnsNotificationMessage;
+import io.awspring.cloud.sqs.support.converter.NotificationRequestConverter;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+
+/**
+ * @author Michael Sosa
+ */
+public class NotificationMessageArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private final MessageConverter converter;
+
+	public NotificationMessageArgumentResolver(MessageConverter converter) {
+		this.converter = new NotificationRequestConverter(converter);
+	}
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(SnsNotificationMessage.class);
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter par, Message<?> msg) throws Exception {
+		Object object = this.converter.fromMessage(msg, par.getParameterType());
+		NotificationRequestConverter.NotificationRequest nr = (NotificationRequestConverter.NotificationRequest) object;
+		return nr.getMessage();
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/NotificationMessageArgumentResolver.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/NotificationMessageArgumentResolver.java
@@ -27,6 +27,8 @@ import org.springframework.util.Assert;
 
 /**
  * @author Michael Sosa
+ * @author gustavomonarin
+ * @since 3.1.1
  */
 public class NotificationMessageArgumentResolver implements HandlerMethodArgumentResolver {
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/NotificationMessageArgumentResolver.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/NotificationMessageArgumentResolver.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.awspring.cloud.sqs.support.resolver;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.sqs.annotation.SnsNotificationMessage;
 import io.awspring.cloud.sqs.support.converter.NotificationRequestConverter;
 import org.springframework.core.MethodParameter;
@@ -30,8 +30,8 @@ public class NotificationMessageArgumentResolver implements HandlerMethodArgumen
 
 	private final MessageConverter converter;
 
-	public NotificationMessageArgumentResolver(MessageConverter converter) {
-		this.converter = new NotificationRequestConverter(converter);
+	public NotificationMessageArgumentResolver(MessageConverter converter, ObjectMapper jsonMapper) {
+		this.converter = new NotificationRequestConverter(converter, jsonMapper);
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/NotificationMessageArgumentResolver.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/NotificationMessageArgumentResolver.java
@@ -17,11 +17,12 @@ package io.awspring.cloud.sqs.support.resolver;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.sqs.annotation.SnsNotificationMessage;
-import io.awspring.cloud.sqs.support.converter.NotificationRequestConverter;
+import io.awspring.cloud.sqs.support.converter.SnsMessageConverter;
 import org.springframework.core.MethodParameter;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.util.Assert;
 
 /**
  * @author Michael Sosa
@@ -31,7 +32,7 @@ public class NotificationMessageArgumentResolver implements HandlerMethodArgumen
 	private final MessageConverter converter;
 
 	public NotificationMessageArgumentResolver(MessageConverter converter, ObjectMapper jsonMapper) {
-		this.converter = new NotificationRequestConverter(converter, jsonMapper);
+		this.converter = new SnsMessageConverter(converter, jsonMapper);
 	}
 
 	@Override
@@ -42,8 +43,9 @@ public class NotificationMessageArgumentResolver implements HandlerMethodArgumen
 	@Override
 	public Object resolveArgument(MethodParameter par, Message<?> msg) throws Exception {
 		Object object = this.converter.fromMessage(msg, par.getParameterType());
-		NotificationRequestConverter.NotificationRequest nr = (NotificationRequestConverter.NotificationRequest) object;
-		return nr.getMessage();
+		Assert.isInstanceOf(SnsMessageConverter.SnsMessage.class, object);
+		SnsMessageConverter.SnsMessage nr = (SnsMessageConverter.SnsMessage) object;
+		return nr.message();
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
@@ -89,6 +89,8 @@ import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
  *
  * @author Tomaz Fernandes
  * @author Mikhail Strokov
+ * @author Michael Sosa
+ * @author gustavomonarin
  */
 @SpringBootTest
 @TestPropertySource(properties = { "property.one=1", "property.five.seconds=5s",

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
@@ -302,12 +302,6 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 			return factory;
 		}
 
-		@Bean
-		SqsListenerConfigurer customizer(ObjectMapper objectMapper) {
-			return registrar -> {
-				registrar.setObjectMapper(objectMapper);
-			};
-		}
 		// @formatter:on
 
 		LatchContainer latchContainer = new LatchContainer();
@@ -354,6 +348,11 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 		@Bean
 		ObjectMapper objectMapper() {
 			return new ObjectMapper();
+		}
+
+		@Bean
+		SqsListenerConfigurer customizer(ObjectMapper objectMapper) {
+			return registrar -> registrar.setObjectMapper(objectMapper);
 		}
 
 		@Bean

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.sqs.annotation.SnsNotificationMessage;
 import io.awspring.cloud.sqs.annotation.SqsListener;
 import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration;
+import io.awspring.cloud.sqs.config.SqsListenerConfigurer;
 import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
@@ -299,6 +300,13 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 				}
 			});
 			return factory;
+		}
+
+		@Bean
+		SqsListenerConfigurer customizer(ObjectMapper objectMapper) {
+			return registrar -> {
+				registrar.setObjectMapper(objectMapper);
+			};
 		}
 		// @formatter:on
 

--- a/spring-cloud-aws-sqs/src/test/resources/notificationMessage.json
+++ b/spring-cloud-aws-sqs/src/test/resources/notificationMessage.json
@@ -1,0 +1,11 @@
+{
+	"Type": "Notification",
+	"MessageId": "f2c15fec-c617-5b08-b54d-13c4099fec60",
+	"TopicArn": "arn:aws:sns:eu-west-1:111111111111:mySampleTopic",
+	"Message": "{\"firstField\":\"pojoNotificationMessage\",\"secondField\":\"secondValue\"}",
+	"Timestamp": "2014-06-28T14:12:24.418Z",
+	"SignatureVersion": "1",
+	"Signature": "XDvKSAnhxECrAmyIrs0Dsfbp/tnKD1IvoOOYTU28FtbUoxr/CgziuW87yZwTuSNNbHJbdD3BEjHS0vKewm0xBeQ0PToDkgtoORXo5RWnmShDQ2nhkthFhZnNulKtmFtRogjBtCwbz8sPnbOCSk21ruyXNdV2RUbdDalndAW002CWEQmYMxFSN6OXUtMueuT610aX+tqeYP4Z6+8WTWLWjAuVyy7rOI6KHYBcVDhKtskvTOPZ4tiVohtQdQbO2Gjuh1vblRzzwMkfaoFTSWImd4pFXxEsv/fq9aGIlqq9xEryJ0w2huFwI5gxyhvGt0RnTd9YvmAEC+WzdJDOqaDNxg==",
+	"SigningCertURL": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-e372f8ca30337fdb084e8ac449342c77.pem",
+	"UnsubscribeURL": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:721324560415:mySampleTopic:9859a6c9-6083-4690-ab02-d1aead3442df"
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
#887 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It allows for reading an SNS Message on an SQS Queue by using `@NotficationMessage`

## :green_heart: How did you test it?
Manually(will try to add tests when I have time)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

@tomazfernandes This is more of a draft for now, this works locally for me but was unsure where these files truly belong. I have put then in the sns project for now, since they use `@NotificationMessage` which lives there, and didn't want SQS project to have a dependency on the SNS one. 

Let me know if you agree, or we should create a new annotation to be used.

Also in the previous implementation of [NotificationRequestConverter](https://github.com/spring-attic/spring-cloud-aws/blob/2.3.x/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/converter/NotificationRequestConverter.java#L53-L79) it added `MessageAttributes` to the message. For my use-case I was able to remove that completely and things worked fine. Let me know if that is actually needed, but I did see `SqsHeaderMapper` has a lot of the same logic for what was being done for `MessageAttributes`
