### PR TITLE
Fix S3Template.createSignedPutURL not applying given ObjectMetadata

### DIFF
--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/ObjectMetadata.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/ObjectMetadata.java
@@ -45,6 +45,9 @@ public class ObjectMetadata {
 	private final String contentLanguage;
 
 	@Nullable
+	private final Long contentLength;
+
+	@Nullable
 	private final String contentType;
 
 	@Nullable
@@ -119,21 +122,22 @@ public class ObjectMetadata {
 
 	ObjectMetadata(@Nullable String acl, @Nullable String cacheControl, @Nullable String contentDisposition,
 			@Nullable String contentEncoding, @Nullable String contentLanguage, @Nullable String contentType,
-			@Nullable Instant expires, @Nullable String grantFullControl, @Nullable String grantRead,
-			@Nullable String grantReadACP, @Nullable String grantWriteACP, @Nullable Map<String, String> metadata,
-			@Nullable String serverSideEncryption, @Nullable String storageClass,
-			@Nullable String websiteRedirectLocation, @Nullable String sseCustomerAlgorithm,
-			@Nullable String sseCustomerKey, @Nullable String sseCustomerKeyMD5, @Nullable String ssekmsKeyId,
-			@Nullable String ssekmsEncryptionContext, @Nullable Boolean bucketKeyEnabled, @Nullable String requestPayer,
-			@Nullable String tagging, @Nullable String objectLockMode, @Nullable Instant objectLockRetainUntilDate,
-			@Nullable String objectLockLegalHoldStatus, @Nullable String expectedBucketOwner,
-			@Nullable String checksumAlgorithm) {
+			@Nullable Long contentLength, @Nullable Instant expires, @Nullable String grantFullControl,
+			@Nullable String grantRead, @Nullable String grantReadACP, @Nullable String grantWriteACP,
+			@Nullable Map<String, String> metadata, @Nullable String serverSideEncryption,
+			@Nullable String storageClass, @Nullable String websiteRedirectLocation,
+			@Nullable String sseCustomerAlgorithm, @Nullable String sseCustomerKey, @Nullable String sseCustomerKeyMD5,
+			@Nullable String ssekmsKeyId, @Nullable String ssekmsEncryptionContext, @Nullable Boolean bucketKeyEnabled,
+			@Nullable String requestPayer, @Nullable String tagging, @Nullable String objectLockMode,
+			@Nullable Instant objectLockRetainUntilDate, @Nullable String objectLockLegalHoldStatus,
+			@Nullable String expectedBucketOwner, @Nullable String checksumAlgorithm) {
 		this.acl = acl;
 		this.cacheControl = cacheControl;
 		this.contentDisposition = contentDisposition;
 		this.contentEncoding = contentEncoding;
 		this.contentLanguage = contentLanguage;
 		this.contentType = contentType;
+		this.contentLength = contentLength;
 		this.expires = expires;
 		this.grantFullControl = grantFullControl;
 		this.grantRead = grantRead;
@@ -176,6 +180,9 @@ public class ObjectMetadata {
 		}
 		if (contentType != null) {
 			builder.contentType(contentType);
+		}
+		if (contentLength != null) {
+			builder.contentLength(contentLength);
 		}
 		if (expires != null) {
 			builder.expires(expires);
@@ -333,6 +340,9 @@ public class ObjectMetadata {
 	}
 
 	void apply(UploadPartRequest.Builder builder) {
+		if (contentLength != null) {
+			builder.contentLength(contentLength);
+		}
 		if (sseCustomerAlgorithm != null) {
 			builder.sseCustomerAlgorithm(sseCustomerAlgorithm);
 		}
@@ -399,6 +409,11 @@ public class ObjectMetadata {
 	@Nullable
 	public String getContentType() {
 		return contentType;
+	}
+
+	@Nullable
+	public Long getContentLength() {
+		return contentLength;
 	}
 
 	@Nullable
@@ -534,6 +549,9 @@ public class ObjectMetadata {
 		private String contentType;
 
 		@Nullable
+		private Long contentLength;
+
+		@Nullable
 		private Instant expires;
 
 		@Nullable
@@ -627,6 +645,11 @@ public class ObjectMetadata {
 
 		public Builder contentType(@Nullable String contentType) {
 			this.contentType = contentType;
+			return this;
+		}
+
+		public Builder contentLength(@Nullable Long contentLength) {
+			this.contentLength = contentLength;
 			return this;
 		}
 
@@ -767,11 +790,11 @@ public class ObjectMetadata {
 
 		public ObjectMetadata build() {
 			return new ObjectMetadata(acl, cacheControl, contentDisposition, contentEncoding, contentLanguage,
-					contentType, expires, grantFullControl, grantRead, grantReadACP, grantWriteACP, metadata,
-					serverSideEncryption, storageClass, websiteRedirectLocation, sseCustomerAlgorithm, sseCustomerKey,
-					sseCustomerKeyMD5, ssekmsKeyId, ssekmsEncryptionContext, bucketKeyEnabled, requestPayer, tagging,
-					objectLockMode, objectLockRetainUntilDate, objectLockLegalHoldStatus, expectedBucketOwner,
-					checksumAlgorithm);
+					contentType, contentLength, expires, grantFullControl, grantRead, grantReadACP, grantWriteACP,
+					metadata, serverSideEncryption, storageClass, websiteRedirectLocation, sseCustomerAlgorithm,
+					sseCustomerKey, sseCustomerKeyMD5, ssekmsKeyId, ssekmsEncryptionContext, bucketKeyEnabled,
+					requestPayer, tagging, objectLockMode, objectLockRetainUntilDate, objectLockLegalHoldStatus,
+					expectedBucketOwner, checksumAlgorithm);
 		}
 
 	}

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Template.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Template.java
@@ -193,7 +193,7 @@ public class S3Template implements S3Operations {
 
 		PutObjectRequest.Builder putObjectRequestBuilder = PutObjectRequest.builder().bucket(bucketName).key(key);
 		if (metadata != null) {
-			putObjectRequestBuilder.metadata(metadata.getMetadata());
+			metadata.apply(putObjectRequestBuilder);
 		}
 		if (contentType != null) {
 			putObjectRequestBuilder.contentType(contentType);

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/ObjectMetadataTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/ObjectMetadataTests.java
@@ -39,7 +39,7 @@ class ObjectMetadataTests {
 		Instant now = Instant.now();
 		ObjectMetadata objectMetadata = ObjectMetadata.builder().acl("acl").cacheControl("cacheControl")
 				.contentDisposition("contentDisposition").contentEncoding("contentEncoding")
-				.contentLanguage("contentLanguage").contentType("contentType").expires(now)
+				.contentLanguage("contentLanguage").contentType("contentType").contentLength(0L).expires(now)
 				.grantFullControl("grantFullControl").grantRead("grantRead").grantReadACP("grantReadACP")
 				.grantWriteACP("grantWriteACP").metadata("key1", "value1").metadata("key2", "value2")
 				.serverSideEncryption("serverSideEncryption").storageClass("storageClass")


### PR DESCRIPTION
…Also added contentLength property to ObjectMetadata

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
- Method S3Template#createSignedPutURL is not applying the ObjectMetadata object that it is passed in as a parameter.
- Added contentLength property to ObjectMetadata class so it can be applied to the url build request.

## :bulb: Motivation and Context
We are migrating our s3 integration to spring-cloud-aws and found the S3Template class very useful.
Trying to migrate some code I found the mentioned bug and also that contentLength was not yet supported.

## :green_heart: How did you test it?
- First of all made sure that the build and all tests finished OK locally after making changes.
- Updated an existing test for the ObjectMetadata class. There is a test for createSignedPutURL but since it uses local stack, the content length property cant be really tested since it is of no effect at all (Real S3 does validate the created signature with the content length sent in the request).
- I installed my changes locally and tested them out on a real life project generating a presigned url and using it to upload an example file.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
