### PR TITLE
Add BackOff when SQS Poll throws an exception

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -812,6 +812,11 @@ See AWS documentation for more information.
 After that period, the framework will try to perform a partial acquire with the available permits, resulting in a poll for less than `maxMessagesPerPoll` messages, unless otherwise configured.
 See <<Message Processing Throughput>>.
 
+|<<pollBackOffPolicy>>
+|Any valid `BackOffPolicy` implementation
+|`ExponentialBackOffPolicy`
+|The back off policy to be applied when a polling thread throws an error. The default is an exponential policy with a delay of `1s`, a multiplier of `2.0`, and a maximum of `10s`.
+
 |`autoStartup`
 |true, false
 |true
@@ -1568,6 +1573,11 @@ Set in `SqsContainerOptions`.
 Represents the maximum amount of time the container will wait for `maxMessagesPerPoll` permits to be available before trying to acquire a partial batch if so configured.
 This wait is applied per queue and one queue has no interference in another in this regard.
 Defaults to 10 seconds.
+
+===== pollBackOffPolicy
+Since 3.2 it's possible to specify a `BackOffPolicy` which will be applied when a polling thread throws an exception.
+The default policy is an exponential back off with a delay of 1000ms, a 2.0 multiplier, and a 10000ms maximum delay.
+Note that in highly concurrent environments with many polling threads it may happen that a successful poll cancels the next scheduled backoff before it happens, and as such no back offs need to be executed.
 
 ==== Default Polling Behavior
 By default, the framework starts all queues in `low throughput mode`, where it will perform one poll for messages at a time.

--- a/spring-cloud-aws-sqs/pom.xml
+++ b/spring-cloud-aws-sqs/pom.xml
@@ -31,6 +31,10 @@
 			<artifactId>spring-context</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.retry</groupId>
+			<artifactId>spring-retry</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptions.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.Collection;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.lang.Nullable;
+import org.springframework.retry.backoff.BackOffPolicy;
 
 /**
  * Contains the options to be used by the {@link MessageListenerContainer} at runtime. Note that after the object has
@@ -72,6 +73,15 @@ public interface ContainerOptions<O extends ContainerOptions<O, B>, B extends Co
 	 * @return the timeout duration.
 	 */
 	Duration getPollTimeout();
+
+	/**
+	 * Return the {@link BackOffPolicy} to be applied when polling throws an exception.
+	 * @return the timeout duration.
+	 * @since 3.2
+	 */
+	default BackOffPolicy getPollBackOffPolicy() {
+		throw new UnsupportedOperationException("Poll Back Off not supported by this ContainerOptions");
+	}
 
 	/**
 	 * Return the {@link TaskExecutor} to be used by this container's components. It's shared by the

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptionsBuilder.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptionsBuilder.java
@@ -20,6 +20,7 @@ import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementMod
 import io.awspring.cloud.sqs.support.converter.MessagingMessageConverter;
 import java.time.Duration;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.retry.backoff.BackOffPolicy;
 
 /**
  * A builder for creating a {@link ContainerOptions} instance.
@@ -73,6 +74,16 @@ public interface ContainerOptionsBuilder<B extends ContainerOptionsBuilder<B, O>
 	 * @return this instance.
 	 */
 	B pollTimeout(Duration pollTimeout);
