### PR TITLE
Add a way to configure custom `ChannelInterceptor` for SNS integration

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sns/SnsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sns/SnsAutoConfigurationTest.java
@@ -39,6 +39,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.Nullable;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import software.amazon.awssdk.arns.Arn;
@@ -53,6 +54,7 @@ import software.amazon.awssdk.services.sns.SnsClientBuilder;
  * Tests for class {@link io.awspring.cloud.autoconfigure.sns.SnsAutoConfiguration}.
  *
  * @author Matej Nedic
+ * @author Mariusz Sondecki
  */
 class SnsAutoConfigurationTest {
 
@@ -137,6 +139,12 @@ class SnsAutoConfigurationTest {
 		});
 	}
 
+	@Test
+	void customChannelInterceptorCanBeConfigured() {
+		this.contextRunner.withUserConfiguration(CustomChannelInterceptorConfiguration.class)
+				.run(context -> assertThat(context).hasSingleBean(CustomChannelInterceptor.class));
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	static class CustomTopicArnResolverConfiguration {
 
@@ -215,4 +223,15 @@ class SnsAutoConfigurationTest {
 		}
 	}
 
+	@Configuration(proxyBeanMethods = false)
+	static class CustomChannelInterceptorConfiguration {
+
+		@Bean
+		ChannelInterceptor customChannelInterceptor() {
+			return new CustomChannelInterceptor();
+		}
+	}
+
+	static class CustomChannelInterceptor implements ChannelInterceptor {
+	}
 }


### PR DESCRIPTION
…onfiguration

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Added support for registration of custom ChannelInterceptor classes with configuration and registration of SnsTemplate in SNS autoconfiguration.
Closes https://github.com/awspring/spring-cloud-aws/issues/565


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
