### PR TITLE
Fix S3Presigner region resolution

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfiguration.java
@@ -90,7 +90,8 @@ public class S3AutoConfiguration {
 	S3Presigner s3Presigner(S3Properties properties, AwsProperties awsProperties,
 			AwsCredentialsProvider credentialsProvider, AwsRegionProvider regionProvider) {
 		S3Presigner.Builder builder = S3Presigner.builder().serviceConfiguration(properties.toS3Configuration())
-				.credentialsProvider(credentialsProvider).region(regionProvider.getRegion());
+				.credentialsProvider(credentialsProvider)
+				.region(AwsClientBuilderConfigurer.resolveRegion(properties, regionProvider));
 
 		if (properties.getEndpoint() != null) {
 			builder.endpointOverride(properties.getEndpoint());

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfigurationTests.java
@@ -267,6 +267,22 @@ class S3AutoConfigurationTests {
 						assertThat(presigner.getRegion()).isEqualTo(Region.of("eu-west-1"));
 					});
 		}
+
+		@Test
+		void setsRegionFromProperties() {
+			contextRunner.withPropertyValues("spring.cloud.aws.s3.region:us-east-1").run(context -> {
+				ConfiguredAwsPresigner presigner = new ConfiguredAwsPresigner(context.getBean(S3Presigner.class));
+				assertThat(presigner.getRegion()).isEqualTo(Region.of("us-east-1"));
+			});
+		}
+
+		@Test
+		void setsRegionToDefault() {
+			contextRunner.run(context -> {
+				ConfiguredAwsPresigner presigner = new ConfiguredAwsPresigner(context.getBean(S3Presigner.class));
+				assertThat(presigner.getRegion()).isEqualTo(Region.of("eu-west-1"));
+			});
+		}
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
The presigner now uses the region from properties if it is set.