### PR TITLE
Fix default value for Acknowledgement Shutdown Timeout and Listener Shutdown Timeout in docs

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -821,13 +821,13 @@ See <<Container Lifecycle>>.
 
 |`listenerShutdownTimeout`
 |0 - undefined
-|10 seconds
+|20 seconds
 |The amount of time the container will wait for a queue to complete message processing before attempting to forcefully shutdown.
 See <<Container Lifecycle>>.
 
 |`acknowledgementShutdownTimeout`
 |0 - undefined
-|10 seconds
+|20 seconds
 |The amount of time the container will wait for acknowledgements to complete for a queue after message processing has ended.
 See <<Container Lifecycle>>.
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptionsBuilder.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptionsBuilder.java
@@ -109,7 +109,7 @@ public interface ContainerOptionsBuilder<B extends ContainerOptionsBuilder<B, O>
 
 	/**
 	 * Set the maximum amount of time that the container should wait for tasks to finish before shutting down. Default
-	 * is 10 seconds.
+	 * is 20 seconds.
 	 *
 	 * @param shutdownTimeout the timeout.
 	 * @return this instance.
@@ -117,9 +117,11 @@ public interface ContainerOptionsBuilder<B extends ContainerOptionsBuilder<B, O>
 	B listenerShutdownTimeout(Duration shutdownTimeout);
 
 	/**
-	 * Set the maximum amount of time that the container should wait for batched acknowledgements to finish before *
-	 * shutting down. Note that this timeout starts counting after listener processing is done or timed out. Default *
-	 * is 20 seconds. * @param acknowledgementShutdownTimeout the timeout.
+	 * Set the maximum amount of time that the container should wait for batched acknowledgements to finish before
+	 * shutting down. Note that this timeout starts counting after listener processing is done or timed out. Default is
+	 * 20 seconds.
+	 *
+	 * @param acknowledgementShutdownTimeout the timeout.
 	 * @return this instance.
 	 */
 	B acknowledgementShutdownTimeout(Duration acknowledgementShutdownTimeout);


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
* The default values for `acknowledgementShutdownTimeout` and `listenerShutdownTimeout` are changed from 10 to 20 in the documentation to reflect the values used in the code.
* The value in `listenerShutdownTimeout` Javadoc is changed to reflect the value used in the code.
* The formatting for the `acknowledgementShutdownTimeout` Javadoc comment is changed to align with other comments.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In `AbstractContainerOptions`, the default value for the field `acknowledgementShutdownTimeout` is 20 seconds ([link](https://github.com/awspring/spring-cloud-aws/blob/249172c4729be2a92baaa73c513f5550cfe0d3cd/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractContainerOptions.java#L195)) and for the field `listenerShutdownTimeout` is 20 seconds ([link](https://github.com/awspring/spring-cloud-aws/blob/249172c4729be2a92baaa73c513f5550cfe0d3cd/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractContainerOptions.java#L193)). These values are mentioned in the relevant Javadoc comments in `ContainerOptionsBuilder` [here](https://github.com/awspring/spring-cloud-aws/blob/249172c4729be2a92baaa73c513f5550cfe0d3cd/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptionsBuilder.java#L122) and  [here](https://github.com/awspring/spring-cloud-aws/blob/249172c4729be2a92baaa73c513f5550cfe0d3cd/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptionsBuilder.java#L112). To reflect that in the documentation, these values should be also changed.

## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
