### PR TITLE
Set more detailed data type on "timestamp" attribute in SNS message.

### DIFF
--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/TopicMessageChannel.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/TopicMessageChannel.java
@@ -103,7 +103,7 @@ public class TopicMessageChannel extends AbstractMessageChannel {
 				messageAttributes.put(messageHeaderName, getStringMessageAttribute(messageHeaderValue.toString()));
 			}
 			else if (MessageHeaders.TIMESTAMP.equals(messageHeaderName) && messageHeaderValue != null) {
-				messageAttributes.put(messageHeaderName, getNumberMessageAttribute(messageHeaderValue));
+				messageAttributes.put(messageHeaderName, getDetailedNumberMessageAttribute(messageHeaderValue));
 			}
 			else if (messageHeaderValue instanceof String) {
 				messageAttributes.put(messageHeaderName, getStringMessageAttribute((String) messageHeaderValue));

--- a/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/core/TopicMessageChannelTest.java
+++ b/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/core/TopicMessageChannelTest.java
@@ -66,6 +66,7 @@ class TopicMessageChannelTest {
 			assertThat(it.topicArn()).isEqualTo(TOPIC_ARN);
 			assertThat(it.message()).isEqualTo("Message content");
 			assertThat(it.messageAttributes()).containsKeys(MessageHeaders.ID, MessageHeaders.TIMESTAMP);
+			assertThat(it.messageAttributes().get(MessageHeaders.TIMESTAMP).dataType()).isEqualTo("Number.java.lang.Long");
 			assertThat(it.messageAttributes()).doesNotContainKey(NOTIFICATION_SUBJECT_HEADER);
 		}));
 		assertThat(sent).isTrue();


### PR DESCRIPTION
Mainly due to keeping backward compatibility with Spring Cloud AWS 2.x

Fixes #791