### PR TITLE
Fix Issue #880: Display Profile Name and Path in Configuration Setup

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProperties.java
@@ -53,6 +53,7 @@ public class CredentialsProperties {
 	/**
 	 * The AWS profile.
 	 */
+	@NestedConfigurationProperty
 	@Nullable
 	private Profile profile;
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/RegionProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/RegionProperties.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.autoconfigure.core;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
@@ -50,6 +51,7 @@ public class RegionProperties {
 	/**
 	 * The AWS profile.
 	 */
+	@NestedConfigurationProperty
 	@Nullable
 	private Profile profile;
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This pull request addresses issue #880 by implementing a solution that adds the `@NestedConfigurationProperty` annotation. This change ensures that the profile name and path are correctly displayed when configuring application properties in both .properties and .yaml files. The code has been tested and verified to resolve the reported issue effectively. Please review and merge as appropriate. Thank you!


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes
