### PR TITLE
Add S3Client objectExists support in S3Template

### DIFF
--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Operations.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Operations.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
  * {@link S3Template}.
  *
  * @author Maciej Walkowiak
+ * @author Ziemowit Stolarczyk
  * @since 3.0
  */
 public interface S3Operations {
@@ -69,6 +70,15 @@ public interface S3Operations {
 	 * @param s3Url - the S3 url s3://bucket/key
 	 */
 	void deleteObject(String s3Url);
+
+	/**
+	 * Checks if an S3 object exists.
+	 *
+	 * @param bucketName - the bucket name
+	 * @param key - the object key
+	 * @return true if object exists; false otherwise
+	 */
+	boolean objectExists(String bucketName, String key);
 
 	/**
 	 * Returns some or all (up to 1,000) of the objects in a bucket. Does not handle pagination. If you need pagination

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Template.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Template.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
@@ -39,6 +40,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
  * Higher level abstraction over {@link S3Client} providing methods for the most common use cases.
  *
  * @author Maciej Walkowiak
+ * @author Ziemowit Stolarczyk
  * @since 3.0
  */
 public class S3Template implements S3Operations {
@@ -99,6 +101,19 @@ public class S3Template implements S3Operations {
 		Assert.notNull(s3Url, "s3Url is required");
 		Location location = Location.of(s3Url);
 		this.deleteObject(location.getBucket(), location.getObject());
+	}
+
+	@Override
+	public boolean objectExists(String bucketName, String key) {
+		Assert.notNull(bucketName, "bucketName is required");
+		Assert.notNull(key, "key is required");
+		try {
+			s3Client.headObject(request -> request.bucket(bucketName).key(key));
+		}
+		catch (NoSuchBucketException | NoSuchKeyException e) {
+			return false;
+		}
+		return true;
 	}
 
 	@Override

--- a/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
+++ b/spring-cloud-aws-s3-parent/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
@@ -61,6 +61,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
  *
  * @author Maciej Walkowiak
  * @author Yuki Yoshida
+ * @author Ziemowit Stolarczyk
  */
 @Testcontainers
 class S3TemplateIntegrationTests {
@@ -162,6 +163,26 @@ class S3TemplateIntegrationTests {
 
 		assertThatExceptionOfType(NoSuchKeyException.class)
 				.isThrownBy(() -> client.headObject(r -> r.bucket(BUCKET_NAME).key("key.txt")));
+	}
+
+	@Test
+	void whenObjectExistsShouldReturnTrue() {
+		client.putObject(r -> r.bucket(BUCKET_NAME).key("key.txt"), RequestBody.fromString("hello"));
+
+		final boolean existsObject = s3Template.objectExists(BUCKET_NAME, "key.txt");
+
+		assertThat(existsObject).isTrue();
+	}
+
+	@Test
+	void whenObjectNotExistsShouldReturnFalse() {
+		client.putObject(r -> r.bucket(BUCKET_NAME).key("key.txt"), RequestBody.fromString("hello"));
+
+		final boolean existsObject1 = s3Template.objectExists(BUCKET_NAME, "other-key.txt");
+		final boolean existsObject2 = s3Template.objectExists("other-bucket", "key.txt");
+
+		assertThat(existsObject1).isFalse();
+		assertThat(existsObject2).isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Introduction of S3Operations#documentExists, the complementary operation to S3Operations#bucketExists.


## :bulb: Motivation and Context
It is useful when we want to check if document exists without downloading it.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
