### PR TITLE
fix: correct conditional for S3CrtAsyncClientAutoConfiguration

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfiguration.java
@@ -42,7 +42,7 @@ import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
  * @since 3.0
  */
 @AutoConfiguration
-@ConditionalOnClass({ S3Client.class })
+@ConditionalOnClass({ S3Client.class, S3AsyncClient.class })
 @EnableConfigurationProperties({ S3Properties.class })
 @ConditionalOnProperty(name = "spring.cloud.aws.s3.enabled", havingValue = "true", matchIfMissing = true)
 @AutoConfigureBefore(S3TransferManagerAutoConfiguration.class)

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfigurationTests.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -90,6 +91,14 @@ class S3CrtAsyncClientAutoConfigurationTests {
 					assertThat(s3NativeClientConfiguration.targetThroughputInGbps()).isEqualTo(100);
 					assertThat(s3NativeClientConfiguration.maxConcurrency()).isEqualTo(20);
 				});
+	}
+
+	@Test
+	void handlesMissingS3AsyncClient() {
+		contextRunner.withClassLoader(new FilteredClassLoader(S3AsyncClient.class)).run(context -> {
+			assertThat(context).hasNotFailed();
+			assertThat(context).doesNotHaveBean(S3AsyncClient.class);
+		});
 	}
 
 	private static S3NativeClientConfiguration s3NativeClientConfiguration(S3AsyncClient client) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Updating `@ConditionalOnClass` to not match when `S3AsyncClient` class is missing.


## :bulb: Motivation and Context
Fixes https://github.com/awspring/spring-cloud-aws/issues/969

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
