### PR TITLE
Add option to set property prefix on Parameter Store property sources

### DIFF
--- a/docs/src/main/asciidoc/parameter-store.adoc
+++ b/docs/src/main/asciidoc/parameter-store.adoc
@@ -61,6 +61,33 @@ spring.config.import[1]=aws-parameterstore=/config/optional-params/
 If you add indexed parameter names such as `/config/application/cloud.aws.stack_0_.name`, `/config/application/cloud.aws.stack_1_.name`, ... to Parameter Store,
 these will become accessible as array properties `cloud.aws.stack[0].name`, `cloud.aws.stack[1].name`, ... in Spring.
 
+==== Adding prefix to property keys
+
+To avoid property key collisions it is possible to configure a property key prefix that gets added to each resolved parameter.
+
+As an example, assuming the following parameters are stored under path `/config/my-datasource`:
+
+|===
+| Parameter Name | Parameter Value
+
+| `/config/my-datasource/url` | `jdbc:mysql://localhost:3306`
+
+| `/config/my-datasource/username` | `db-user`
+
+|===
+
+By default, `url` and `username` properties will be added to the Spring environment. To add a prefix to property keys configure `spring.config.import` property with `?prefix=` added to the parameter path:
+
+[source,properties]
+----
+spring.config.import=aws-parameterstore:/config/my-datasource/?prefix=spring.datasource.
+----
+
+With such config, properties `spring.datasource.url` and `spring.datasource.username` are added to the Spring environment.
+
+NOTE: Prefixes are added as-is to all property names returned by Parameter Store. If you want key names to be separated with a dot between the prefix and key name, make sure to add a trailing dot to the prefix.
+
+
 === Using SsmClient
 
 The starter automatically configures and registers a `SsmClient` bean in the Spring application context. The `SsmClient` bean can be used to create or retrieve parameters from Parameter Store.

--- a/spring-cloud-aws-parameter-store/src/main/java/io/awspring/cloud/parameterstore/ParameterStorePropertySource.java
+++ b/spring-cloud-aws-parameter-store/src/main/java/io/awspring/cloud/parameterstore/ParameterStorePropertySource.java
@@ -40,20 +40,31 @@ public class ParameterStorePropertySource extends AwsPropertySource<ParameterSto
 	// logger must stay static non-final so that it can be set with a value in
 	// ParameterStoreConfigDataLoader
 	private static Log LOG = LogFactory.getLog(ParameterStorePropertySource.class);
-
+	private static final String PREFIX_PART = "?prefix=";
 	private final String context;
+
+	private final String parameterPath;
+
+	/**
+	 * Prefix that gets added to resolved property keys. Useful when same property keys are returned by multiple
+	 * parameter paths. sources.
+	 */
+	@Nullable
+	private final String prefix;
 
 	private final Map<String, Object> properties = new LinkedHashMap<>();
 
 	public ParameterStorePropertySource(String context, SsmClient ssmClient) {
 		super("aws-parameterstore:" + context, ssmClient);
 		this.context = context;
+		this.parameterPath = resolveParameterPath(context);
+		this.prefix = resolvePrefix(context);
 	}
 
 	@Override
 	public void init() {
-		GetParametersByPathRequest paramsRequest = GetParametersByPathRequest.builder().path(context).recursive(true)
-				.withDecryption(true).build();
+		GetParametersByPathRequest paramsRequest = GetParametersByPathRequest.builder().path(parameterPath)
+				.recursive(true).withDecryption(true).build();
 		getParameters(paramsRequest);
 	}
 
@@ -76,13 +87,45 @@ public class ParameterStorePropertySource extends AwsPropertySource<ParameterSto
 	private void getParameters(GetParametersByPathRequest paramsRequest) {
 		GetParametersByPathResponse paramsResult = this.source.getParametersByPath(paramsRequest);
 		for (Parameter parameter : paramsResult.parameters()) {
-			String key = parameter.name().replace(this.context, "").replace('/', '.').replaceAll("_(\\d)_", "[$1]");
+			String key = parameter.name().replace(this.parameterPath, "").replace('/', '.')
+					.replaceAll("_(\\d)_", "[$1]");
 			LOG.debug("Populating property retrieved from AWS Parameter Store: " + key);
-			this.properties.put(key, parameter.value());
+			String propertyKey = prefix != null ? prefix + key : key;
+			this.properties.put(propertyKey, parameter.value());
 		}
 		if (paramsResult.nextToken() != null) {
 			getParameters(paramsRequest.toBuilder().nextToken(paramsResult.nextToken()).build());
 		}
+	}
+
+	@Nullable
+	String getPrefix() {
+		return prefix;
+	}
+
+	String getContext() {
+		return context;
+	}
+
+	String getParameterPath() {
+		return parameterPath;
+	}
+
+	@Nullable
+	private static String resolvePrefix(String context) {
+		int prefixIndex = context.indexOf(PREFIX_PART);
+		if (prefixIndex != -1) {
+			return context.substring(prefixIndex + PREFIX_PART.length());
+		}
+		return null;
+	}
+
+	private static String resolveParameterPath(String context) {
+		int prefixIndex = context.indexOf(PREFIX_PART);
+		if (prefixIndex != -1) {
+			return context.substring(0, prefixIndex);
+		}
+		return context;
 	}
 
 }

--- a/spring-cloud-aws-parameter-store/src/main/java/io/awspring/cloud/parameterstore/ParameterStorePropertySource.java
+++ b/spring-cloud-aws-parameter-store/src/main/java/io/awspring/cloud/parameterstore/ParameterStorePropertySource.java
@@ -47,7 +47,7 @@ public class ParameterStorePropertySource extends AwsPropertySource<ParameterSto
 
 	/**
 	 * Prefix that gets added to resolved property keys. Useful when same property keys are returned by multiple
-	 * parameter paths. sources.
+	 * parameter paths.
 	 */
 	@Nullable
 	private final String prefix;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Added the ability to specify a property prefix for parameter store property sources.  This replicates the functionality recently added for secrets manager property sources (see #621, #622, #630).  I pulled heavily from the secrets manager prefix implementation written by @snigdhasjg and @maciejwalkowiak to try to keep the code and documentation consistent 🤓 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When multiple parameter store paths are imported that contain the same key, properties will be overwritten.

For example:
- `/config/my-db/url` = `jdbc:mysql://localhost:3306`
- `/config/my-db/username` = `mysql-user`
- `/config/another-db/url` = `jdbc:postgresql://localhost:5432/postgres`

`spring.config.import=aws-parameterstore:/config/my-db/;/config/another-db/` results in the following properties:

- `url` = `jdbc:postgresql://localhost:5432/postgres`
- `username` = `mysql-user`

Additionally users might want to add a prefix to their parameters for improved readability or to match autoconfig conventions.  With the above properties, you can now do

`spring.config.import=aws-parameterstore:/config/my-db/?prefix=spring.datasource.` resulting in properties:

- `spring.datasource.url` = `jdbc:mysql://localhost:3306`
- `spring.datasource.username` = `mysql-user`

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
