### PR TITLE
Introduce AnonymousProvider

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProviderAutoConfiguration.java
@@ -37,6 +37,7 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -134,7 +135,8 @@ public class CredentialsProviderAutoConfiguration {
 				AwsRegionProvider regionProvider) {
 			PropertyMapper propertyMapper = PropertyMapper.get();
 			StsWebIdentityTokenFileCredentialsProvider.Builder builder = StsWebIdentityTokenFileCredentialsProvider
-					.builder().stsClient(StsClient.builder().region(regionProvider.getRegion()).build());
+					.builder().stsClient(StsClient.builder().credentialsProvider(AnonymousCredentialsProvider.create())
+							.region(regionProvider.getRegion()).build());
 
 			if (stsProperties != null) {
 				builder.asyncCredentialUpdateEnabled(stsProperties.isAsyncCredentialsUpdate());


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
AnonymousProvider is needed since otherwise StsClient will need a credentials passed from environment. This is not needed when configuring `StsWebIdentityTokenFileCredentialsProvider` since call uses token from a file and role ARN to authenticate.

## :bulb: Motivation and Context


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
