### PR TITLE
Add Integration Test for Consuming One Message at a Time

### DIFF
--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/BaseSqsIntegrationTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/BaseSqsIntegrationTest.java
@@ -44,9 +44,9 @@ abstract class BaseSqsIntegrationTest {
 
 	protected static final boolean useLocalStackClient = true;
 
-	protected static boolean purgeQueues = true;
+	protected static boolean purgeQueues = false;
 
-	protected static boolean waitForPurge = true;
+	protected static boolean waitForPurge = false;
 
 	private static final String LOCAL_STACK_VERSION = "localstack/localstack:2.3.2";
 


### PR DESCRIPTION
Adds an integration test to assert consuming one message at a time for 100 messages works as expected.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring