### PR TITLE
Fix startup when only base starter is included in classpath.

### DIFF
--- a/spring-cloud-aws-autoconfigure/pom.xml
+++ b/spring-cloud-aws-autoconfigure/pom.xml
@@ -19,17 +19,21 @@
 			<artifactId>spring-boot-autoconfigure</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>aws-core</artifactId>
+		</dependency>
+
+		<!-- optional dependencies -->
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-actuator-autoconfigure</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>io.awspring.cloud</groupId>
 			<artifactId>spring-cloud-aws-core</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
@@ -130,7 +134,6 @@
 			<artifactId>micrometer-registry-cloudwatch2</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-commons</artifactId>
@@ -151,6 +154,5 @@
 			<artifactId>sts</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 	</dependencies>
 </project>


### PR DESCRIPTION
Add explicit `sdk-core` dependency to autoconfigure module to fix startup when only base starter is included in classpath.

Fixes #934