### PR TITLE
Simplify not adding type header in SqsTemplate sent messages (#659)

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -1231,6 +1231,8 @@ public interface MessagingMessageConverter<S> {
 
 The default header-based type mapping can be configured to use a different header name by using the `setPayloadTypeHeader` method.
 
+Also is possible to not send `TypeHeader` by using the `doNotSendTypeHeader` method.
+
 More complex mapping can be achieved by using the `setPayloadTypeMapper` method, which overrides the default header-based mapping.
 This method receives a `Function<Message<?>, Class<?>> payloadTypeMapper` that will be applied to incoming messages.
 
@@ -1248,6 +1250,9 @@ SqsMessagingMessageConverter messageConverter = new SqsMessagingMessageConverter
 
 // Configure Type Header
 messageConverter.setPayloadTypeHeader("myTypeHeader");
+
+// Not send Type Header
+messageConverter.doNotSendTypeHeader();
 
 // Configure Header Mapper
 SqsHeaderMapper headerMapper = new SqsHeaderMapper();

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -1251,7 +1251,7 @@ SqsMessagingMessageConverter messageConverter = new SqsMessagingMessageConverter
 // Configure Type Header
 messageConverter.setPayloadTypeHeader("myTypeHeader");
 
-// Not send Type Header
+// Do not send Type Header
 messageConverter.doNotSendPayloadTypeHeader();
 
 // Configure Header Mapper

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -1231,7 +1231,7 @@ public interface MessagingMessageConverter<S> {
 
 The default header-based type mapping can be configured to use a different header name by using the `setPayloadTypeHeader` method.
 
-Also is possible to not send `TypeHeader` by using the `doNotSendTypeHeader` method.
+It is also possible not include payload type information in the header by using `doNotSendPayloadTypeHeader` method.
 
 More complex mapping can be achieved by using the `setPayloadTypeMapper` method, which overrides the default header-based mapping.
 This method receives a `Function<Message<?>, Class<?>> payloadTypeMapper` that will be applied to incoming messages.
@@ -1252,7 +1252,7 @@ SqsMessagingMessageConverter messageConverter = new SqsMessagingMessageConverter
 messageConverter.setPayloadTypeHeader("myTypeHeader");
 
 // Not send Type Header
-messageConverter.doNotSendTypeHeader();
+messageConverter.doNotSendPayloadTypeHeader();
 
 // Configure Header Mapper
 SqsHeaderMapper headerMapper = new SqsHeaderMapper();

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -1231,7 +1231,7 @@ public interface MessagingMessageConverter<S> {
 
 The default header-based type mapping can be configured to use a different header name by using the `setPayloadTypeHeader` method.
 
-It is also possible not include payload type information in the header by using `doNotSendPayloadTypeHeader` method.
+It is also possible not to include payload type information in the header by using the `doNotSendPayloadTypeHeader` method.
 
 More complex mapping can be achieved by using the `setPayloadTypeMapper` method, which overrides the default header-based mapping.
 This method receives a `Function<Message<?>, Class<?>> payloadTypeMapper` that will be applied to incoming messages.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
@@ -146,9 +146,10 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 	}
 
 	/**
-	 * Configure the converter to not include payload type information in the {@link software.amazon.awssdk.services.sqs.model.Message} headers.
+	 * Configure the converter to not include payload type information in the
+	 * {@link software.amazon.awssdk.services.sqs.model.Message} headers.
 	 */
-	public void doNotSendTypeHeader() {
+	public void doNotSendPayloadTypeHeader() {
 		this.payloadTypeHeaderFunction = message -> null;
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
@@ -146,7 +146,7 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 	}
 
 	/**
-	 * Configure to not send TypeHeader information for {@link software.amazon.awssdk.services.sqs.model.Message} instances.
+	 * Configure the converter to not include payload type information in the {@link software.amazon.awssdk.services.sqs.model.Message} headers.
 	 */
 	public void doNotSendTypeHeader() {
 		this.payloadTypeHeaderFunction = message -> null;

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
@@ -145,6 +145,13 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 		this.headerMapper = headerMapper;
 	}
 
+	/**
+	 * Configure to not send TypeHeader information for {@link software.amazon.awssdk.services.sqs.model.Message} instances.
+	 */
+	public void doNotSendTypeHeader() {
+		this.payloadTypeHeaderFunction = message -> null;
+	}
+
 	protected abstract HeaderMapper<S> createDefaultHeaderMapper();
 
 	@Override

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
@@ -305,7 +305,7 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void shouldSendAndReceiveRecordMessageWithoutPayloadInfoHeader() {
 		SqsTemplate template = SqsTemplate.builder().sqsAsyncClient(this.asyncClient)
-				.configureDefaultConverter(converter -> converter.setPayloadTypeHeaderValueFunction(msg -> null))
+				.configureDefaultConverter(converter -> converter.doNotSendTypeHeader())
 				.build();
 		SampleRecord testRecord = new SampleRecord("Hello world!",
 				"From shouldSendAndReceiveRecordMessageWithoutPayloadInfoHeader!");

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
@@ -32,6 +32,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
+
+import io.awspring.cloud.sqs.support.converter.AbstractMessagingMessageConverter;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -305,7 +307,7 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void shouldSendAndReceiveRecordMessageWithoutPayloadInfoHeader() {
 		SqsTemplate template = SqsTemplate.builder().sqsAsyncClient(this.asyncClient)
-				.configureDefaultConverter(converter -> converter.doNotSendTypeHeader())
+				.configureDefaultConverter(AbstractMessagingMessageConverter::doNotSendPayloadTypeHeader)
 				.build();
 		SampleRecord testRecord = new SampleRecord("Hello world!",
 				"From shouldSendAndReceiveRecordMessageWithoutPayloadInfoHeader!");


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description

- Implemented the method `doNotSendTypeHeader()` in `AbstractMessagingMessageConverter` to simplify the way to not send type information in messages sent with `SqsTemplate`.

## :bulb: Motivation and Context
Issue related: #659 

## :green_heart: How did you test it?
Updated unit test `shouldSendAndReceiveRecordMessageWithoutPayloadInfoHeader` in `SqsTemplateIntegrationTests` with this new implementation instead of old one.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
