### PR TITLE
Add option to set DynamoDb table name suffix

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -29,6 +29,7 @@
 |spring.cloud.aws.dynamodb.endpoint |  | Overrides the default endpoint.
 |spring.cloud.aws.dynamodb.region |  | Overrides the default region.
 |spring.cloud.aws.dynamodb.table-prefix |  | The prefix used to resolve table names.
+|spring.cloud.aws.dynamodb.table-suffix |  | The suffix used to resolve table names.
 |spring.cloud.aws.endpoint |  | Overrides the default endpoint for all auto-configured AWS clients.
 |spring.cloud.aws.fips-enabled |  | Configure whether the SDK should use the AWS fips endpoints.
 |spring.cloud.aws.parameterstore.endpoint |  | Overrides the default endpoint.

--- a/docs/src/main/asciidoc/dynamodb.adoc
+++ b/docs/src/main/asciidoc/dynamodb.adoc
@@ -62,7 +62,7 @@ dynamoDbTemplate.save(person);
 
 ==== Resolving Table Name
 
-To resolve a table name for an entity, `DynamoDbTemplate` uses a bean of type `DynamoDbTableNameResolver`. The default implementation turns an entity class name into its snake case representation with the possibility of using a table name prefix (optional). Specify the `spring.cloud.aws.dynamodb.table-prefix` to provide a table name prefix. The prefix is prepended to the table name. For example, if `spring.cloud.aws.dynamodb.table-prefix` is configured as `foo_` and the entity class is `Person`, then the default implementation resolves the table name as `foo_person`. However if you do not specify `spring.cloud.aws.dynamodb.table-prefix`, the table name will be resolved as `person`.
+To resolve a table name for an entity, `DynamoDbTemplate` uses a bean of type `DynamoDbTableNameResolver`. The default implementation turns an entity class name into its snake case representation with the possibility of using a table name prefix (optional) and suffix (optional). Specify the `spring.cloud.aws.dynamodb.table-prefix` and `spring.cloud.aws.dynamodb.table-suffix` to provide a table name prefix and suffix. The prefix is prepended to the table name and suffix is appended to the table name. For example, if `spring.cloud.aws.dynamodb.table-prefix` is configured as `foo_` and `spring.cloud.aws.dynamodb.table-suffix` is configured as `_foo2` and the entity class is `Person`, then the default implementation resolves the table name as `foo_person_foo2`. You can configure both properties, only one of them or none. However if you do not specify `spring.cloud.aws.dynamodb.table-prefix` and `spring.cloud.aws.dynamodb.table-suffix`, the table name will be resolved as `person`.
 
 To use a custom implementation, declare a bean of type `DynamoDbTableNameResolver` and it will get injected into `DynamoDbTemplate` automatically during auto-configuration.
 
@@ -134,6 +134,7 @@ The Spring Boot Starter for DynamoDb provides the following configuration option
 | `spring.cloud.aws.dynamodb.endpoint` | Configures endpoint used by `DynamoDbClient`. | No |
 | `spring.cloud.aws.dynamodb.region` | Configures region used by `DynamoDbClient`. | No |
 | `spring.cloud.aws.dynamodb.table-prefix` | Table name prefix used by the default `DynamoDbTableNameResolver` implementation. | No |
