### PR TITLE
Fix QueueAttributesResolver throws when creating Fifo queue (#995)

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/QueueAttributesResolver.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/QueueAttributesResolver.java
@@ -119,9 +119,15 @@ public class QueueAttributesResolver {
 	}
 
 	private CompletableFuture<String> createQueue() {
-		return this.sqsAsyncClient.createQueue(req -> req.queueName(this.queueName).build())
+		return this.sqsAsyncClient.createQueue(req -> req.queueName(this.queueName)
+				.attributes(getAttributes())
+				.build())
 			.thenApply(CreateQueueResponse::queueUrl)
 			.whenComplete(this::logCreateQueueResult);
+	}
+
+	private Map<QueueAttributeName,String> getAttributes() {
+        return FifoUtils.isFifo(this.queueName) ? Map.of(QueueAttributeName.FIFO_QUEUE, "true") : Map.of();
 	}
 
 	private void logCreateQueueResult(String v, Throwable t) {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/QueueAttributesResolverIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/QueueAttributesResolverIntegrationTests.java
@@ -71,6 +71,29 @@ class QueueAttributesResolverIntegrationTests extends BaseSqsIntegrationTest {
 		}
 	}
 
+	// @formatter:off
+	@Test
+	void shouldCreateFifoQueue() {
+		String queueName = "testQueueName-" + UUID.randomUUID() + ".fifo";
+		SqsAsyncClient client = createAsyncClient();
+		QueueAttributesResolver resolver = QueueAttributesResolver
+			.builder()
+			.queueAttributeNames(Collections.emptyList())
+			.sqsAsyncClient(client)
+			.queueName(queueName)
+			.queueNotFoundStrategy(QueueNotFoundStrategy.CREATE)
+			.build();
+		try {
+			QueueAttributes attributes = resolver.resolveQueueAttributes().join();
+			assertThat(attributes.getQueueName()).isEqualTo(queueName);
+			assertThat(attributes.getQueueAttribute(QueueAttributeName.QUEUE_ARN)).isNull();
+		}
+		finally {
+			String queueUrl = client.getQueueUrl(GetQueueUrlRequest.builder().queueName(queueName).build()).join().queueUrl();
+			client.deleteQueue(DeleteQueueRequest.builder().queueUrl(queueUrl).build()).join();
+		}
+	}
+
 	@Test
 	void shouldNotCreateQueue() {
 		String queueName = "testQueueName-" + UUID.randomUUID();


### PR DESCRIPTION
This commit adds the FIFO attribute to the CreateQueueRequest when the queue name is fifo.