### PR TITLE
Assert queues are all the same type in setQueueNames so applications …

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainer.java
@@ -122,14 +122,15 @@ public class SqsMessageListenerContainer<T>
 
 	@Override
 	protected Collection<ContainerComponentFactory<T, SqsContainerOptions>> createDefaultComponentFactories() {
-		Assert.isTrue(allQueuesSameType(),
-				"SqsMessageListenerContainer must contain either all FIFO or all Standard queues.");
 		return Arrays.asList(new FifoSqsComponentFactory<>(), new StandardSqsComponentFactory<>());
 	}
 
-	private boolean allQueuesSameType() {
-		return getQueueNames().stream().allMatch(this::isFifoQueue)
-				|| getQueueNames().stream().noneMatch(this::isFifoQueue);
+	@Override
+	public void setQueueNames(Collection<String> queueNames) {
+		Assert.isTrue(
+			queueNames.stream().allMatch(this::isFifoQueue) || queueNames.stream().noneMatch(this::isFifoQueue),
+			"SqsMessageListenerContainer must contain either all FIFO or all Standard queues.");
+		super.setQueueNames(queueNames);
 	}
 
 	private boolean isFifoQueue(String name) {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainerTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainerTests.java
@@ -185,4 +185,14 @@ class SqsMessageListenerContainerTests {
 		container.stop();
 	}
 
+	@Test
+	void shouldThrowIfMixedQueueTypes() {
+		SqsAsyncClient client = mock(SqsAsyncClient.class);
+		SqsMessageListenerContainer.Builder<Object> builder = SqsMessageListenerContainer.builder()
+				.sqsAsyncClient(client).queueNames("queue", "queue.fifo");
+
+		assertThatThrownBy(builder::build).isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("must contain either all FIFO or all Standard queues");
+	}
+
 }


### PR DESCRIPTION
…fail to start rather than throwing endless Executor errors.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This asserts there's not a mix of FIFO and non-FIFO queues earlier in `SqsMessageListenerContainer.setQueueNames` instead of waiting for the container to fail on startup.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Migrating from 2.x, we had an `@SqsListener` with a mix of queue types. Instead of failing at startup, there's only one line logged:

```s.c.a.AnnotationConfigApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.context.ApplicationContextException: Failed to start bean 'io.awspring.cloud.messaging.internalEndpointRegistryBeanName'```

... followed by an endless loop of AWS SDK `executor not accepting a task` errors from all queues.

This is probably not an ideal fix - it seems like any failure in `io.awspring.cloud.sqs.listener.DefaultListenerContainerRegistry#start` should be fatal rather than leaving queues in a weird half-started state. I didn't go that deeply. Feel free to chuck this for a wider fix. :)


## :green_heart: How did you test it?

Added a simple UT, then pulled the SNAPSHOT into the application with the issue. Verified the app failed immediately with a very clear error.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
