### PR TITLE
Document behavior change when sending / receiving List of messages.

### DIFF
--- a/docs/src/main/asciidoc/migration.adoc
+++ b/docs/src/main/asciidoc/migration.adoc
@@ -79,3 +79,8 @@ spring.config.import=aws-parameterstore:/config/application/;/config/my-service/
 ```
 
 NOTE: The paths specified after the `aws-parameterstore:` scheme are used as-is for resolving parameter names. If you want parameter names to be separated with a slash between the prefix and property name, make sure to add a trailing slash to the prefix.
+
+=== SQS Integration migration
+
+In Spring Cloud AWS 2.x, when a collection of objects was passed as an argument to send or receive payloads, the framework serialized and deserialized the list in a single message.
+In Spring Cloud AWS 3.x, the way to send and receive object collections has changed, see <<sqs-send-message>>.

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -219,6 +219,7 @@ Such attributes are available as `MessageHeaders` in received messages.
 With `ContentBasedDeduplication#AUTO`, the queue attribute value will be resolved automatically.
 |===
 
+[[sqs-send-message]]
 ==== Sending Messages
 
 There are a number of available methods to send messages to SQS queues using the `SqsTemplate`.
@@ -240,6 +241,9 @@ SendResult<T> send(Consumer<SqsSendOptions> to);
 // Send a batch of Messages to the provided queue
 SendResult.Batch<T> sendMany(String queue, Collection<Message<T>> messages);
 ```
+
+NOTE: To send a collection of objects, it is recommended to use `sendMany(String queue, Collection<Message<T>> messages)` to optimize throughput.
+To send a collection of objects in a single message, the collection must be wrapped in an object.
 
 An example using the `options` variant follows:
 
@@ -676,6 +680,8 @@ AcknowledgementMode must be set to `MANUAL` (see <<Acknowledging Messages>>)
 - `QueueAttributes` - provides queue attributes for the queue that received the message.
 See <<Retrieving Attributes from SQS>> for how to specify the queue attributes that will be fetched from `SQS`
 - `software.amazon.awssdk.services.sqs.model.Message` - provides the original `Message` from `SQS`
+
+NOTE: To receive a collection of objects in a single message, the collection must be wrapped in an object. See <<Sending Messages>>.
 
 Here's a sample with many arguments:
 


### PR DESCRIPTION

Add documentation on migration of SQS Integration between Spring Cloud 2.X and Spring Cloud 3.X. In Spring Cloud 3.X there is a behavior change on sending/receiving list of messages

Issue : https://github.com/awspring/spring-cloud-aws/issues/1053

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
