### PR TITLE
doc clarification for issue 971

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -640,6 +640,8 @@ See <<FIFO Support>> for more information.
 If any value is set, it will take precedence over the acknowledgement mode defined for the container factory options.
 See <<Acknowledgement Mode>> for more information.
 
+NOTE: When using `acknowledgementMode`, if you are also defining any custom `SqsMessageListenerContainerFactory` bean, it is necessary to update the default bean name for `SqsMessageListenerContainerFactory` to the bean name of your custom factory. This will allow this annotation to override the acknowledgement mode in your factory. This can be achieved by creating and configuring a `SqsListenerConfigurer` bean. Refer to section <<Global Configuration for @SqsListeners>> for more information, and see <<Specifying a MessageListenerContainerFactory>> for more details about this bean naming caveat.
+
 ===== Listener Method Arguments
 
 A number of possible argument types are allowed in the listener method's signature.


### PR DESCRIPTION
https://github.com/awspring/spring-cloud-aws/issues/971

Clarify bean factory name overrides needed for a mix of @SqsListener acknowledgmentMode usages with existing custom MessageListenerContainerFactory defined in the app.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X ] Enhancement
- [ ] Refactoring


## :scroll: Description
Doc clarification for issue https://github.com/awspring/spring-cloud-aws/issues/971

## :bulb: Motivation and Context
Helps clarify the reason for the following exception found when using custom MessageListenerContainerFactory and `acknowledgementMode` annotation in the same app.  

`No MessageListenerContainerFactory bean with name defaultSqsListenerContainerFactory found for endpoint names`


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] I updated reference documentation to reflect the change
- [ ] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
