### PR TITLE
Add ContentBasedDeduplication option when sending SQS messages (#938)

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -210,6 +210,13 @@ Such attributes are available as `MessageHeaders` in received messages.
 |All
 |Set the message system attribute names that will be retrieved with messages on receive operations.
 Such attributes are available as `MessageHeaders` in received messages.
+
+|`contentBasedDeduplication`
+|ContentBasedDeduplication
+|ContentBasedDeduplication
+#AUTO
+|Set the ContentBasedDeduplication queue attribute value of the queues the template is sending messages to.
+With `ContentBasedDeduplication#AUTO`, the queue attribute value will be resolved automatically.
 |===
 
 ==== Sending Messages

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
@@ -33,16 +33,15 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.lang.Nullable;
@@ -68,6 +67,14 @@ import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchResultEntry;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
+/**
+ * Sqs-specific implementation of {@link AbstractMessagingTemplate}
+ *
+ * @author Tomaz Fernandes
+ * @author Zhong Xi Lu
+ *
+ * @since 3.0
+ */
 public class SqsTemplate extends AbstractMessagingTemplate<Message> implements SqsOperations, SqsAsyncOperations {
 
 	private static final Logger logger = LoggerFactory.getLogger(SqsTemplate.class);
@@ -86,6 +93,8 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 	private final Collection<String> messageSystemAttributeNames;
 
+	private final TemplateContentBasedDeduplication contentBasedDeduplication;
+
 	private SqsTemplate(SqsTemplateBuilderImpl builder) {
 		super(builder.messageConverter, builder.options);
 		SqsTemplateOptionsImpl options = builder.options;
@@ -94,6 +103,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		this.queueAttributeNames = options.queueAttributeNames;
 		this.queueNotFoundStrategy = options.queueNotFoundStrategy;
 		this.messageSystemAttributeNames = options.messageSystemAttributeNames;
+		this.contentBasedDeduplication = options.contentBasedDeduplication;
 	}
 
 	/**
@@ -127,6 +137,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 	/**
 	 * Create a new {@link SqsTemplate} instance with the provided {@link SqsAsyncClient}, only exposing the async
 	 * methods contained in {@link SqsAsyncOperations}.
+	 *
 	 * @param sqsAsyncClient the client.
 	 * @return the new template instance.
 	 */
@@ -247,35 +258,61 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 	@Override
 	protected <T> org.springframework.messaging.Message<T> preProcessMessageForSend(String endpointToUse,
 			org.springframework.messaging.Message<T> message) {
-		return FifoUtils.isFifo(endpointToUse) ? addMissingFifoSendHeaders(endpointToUse, message) : message;
+		return message;
 	}
 
 	@Override
 	protected <T> Collection<org.springframework.messaging.Message<T>> preProcessMessagesForSend(String endpointToUse,
 			Collection<org.springframework.messaging.Message<T>> messages) {
-		return FifoUtils.isFifo(endpointToUse)
-				? messages.stream().map(message -> addMissingFifoSendHeaders(endpointToUse, message)).toList()
-				: messages;
+		return messages;
 	}
 
-	private <T> org.springframework.messaging.Message<T> addMissingFifoSendHeaders(String endpointName,
-			org.springframework.messaging.Message<T> message) {
+	@Override
+	protected <T> CompletableFuture<org.springframework.messaging.Message<T>> preProcessMessageForSendAsync(
+			String endpointToUse, org.springframework.messaging.Message<T> message) {
+		return FifoUtils.isFifo(endpointToUse)
+				? endpointHasContentBasedDeduplicationEnabled(endpointToUse)
+						.thenApply(enabled -> enabled ? addMissingFifoSendHeaders(message, Map.of())
+								: addMissingFifoSendHeaders(message, getRandomDeduplicationIdHeader()))
+				: CompletableFuture.completedFuture(message);
+	}
 
-		Set<QueueAttributeName> additionalAttributes = Set.of(QueueAttributeName.CONTENT_BASED_DEDUPLICATION);
-		String contentBasedDedupQueueAttribute = getQueueAttributes(endpointName, additionalAttributes).join()
-				.getQueueAttribute(QueueAttributeName.CONTENT_BASED_DEDUPLICATION);
+	@Override
+	protected <T> CompletableFuture<Collection<org.springframework.messaging.Message<T>>> preProcessMessagesForSendAsync(
+			String endpointToUse, Collection<org.springframework.messaging.Message<T>> messages) {
+		return FifoUtils.isFifo(endpointToUse)
+				? endpointHasContentBasedDeduplicationEnabled(endpointToUse).thenApply(enabled -> messages.stream()
+						.map(message -> enabled ? addMissingFifoSendHeaders(message, Map.of())
+								: addMissingFifoSendHeaders(message, getRandomDeduplicationIdHeader()))
+						.toList())
+				: CompletableFuture.completedFuture(messages);
+	}
 
-		boolean isContentBasedDedup = Boolean.parseBoolean(contentBasedDedupQueueAttribute);
-		Map<String, Object> defaultHeaders;
-		if (isContentBasedDedup) {
-			defaultHeaders = Map.of(MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, UUID.randomUUID().toString());
-		}
-		else {
-			defaultHeaders = Map.of(MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, UUID.randomUUID().toString(),
-					MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, UUID.randomUUID().toString());
-		}
+	private <T> org.springframework.messaging.Message<T> addMissingFifoSendHeaders(
+			org.springframework.messaging.Message<T> message, Map<String, Object> additionalHeaders) {
+		return MessageHeaderUtils.addHeadersIfAbsent(message,
+				Stream.concat(additionalHeaders.entrySet().stream(), getRandomMessageGroupIdHeader().entrySet().stream())
+						.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+	}
 
-		return MessageHeaderUtils.addHeadersIfAbsent(message, defaultHeaders);
+	private Map<String, String> getRandomMessageGroupIdHeader() {
+		return Map.of(MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, UUID.randomUUID().toString());
+	}
+
+	private Map<String, Object> getRandomDeduplicationIdHeader() {
+		return Map.of(MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, UUID.randomUUID().toString());
+	}
+
+	private CompletableFuture<Boolean> endpointHasContentBasedDeduplicationEnabled(String endpointName) {
+		return TemplateContentBasedDeduplication.AUTO.equals(this.contentBasedDeduplication)
+				? handleAutoDeduplication(endpointName)
+				: CompletableFuture
+						.completedFuture(contentBasedDeduplication.equals(TemplateContentBasedDeduplication.ENABLED));
+	}
+
+	private CompletableFuture<Boolean> handleAutoDeduplication(String endpointName) {
+		return getQueueAttributes(endpointName).thenApply(attributes -> Boolean
+				.parseBoolean(attributes.getQueueAttribute(QueueAttributeName.CONTENT_BASED_DEDUPLICATION)));
 	}
 
 	@Override
@@ -363,14 +400,18 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		SqsMessageConversionContext conversionContext = new SqsMessageConversionContext();
 		conversionContext.setSqsAsyncClient(this.sqsAsyncClient);
 		// At this point we'll already have retrieved and cached the queue attributes
-		CompletableFuture<QueueAttributes> queueAttributes = getQueueAttributes(newEndpoint);
-		Assert.isTrue(queueAttributes.isDone(), () -> "Queue attributes not done for " + newEndpoint);
-		conversionContext.setQueueAttributes(queueAttributes.join());
+		conversionContext.setQueueAttributes(getAttributesImmediately(newEndpoint));
 		if (payloadClass != null) {
 			conversionContext.setPayloadClass(payloadClass);
 		}
 		conversionContext.setAcknowledgementCallback(new TemplateAcknowledgementCallback<T>());
 		return conversionContext;
+	}
+
+	private QueueAttributes getAttributesImmediately(String newEndpoint) {
+		CompletableFuture<QueueAttributes> queueAttributes = getQueueAttributes(newEndpoint);
+		Assert.isTrue(queueAttributes.isDone(), () -> "Queue attributes not done for " + newEndpoint);
+		return queueAttributes.join();
 	}
 
 	private CompletableFuture<SendMessageBatchRequest> createSendMessageBatchRequest(String endpointName,
@@ -423,21 +464,23 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 	}
 
 	private CompletableFuture<QueueAttributes> getQueueAttributes(String endpointName) {
-		return getQueueAttributes(endpointName, Collections.emptySet());
+		return this.queueAttributesCache.computeIfAbsent(endpointName,
+				newName -> doGetQueueAttributes(endpointName, newName));
 	}
 
-	private CompletableFuture<QueueAttributes> getQueueAttributes(String endpointName,
-			Set<QueueAttributeName> additionalAttributes) {
-		return this.queueAttributesCache.computeIfAbsent(endpointName, newName -> {
-			// ensure we have the content based dedupe config to determine default fifo send headers
-			Set<QueueAttributeName> namesToRequest = new HashSet<>(queueAttributeNames);
-			if (additionalAttributes != null && !additionalAttributes.isEmpty()) {
-				namesToRequest.addAll(additionalAttributes);
-			}
-			return QueueAttributesResolver.builder().sqsAsyncClient(this.sqsAsyncClient).queueName(newName)
-					.queueNotFoundStrategy(this.queueNotFoundStrategy).queueAttributeNames(namesToRequest).build()
-					.resolveQueueAttributes();
-		});
+	private CompletableFuture<QueueAttributes> doGetQueueAttributes(String endpointName, String newName) {
+		return QueueAttributesResolver.builder().sqsAsyncClient(this.sqsAsyncClient).queueName(newName)
+				.queueNotFoundStrategy(this.queueNotFoundStrategy)
+				.queueAttributeNames(maybeAddContentBasedDeduplicationAttribute(endpointName)).build()
+				.resolveQueueAttributes();
+	}
+
+	private Collection<QueueAttributeName> maybeAddContentBasedDeduplicationAttribute(String endpointName) {
+		return FifoUtils.isFifo(endpointName)
+				&& TemplateContentBasedDeduplication.AUTO.equals(this.contentBasedDeduplication)
+						? Stream.concat(queueAttributeNames.stream(),
+								Stream.of(QueueAttributeName.CONTENT_BASED_DEDUPLICATION)).toList()
+						: queueAttributeNames;
 	}
 
 	@Override
@@ -591,6 +634,8 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 		private Collection<String> messageSystemAttributeNames = Collections.singletonList("All");
 
+		private TemplateContentBasedDeduplication contentBasedDeduplication = TemplateContentBasedDeduplication.AUTO;
+
 		@Override
 		public SqsTemplateOptions queueAttributeNames(Collection<QueueAttributeName> queueAttributeNames) {
 			Assert.notEmpty(queueAttributeNames, "queueAttributeNames cannot be null or empty");
@@ -622,6 +667,13 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 				Collection<MessageSystemAttributeName> messageSystemAttributeNames) {
 			this.messageSystemAttributeNames = messageSystemAttributeNames.stream()
 					.map(MessageSystemAttributeName::name).toList();
+			return this;
+		}
+
+		@Override
+		public SqsTemplateOptions contentBasedDeduplication(
+				TemplateContentBasedDeduplication contentBasedDeduplication) {
+			this.contentBasedDeduplication = contentBasedDeduplication;
 			return this;
 		}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
@@ -69,4 +69,13 @@ public interface SqsTemplateOptions extends MessagingTemplateOptions<SqsTemplate
 	 */
 	SqsTemplateOptions messageSystemAttributeNames(Collection<MessageSystemAttributeName> messageSystemAttributeNames);
 
+	/**
+	 * Set the ContentBasedDeduplication queue attribute value of the queues the template is sending messages to. By
+	 * default, this is set to AUTO and the queue attribute value will be resolved automatically per queue. If set to
+	 * ENABLED or DISABLED, the value will apply to all queues.
+	 *
+	 * @param contentBasedDeduplication the ContentBasedDeduplication value.
+	 * @return the options instance.
+	 */
+	SqsTemplateOptions contentBasedDeduplication(TemplateContentBasedDeduplication contentBasedDeduplication);
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/TemplateContentBasedDeduplication.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/TemplateContentBasedDeduplication.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.operations;
+
+/**
+ * The ContentBasedDeduplication queue attribute value to be used by the {@link SqsTemplate} when sending messages to a
+ * FIFO queue.
+ *
+ * @author Zhong Xi Lu
+ * @since 3.0.4
+ */
+public enum TemplateContentBasedDeduplication {
+
+	/**
+	 * The ContentBasedDeduplication queue attribute value will be resolved automatically at runtime.
+	 */
+	AUTO,
+
+	/**
+	 * ContentBasedDeduplication is enabled on all FIFO SQS queues.
+	 */
+	ENABLED,
+
+	/**
+	 * ContentBasedDeduplication is disabled on all FIFO SQS queues.
+	 */
+	DISABLED
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
@@ -43,6 +43,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.StopWatch;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 
 /**
  * @author Tomaz Fernandes
@@ -74,6 +75,8 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 
 	private static final String SENDS_AND_RECEIVES_MESSAGE_FIFO_QUEUE_NAME = "send-receive-message-queue.fifo";
 
+	private static final String HANDLES_CONTENT_DEDUPLICATION_QUEUE_NAME = "handles-content-deduplication-queue.fifo";
+
 	@Autowired
 	private SqsAsyncClient asyncClient;
 
@@ -90,7 +93,10 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 				createQueue(client, THROWS_ON_PARTIAL_BATCH_QUEUE_NAME),
 				createQueue(client, SENDS_AND_RECEIVES_MANUAL_ACK_QUEUE_NAME), createQueue(client, EMPTY_QUEUE_NAME),
 				createFifoQueue(client, SENDS_AND_RECEIVES_MESSAGE_FIFO_QUEUE_NAME),
-				createFifoQueue(client, SENDS_AND_RECEIVES_BATCH_FIFO_QUEUE_NAME)).join();
+				createFifoQueue(client, SENDS_AND_RECEIVES_BATCH_FIFO_QUEUE_NAME),
+				createFifoQueue(client, HANDLES_CONTENT_DEDUPLICATION_QUEUE_NAME,
+						Map.of(QueueAttributeName.CONTENT_BASED_DEDUPLICATION, "true")))
+				.join();
 	}
 
 	@Test
@@ -223,6 +229,29 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 			assertThat(result.messageId()).isEqualTo(message.getHeaders().getId());
 		});
 
+	}
+
+	@Test
+	void shouldHandleContentBasedDeduplication() {
+		String testBody = "Hello world!";
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(this.asyncClient).build();
+		SendResult<Object> result = template
+				.send(to -> to.queue(HANDLES_CONTENT_DEDUPLICATION_QUEUE_NAME).payload(testBody));
+		Optional<Message<?>> receivedMessage = template
+				.receive(from -> from.queue(HANDLES_CONTENT_DEDUPLICATION_QUEUE_NAME));
+		assertThat(result.message().getHeaders()
+				.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER)).isNull();
+		assertThat(receivedMessage).isPresent().get().isInstanceOfSatisfying(Message.class, message -> {
+			assertThat(message.getPayload()).isEqualTo(testBody);
+			assertThat(result.additionalInformation().get(SqsTemplateParameters.SEQUENCE_NUMBER_PARAMETER_NAME))
+					.isEqualTo(message.getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_SEQUENCE_NUMBER));
+			assertThat(message.getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER))
+					.isEqualTo(result.message().getHeaders()
+							.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER));
+			assertThat(message.getHeaders().get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER))
+					.isNotNull();
+			assertThat(result.messageId()).isEqualTo(message.getHeaders().getId());
+		});
 	}
 
 	@Test

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -249,6 +249,138 @@ class SqsTemplateTests {
 	}
 
 	@Test
+	void shouldSendWithDeduplicationIdWhenContentBasedDeduplicationSetToAutoAndIsDisabled() {
+		String queue = "test-queue.fifo";
+		String payload = "test-payload";
+
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
+
+		var queueAttributesResponse = GetQueueAttributesResponse.builder()
+				.attributes(Map.of(QueueAttributeName.CONTENT_BASED_DEDUPLICATION, "false")).build();
+
+		given(mockClient.getQueueAttributes(any(Consumer.class)))
+				.willReturn(CompletableFuture.completedFuture(queueAttributesResponse));
+
+		UUID uuid = UUID.randomUUID();
+		String sequenceNumber = "1234";
+		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
+				.sequenceNumber(sequenceNumber).build();
+		given(mockClient.sendMessage(any(SendMessageRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(response));
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient).configure(options -> options
+				.defaultQueue(queue).contentBasedDeduplication(TemplateContentBasedDeduplication.AUTO))
+				.buildSyncTemplate();
+
+		SendResult<String> result = template.send(payload);
+
+		assertThat(result.endpoint()).isEqualTo(queue);
+		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+		then(mockClient).should().sendMessage(captor.capture());
+		SendMessageRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.queueUrl()).isEqualTo(queue);
+		assertThat(capturedRequest.messageDeduplicationId()).isNotNull();
+	}
+
+	@Test
+	void shouldSendWithoutDeduplicationIdWhenContentBasedDeduplicationSetToAutoAndEnabled() {
+		String queue = "test-queue.fifo";
+		String payload = "test-payload";
+
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
+
+		var queueAttributesResponse = GetQueueAttributesResponse.builder()
+				.attributes(Map.of(QueueAttributeName.CONTENT_BASED_DEDUPLICATION, "true")).build();
+
+		given(mockClient.getQueueAttributes(any(Consumer.class)))
+				.willReturn(CompletableFuture.completedFuture(queueAttributesResponse));
+
+		UUID uuid = UUID.randomUUID();
+		String sequenceNumber = "1234";
+		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
+				.sequenceNumber(sequenceNumber).build();
+		given(mockClient.sendMessage(any(SendMessageRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(response));
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient).configure(options -> options
+				.defaultQueue(queue).contentBasedDeduplication(TemplateContentBasedDeduplication.AUTO))
+				.buildSyncTemplate();
+
+		SendResult<String> result = template.send(payload);
+
+		assertThat(result.endpoint()).isEqualTo(queue);
+		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+		then(mockClient).should().sendMessage(captor.capture());
+		SendMessageRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.queueUrl()).isEqualTo(queue);
+		assertThat(capturedRequest.messageDeduplicationId()).isNull();
+	}
+
+	@Test
+	void shouldSendWithDeduplicationIdWhenContentBasedDeduplicationSetToDisabled() {
+		String queue = "test-queue.fifo";
+		String payload = "test-payload";
+
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
+
+		UUID uuid = UUID.randomUUID();
+		String sequenceNumber = "1234";
+		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
+				.sequenceNumber(sequenceNumber).build();
+		given(mockClient.sendMessage(any(SendMessageRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(response));
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient).configure(options -> options
+				.defaultQueue(queue).contentBasedDeduplication(TemplateContentBasedDeduplication.DISABLED))
+				.buildSyncTemplate();
+
+		SendResult<String> result = template.send(payload);
+
+		assertThat(result.endpoint()).isEqualTo(queue);
+		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+		then(mockClient).should().sendMessage(captor.capture());
+		SendMessageRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.queueUrl()).isEqualTo(queue);
+		assertThat(capturedRequest.messageDeduplicationId()).isNotNull();
+	}
+
+	@Test
+	void shouldSendWithoutDeduplicationIdWhenContentBasedDeduplicationSetToEnabled() {
+		String queue = "test-queue.fifo";
+		String payload = "test-payload";
+
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
+
+		UUID uuid = UUID.randomUUID();
+		String sequenceNumber = "1234";
+		SendMessageResponse response = SendMessageResponse.builder().messageId(uuid.toString())
+				.sequenceNumber(sequenceNumber).build();
+		given(mockClient.sendMessage(any(SendMessageRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(response));
+		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(mockClient).configure(options -> options
+				.defaultQueue(queue).contentBasedDeduplication(TemplateContentBasedDeduplication.ENABLED))
+				.buildSyncTemplate();
+
+		SendResult<String> result = template.send(payload);
+
+		assertThat(result.endpoint()).isEqualTo(queue);
+		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+		then(mockClient).should().sendMessage(captor.capture());
+		SendMessageRequest capturedRequest = captor.getValue();
+		assertThat(capturedRequest.queueUrl()).isEqualTo(queue);
+		assertThat(capturedRequest.messageDeduplicationId()).isNull();
+	}
+
+	@Test
 	void shouldWrapSendError() {
 		String queue = "test-queue";
 		String payload = "test-payload";


### PR DESCRIPTION
Supersedes https://github.com/awspring/spring-cloud-aws/pull/950

Adds ContentDeduplication option to SqsTemplate and fixes a bug introduced in #799