+
+	/**
+	 * Set the {@link BackOffPolicy} to use when polling throws an exception.
+	 * @param pollBackOffPolicy the back off policy.
+	 * @return this instance.
+	 * @since 3.2
+	 */
+	default B pollBackOffPolicy(BackOffPolicy pollBackOffPolicy) {
+		throw new UnsupportedOperationException("Poll back off not supported by this container options builder");
+	}
 
 	/**
 	 * Set the {@link ListenerMode} mode for this container. Default is {@link ListenerMode#SINGLE_MESSAGE}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSource.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSource.java
@@ -33,10 +33,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.messaging.Message;
+import org.springframework.retry.backoff.BackOffContext;
+import org.springframework.retry.backoff.BackOffPolicy;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -65,6 +68,10 @@ public abstract class AbstractPollingMessageSource<T, S> extends AbstractMessage
 
 	private Duration shutdownTimeout;
 
+	private BackOffPolicy pollBackOffPolicy;
+
+	private AtomicReference<BackOffContext> pollBackOffContext = new AtomicReference<>();
+
 	private TaskExecutor taskExecutor;
 
 	private BatchAwareBackPressureHandler backPressureHandler;
@@ -87,6 +94,7 @@ public abstract class AbstractPollingMessageSource<T, S> extends AbstractMessage
 	@Override
 	protected void configureMessageSource(ContainerOptions<?, ?> containerOptions) {
 		this.shutdownTimeout = containerOptions.getListenerShutdownTimeout();
+		this.pollBackOffPolicy = containerOptions.getPollBackOffPolicy();
 		doConfigure(containerOptions);
 	}
 
@@ -163,6 +171,7 @@ public abstract class AbstractPollingMessageSource<T, S> extends AbstractMessage
 			Assert.notNull(this.messageSink, "messageSink not set");
 			Assert.notNull(this.backPressureHandler, "backPressureHandler not set");
 			Assert.notNull(this.acknowledgmentProcessor, "acknowledgmentProcessor not set");
+			Assert.notNull(this.pollBackOffPolicy, "pollBackOffPolicy not set");
 			logger.debug("Starting {} for queue {}", getClass().getSimpleName(), this.pollingEndpointName);
 			this.running = true;
 			ConfigUtils.INSTANCE
@@ -194,6 +203,7 @@ public abstract class AbstractPollingMessageSource<T, S> extends AbstractMessage
 				if (!isRunning()) {
 					continue;
 				}
+				handlePollBackOff();
 				logger.trace("Requesting permits for queue {}", this.pollingEndpointName);
 				final int acquiredPermits = this.backPressureHandler.requestBatch();
 				if (acquiredPermits == 0) {
@@ -209,6 +219,7 @@ public abstract class AbstractPollingMessageSource<T, S> extends AbstractMessage
 				}
 				// @formatter:off
 				managePollingFuture(doPollForMessages(acquiredPermits))
+					.thenApply(this::resetBackOffContext)
 					.exceptionally(this::handlePollingException)
 					.thenApply(msgs -> releaseUnusedPermits(acquiredPermits, msgs))
 					.thenApply(this::convertMessages)
@@ -226,6 +237,16 @@ public abstract class AbstractPollingMessageSource<T, S> extends AbstractMessage
 			}
 		}
 		logger.debug("Execution thread stopped for queue {}", this.pollingEndpointName);
+	}
+
+	private void handlePollBackOff() {
+		BackOffContext backOffContext = this.pollBackOffContext.get();
+		if (backOffContext == null) {
+			return;
+		}
+		logger.trace("Back off context found, backing off");
+		this.pollBackOffPolicy.backOff(backOffContext);
+		logger.trace("Resuming from back off");
 	}
 
 	protected abstract CompletableFuture<Collection<S>> doPollForMessages(int messagesToRequest);
@@ -273,8 +294,28 @@ public abstract class AbstractPollingMessageSource<T, S> extends AbstractMessage
 	}
 
 	private Collection<S> handlePollingException(Throwable t) {
-		logger.error("Error polling for messages in queue {}", this.pollingEndpointName, t);
+		logger.error("Error polling for messages in queue {}.", this.pollingEndpointName, t);
+		if (this.pollBackOffContext.get() == null) {
+			logger.trace("Setting back off policy in queue {}", this.pollingEndpointName);
+			this.pollBackOffContext.set(createBackOffContext());
+		}
 		return Collections.emptyList();
+	}
+
+	private BackOffContext createBackOffContext() {
+		BackOffContext context = this.pollBackOffPolicy.start(null);
+		return context != null ? context : new NoOpsBackOffContext();
+	}
+
+	private static class NoOpsBackOffContext implements BackOffContext {
+	}
+
+	private Collection<S> resetBackOffContext(Collection<S> messages) {
+		if (this.pollBackOffContext.get() != null) {
+			logger.trace("Polling successful, resetting back off context.");
+			this.pollBackOffContext.set(null);
+		}
+		return messages;
 	}
 
 	private <F> CompletableFuture<F> managePollingFuture(CompletableFuture<F> pollingFuture) {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/ContainerOptionsTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/ContainerOptionsTests.java
@@ -28,6 +28,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.retry.backoff.BackOffPolicy;
+import org.springframework.retry.backoff.BackOffPolicyBuilder;
+
 import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 
@@ -97,6 +100,13 @@ class ContainerOptionsTests {
 	}
 
 	@Test
+	void shouldSetPollBackOffPolicyExecutor() {
+		BackOffPolicy pollBackOffPolicy = BackOffPolicyBuilder.newDefaultPolicy();
+		SqsContainerOptions options = SqsContainerOptions.builder().pollBackOffPolicy(pollBackOffPolicy).build();
+		assertThat(options.getPollBackOffPolicy()).isEqualTo(pollBackOffPolicy);
+	}
+
+	@Test
 	void shouldSetQueueNotFoundStrategy() {
 		SqsContainerOptions options = SqsContainerOptions.builder().queueNotFoundStrategy(QueueNotFoundStrategy.FAIL)
 				.build();
@@ -118,6 +128,7 @@ class ContainerOptionsTests {
 	private SqsContainerOptionsBuilder createConfiguredBuilder() {
 		return SqsContainerOptions.builder().acknowledgementShutdownTimeout(Duration.ofSeconds(7))
 				.messageVisibility(Duration.ofSeconds(11))
+				.pollBackOffPolicy(BackOffPolicyBuilder.newBuilder().delay(1000).build())
 				.queueAttributeNames(Collections.singletonList(QueueAttributeName.QUEUE_ARN))
 				.messageSystemAttributeNames(Collections.singletonList(MessageSystemAttributeName.MESSAGE_GROUP_ID))
 				.messageAttributeNames(Collections.singletonList("my-attribute"))


### PR DESCRIPTION
Fixes #714

Adds support for a Spring Retry BackOffPolicy to be executed when an exception is thrown by a polling thread.

Adds the configuration to ContainerOptions with a exponential default of 1000ms / 2.0 / 10000ms.