### PR TITLE
Fix sending message to cross account FIFO SQS queue, fixes gh-938.

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -210,6 +210,13 @@ Such attributes are available as `MessageHeaders` in received messages.
 |All
 |Set the message system attribute names that will be retrieved with messages on receive operations.
 Such attributes are available as `MessageHeaders` in received messages.
+
+|`contentBasedDeduplication`
+|ContentBasedDeduplication
+|ContentBasedDeduplication
+#AUTO
+|Set the ContentBasedDeduplication queue attribute value of the queues the template is sending messages to.
+With `ContentBasedDeduplication#AUTO`, the queue attribute value will be resolved automatically.
 |===
 
 ==== Sending Messages

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/ContentBasedDeduplication.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/ContentBasedDeduplication.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.operations;
+
+/**
+ * The ContentBasedDeduplication queue attribute value of a FIFO SQS queue.
+ *
+ * @author Zhong Xi Lu
+ * @since 3.0.4
+ */
+public enum ContentBasedDeduplication {
+
+	/**
+	 * The ContentBasedDeduplication queue attribute value will be resolved automatically at runtime.
+	 */
+	AUTO,
+
+	/**
+	 * ContentBasedDeduplication is enabled on the FIFO SQS queue.
+	 */
+	ENABLED,
+
+	/**
+	 * ContentBasedDeduplication is disabled on the FIFO SQS queue.
+	 */
+	DISABLED
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
@@ -69,4 +69,12 @@ public interface SqsTemplateOptions extends MessagingTemplateOptions<SqsTemplate
 	 */
 	SqsTemplateOptions messageSystemAttributeNames(Collection<MessageSystemAttributeName> messageSystemAttributeNames);
 
+	/**
+	 * Set the ContentBasedDeduplication queue attribute value of the queues the template is sending messages to. By
+	 * default, this is set to AUTO and the queue attribute value will be resolved automatically.
+	 *
+	 * @param contentBasedDeduplication the ContentBasedDeduplication value.
+	 * @return the options instance.
+	 */
+	SqsTemplateOptions contentBasedDeduplication(ContentBasedDeduplication contentBasedDeduplication);
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Currently, it is not possible to send a message to a cross account FIFO SQS queue due to a bug where AWS does not allow you to access the `ContentDeduplication` queue attribute value of a cross account FIFO SQS queue.

As described in [this comment](https://github.com/awspring/spring-cloud-aws/issues/938#issuecomment-1796988934) and [this comment](https://github.com/awspring/spring-cloud-aws/pull/950#issuecomment-1814353850), I've introduced a new enum `ContentDeduplication` and added this as an option in `SqsTemplateOptions`.

If the value is `ContentDeduplication.AUTO`, then it follows the current implementation and will always retrieve the ContentDeduplication value at runtime. Otherwise, we take the value from the user and will not make an extra request to AWS to resolve this value. Of course, by default, the strategy is `ContentDeduplication.AUTO`.


## :bulb: Motivation and Context
Fixes [this issue](https://github.com/awspring/spring-cloud-aws/issues/938).


## :green_heart: How did you test it?
- Added some unit tests in `SqsTemplateTests`.
- Also manually tested with a real cross account FIFO SQS queue.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] I updated reference documentation to reflect the change
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