+| `spring.cloud.aws.dynamodb.table-suffix` | Table name suffix used by the default `DynamoDbTableNameResolver` implementation. | No |
 
 | `spring.cloud.aws.dynamodb.dax.idle-timeout-millis` |Timeout for idle connections with the DAX cluster. | No | `30000`
 | `spring.cloud.aws.dynamodb.dax.url` | DAX cluster endpoint. | Yes |

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfiguration.java
@@ -126,7 +126,7 @@ public class DynamoDbAutoConfiguration {
 	@ConditionalOnMissingBean(DynamoDbTableNameResolver.class)
 	@Bean
 	public DefaultDynamoDbTableNameResolver dynamoDbTableNameResolver(DynamoDbProperties properties) {
-		return new DefaultDynamoDbTableNameResolver(properties.getTablePrefix());
+		return new DefaultDynamoDbTableNameResolver(properties.getTablePrefix(), properties.getTableSuffix());
 	}
 
 	@ConditionalOnMissingBean(DynamoDbOperations.class)

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbProperties.java
@@ -41,6 +41,12 @@ public class DynamoDbProperties extends AwsClientProperties {
 	private String tablePrefix;
 
 	/**
+	 * The suffix used to resolve table names.
+	 */
+	@Nullable
+	private String tableSuffix;
+
+	/**
 	 * Properties that are used to configure {@link software.amazon.dax.ClusterDaxClient}.
 	 */
 	@NestedConfigurationProperty
@@ -50,8 +56,16 @@ public class DynamoDbProperties extends AwsClientProperties {
 		return tablePrefix;
 	}
 
+	public String getTableSuffix() {
+		return tableSuffix;
+	}
+
 	public void setTablePrefix(String tablePrefix) {
 		this.tablePrefix = tablePrefix;
+	}
+
+	public void setTableSuffix(String tableSuffix) {
+		this.tableSuffix = tableSuffix;
 	}
 
 	public DaxProperties getDax() {

--- a/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DefaultDynamoDbTableNameResolver.java
+++ b/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DefaultDynamoDbTableNameResolver.java
@@ -25,6 +25,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Matej Nedic
  * @author Arun Patra
+ * @author Volodymyr Ivakhnenko
  * @since 3.0
  */
 public class DefaultDynamoDbTableNameResolver implements DynamoDbTableNameResolver {
@@ -32,12 +33,20 @@ public class DefaultDynamoDbTableNameResolver implements DynamoDbTableNameResolv
 	@Nullable
 	private final String tablePrefix;
 
+	@Nullable
+	private final String tableSuffix;
+
 	public DefaultDynamoDbTableNameResolver(@Nullable String tablePrefix) {
-		this.tablePrefix = tablePrefix;
+		this(tablePrefix, null);
 	}
 
 	public DefaultDynamoDbTableNameResolver() {
-		this(null);
+		this(null, null);
+	}
+
+	public DefaultDynamoDbTableNameResolver(@Nullable String tablePrefix, @Nullable String tableSuffix) {
+		this.tablePrefix = tablePrefix;
+		this.tableSuffix = tableSuffix;
 	}
 
 	@Override
@@ -45,6 +54,10 @@ public class DefaultDynamoDbTableNameResolver implements DynamoDbTableNameResolv
 		Assert.notNull(clazz, "clazz is required");
 
 		String prefix = StringUtils.hasText(tablePrefix) ? tablePrefix : "";
-		return prefix.concat(clazz.getSimpleName().replaceAll("(.)(\\p{Lu})", "$1_$2").toLowerCase(Locale.ROOT));
+		String suffix = StringUtils.hasText(tableSuffix) ? tableSuffix : "";
+
+		return prefix.concat(clazz.getSimpleName().replaceAll("(.)(\\p{Lu})", "$1_$2").toLowerCase(Locale.ROOT))
+				.concat(suffix);
 	}
+
 }

--- a/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTableNameResolverTest.java
+++ b/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTableNameResolverTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Matej Nedic
  * @author Arun Patra
+ * @author Volodymyr Ivakhnenko
  */
 class DynamoDbTableNameResolverTest {
 
@@ -32,6 +33,9 @@ class DynamoDbTableNameResolverTest {
 
 	private static final DefaultDynamoDbTableNameResolver prefixedTableNameResolver = new DefaultDynamoDbTableNameResolver(
 			"my_prefix_");
+
+	private static final DefaultDynamoDbTableNameResolver prefixedAndSuffixedTableNameResolver = new DefaultDynamoDbTableNameResolver(
+			"my_prefix_", "_my_suffix");
 
 	@Test
 	void resolveTableNameSuccessfully() {
@@ -44,6 +48,13 @@ class DynamoDbTableNameResolverTest {
 		assertThat(prefixedTableNameResolver.resolve(MoreComplexPerson.class))
 				.isEqualTo("my_prefix_more_complex_person");
 		assertThat(prefixedTableNameResolver.resolve(Person.class)).isEqualTo("my_prefix_person");
+	}
+
+	@Test
+	void resolvePrefixedAndSuffixedTableNameSuccessfully() {
+		assertThat(prefixedAndSuffixedTableNameResolver.resolve(MoreComplexPerson.class))
+				.isEqualTo("my_prefix_more_complex_person_my_suffix");
+		assertThat(prefixedAndSuffixedTableNameResolver.resolve(Person.class)).isEqualTo("my_prefix_person_my_suffix");
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Update `DefaultDynamoDbTableNameResolver` to append suffix (if provided in config properties) to the dynamo db table name.

- Add dynamo db property `spring.cloud.aws.dynamodb.table-suffix`
- Add property field, getter, setter in `DynamoDbProperties`
- Add constructor for prefix and suffix in `DefaultDynamoDbTableNameResolver`
- Add suffix or empty string append in `DefaultDynamoDbTableNameResolver` `resolve` method
- Update `DefaultDynamoDbTableNameResolver` bean initialization with both properties in `DynamoDbAutoConfiguration` 
- Docs update


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
[Issue-1073](https://github.com/awspring/spring-cloud-aws/issues/1073)


## :green_heart: How did you test it?
Unit tests added to assert edge cases handled properly.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
