### PR TITLE
Auto-configure `SecretsManagerClient` even if config import is not used.

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerAutoConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.autoconfigure.config.secretsmanager;
 
 import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
@@ -25,18 +40,18 @@ import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilde
  */
 @AutoConfiguration
 @EnableConfigurationProperties(SecretsManagerProperties.class)
-@ConditionalOnClass({SecretsManagerClient.class})
-@AutoConfigureAfter({CredentialsProviderAutoConfiguration.class, RegionProviderAutoConfiguration.class})
+@ConditionalOnClass({ SecretsManagerClient.class })
+@AutoConfigureAfter({ CredentialsProviderAutoConfiguration.class, RegionProviderAutoConfiguration.class })
 @ConditionalOnProperty(name = "spring.cloud.aws.secretsmanager.enabled", havingValue = "true", matchIfMissing = true)
 public class SecretsManagerAutoConfiguration {
 
 	@ConditionalOnMissingBean
 	@Bean
 	public SecretsManagerClient secretsManagerClient(SecretsManagerProperties properties,
-													 AwsClientBuilderConfigurer awsClientBuilderConfigurer,
-													 ObjectProvider<AwsClientCustomizer<SecretsManagerClientBuilder>> customizer,
-													 ObjectProvider<AwsConnectionDetails> connectionDetails) {
-		return awsClientBuilderConfigurer.configure(SecretsManagerClient.builder(), properties, connectionDetails.getIfAvailable(),
-			customizer.getIfAvailable()).build();
+			AwsClientBuilderConfigurer awsClientBuilderConfigurer,
+			ObjectProvider<AwsClientCustomizer<SecretsManagerClientBuilder>> customizer,
+			ObjectProvider<AwsConnectionDetails> connectionDetails) {
+		return awsClientBuilderConfigurer.configure(SecretsManagerClient.builder(), properties,
+				connectionDetails.getIfAvailable(), customizer.getIfAvailable()).build();
 	}
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerAutoConfiguration.java
@@ -1,0 +1,42 @@
+package io.awspring.cloud.autoconfigure.config.secretsmanager;
+
+import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
+import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
+import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;
+import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
+
+/**
+ * {@link EnableAutoConfiguration Auto-Configuration} for Secrets Manager integration.
+ *
+ * @author Maciej Walkowiak
+ * @since 3.2.0
+ */
+@AutoConfiguration
+@EnableConfigurationProperties(SecretsManagerProperties.class)
+@ConditionalOnClass({SecretsManagerClient.class})
+@AutoConfigureAfter({CredentialsProviderAutoConfiguration.class, RegionProviderAutoConfiguration.class})
+@ConditionalOnProperty(name = "spring.cloud.aws.secretsmanager.enabled", havingValue = "true", matchIfMissing = true)
+public class SecretsManagerAutoConfiguration {
+
+	@ConditionalOnMissingBean
+	@Bean
+	public SecretsManagerClient secretsManagerClient(SecretsManagerProperties properties,
+													 AwsClientBuilderConfigurer awsClientBuilderConfigurer,
+													 ObjectProvider<AwsClientCustomizer<SecretsManagerClientBuilder>> customizer,
+													 ObjectProvider<AwsConnectionDetails> connectionDetails) {
+		return awsClientBuilderConfigurer.configure(SecretsManagerClient.builder(), properties, connectionDetails.getIfAvailable(),
+			customizer.getIfAvailable()).build();
+	}
+}

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -10,4 +10,5 @@ io.awspring.cloud.autoconfigure.sns.SnsAutoConfiguration
 io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration
 io.awspring.cloud.autoconfigure.dynamodb.DynamoDbAutoConfiguration
 io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerReloadAutoConfiguration
+io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerAutoConfiguration
 io.awspring.cloud.autoconfigure.config.parameterstore.ParameterStoreReloadAutoConfiguration

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerAutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerAutoConfigurationTests.java
@@ -1,4 +1,22 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.autoconfigure.config.secretsmanager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
@@ -11,42 +29,42 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-
+/**
+ * Tests for {@link SecretsManagerAutoConfiguration}.
+ *
+ * @author Maciej Walkowiak
+ */
 class SecretsManagerAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-		.withPropertyValues("spring.cloud.aws.region.static:eu-west-1")
-		.withConfiguration(AutoConfigurations.of(RegionProviderAutoConfiguration.class,
-			CredentialsProviderAutoConfiguration.class, SecretsManagerAutoConfiguration.class,
-			AwsAutoConfiguration.class));
+			.withPropertyValues("spring.cloud.aws.region.static:eu-west-1")
+			.withConfiguration(AutoConfigurations.of(RegionProviderAutoConfiguration.class,
+					CredentialsProviderAutoConfiguration.class, SecretsManagerAutoConfiguration.class,
+					AwsAutoConfiguration.class));
 
 	@Test
 	void secretsManagerAutoConfigurationIsDisabled() {
 		this.contextRunner.withPropertyValues("spring.cloud.aws.secretsmanager.enabled:false")
-			.run(context -> assertThat(context).doesNotHaveBean(SecretsManagerClient.class));
+				.run(context -> assertThat(context).doesNotHaveBean(SecretsManagerClient.class));
 	}
 
 	@Test
 	void secretsManagerAutoConfigurationIsEnabled() {
 		this.contextRunner.withPropertyValues("spring.cloud.aws.secretsmanager.enabled:true")
-			.run(context -> assertThat(context).hasSingleBean(SecretsManagerClient.class));
+				.run(context -> assertThat(context).hasSingleBean(SecretsManagerClient.class));
 	}
 
 	@Test
 	void createsClientBeanByDefault() {
-		this.contextRunner
-			.run(context -> assertThat(context).hasSingleBean(SecretsManagerClient.class));
+		this.contextRunner.run(context -> assertThat(context).hasSingleBean(SecretsManagerClient.class));
 	}
 
 	@Test
 	void usesCustomBeanWhenProvided() {
-		this.contextRunner.withUserConfiguration(CustomConfiguration.class)
-			.run(context -> {
-				assertThat(context).hasSingleBean(SecretsManagerClient.class);
-				assertThat(MockUtil.isMock(context.getBean(SecretsManagerClient.class))).isTrue();
-			});
+		this.contextRunner.withUserConfiguration(CustomConfiguration.class).run(context -> {
+			assertThat(context).hasSingleBean(SecretsManagerClient.class);
+			assertThat(MockUtil.isMock(context.getBean(SecretsManagerClient.class))).isTrue();
+		});
 	}
 
 	@TestConfiguration

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerAutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerAutoConfigurationTests.java
@@ -1,0 +1,61 @@
+package io.awspring.cloud.autoconfigure.config.secretsmanager;
+
+import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.mockito.internal.util.MockUtil;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class SecretsManagerAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withPropertyValues("spring.cloud.aws.region.static:eu-west-1")
+		.withConfiguration(AutoConfigurations.of(RegionProviderAutoConfiguration.class,
+			CredentialsProviderAutoConfiguration.class, SecretsManagerAutoConfiguration.class,
+			AwsAutoConfiguration.class));
+
+	@Test
+	void secretsManagerAutoConfigurationIsDisabled() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.secretsmanager.enabled:false")
+			.run(context -> assertThat(context).doesNotHaveBean(SecretsManagerClient.class));
+	}
+
+	@Test
+	void secretsManagerAutoConfigurationIsEnabled() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.secretsmanager.enabled:true")
+			.run(context -> assertThat(context).hasSingleBean(SecretsManagerClient.class));
+	}
+
+	@Test
+	void createsClientBeanByDefault() {
+		this.contextRunner
+			.run(context -> assertThat(context).hasSingleBean(SecretsManagerClient.class));
+	}
+
+	@Test
+	void usesCustomBeanWhenProvided() {
+		this.contextRunner.withUserConfiguration(CustomConfiguration.class)
+			.run(context -> {
+				assertThat(context).hasSingleBean(SecretsManagerClient.class);
+				assertThat(MockUtil.isMock(context.getBean(SecretsManagerClient.class))).isTrue();
+			});
+	}
+
+	@TestConfiguration
+	static class CustomConfiguration {
+
+		@Bean
+		SecretsManagerClient secretsManagerClient() {
+			return mock();
+		}
+
+	}
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
@@ -99,10 +99,12 @@ class SecretsManagerConfigDataLoaderIntegrationTests {
 		SpringApplication application = new SpringApplication(App.class);
 		application.setWebApplicationType(WebApplicationType.NONE);
 
-		try (ConfigurableApplicationContext context = application.run("--spring.cloud.aws.secretsmanager.region=" + REGION,
-			"--spring.cloud.aws.secretsmanager.endpoint=" + localstack.getEndpoint(),
-			"--spring.cloud.aws.credentials.access-key=noop", "--spring.cloud.aws.credentials.secret-key=noop",
-			"--spring.cloud.aws.region.static=eu-west-1", "--logging.level.io.awspring.cloud.secretsmanager=debug")) {
+		try (ConfigurableApplicationContext context = application.run(
+				"--spring.cloud.aws.secretsmanager.region=" + REGION,
+				"--spring.cloud.aws.secretsmanager.endpoint=" + localstack.getEndpoint(),
+				"--spring.cloud.aws.credentials.access-key=noop", "--spring.cloud.aws.credentials.secret-key=noop",
+				"--spring.cloud.aws.region.static=eu-west-1",
+				"--logging.level.io.awspring.cloud.secretsmanager=debug")) {
 
 		}
 	}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLoaderIntegrationTests.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.BootstrapRegistry;
 import org.springframework.boot.BootstrapRegistryInitializer;
 import org.springframework.boot.SpringApplication;
@@ -45,7 +44,6 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.Bean;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -99,13 +97,12 @@ class SecretsManagerConfigDataLoaderIntegrationTests {
 		SpringApplication application = new SpringApplication(App.class);
 		application.setWebApplicationType(WebApplicationType.NONE);
 
-		try (ConfigurableApplicationContext context = application.run(
-				"--spring.cloud.aws.secretsmanager.region=" + REGION,
-				"--spring.cloud.aws.secretsmanager.endpoint=" + localstack.getEndpoint(),
-				"--spring.cloud.aws.credentials.access-key=noop", "--spring.cloud.aws.credentials.secret-key=noop",
-				"--spring.cloud.aws.region.static=eu-west-1",
-				"--logging.level.io.awspring.cloud.secretsmanager=debug")) {
-
+		try (ConfigurableApplicationContext context = runApplication(application,
+				"aws-secretsmanager:/config/spring;/config/second")) {
+			assertThat(context.getEnvironment().getProperty("message")).isEqualTo("value from tests");
+			assertThat(context.getEnvironment().getProperty("another-parameter")).isEqualTo("another parameter value");
+			assertThat(context.getEnvironment().getProperty("secondMessage")).isEqualTo("second value from tests");
+			assertThat(context.getEnvironment().getProperty("non-existing-parameter")).isNull();
 		}
 	}
 
@@ -481,15 +478,6 @@ class SecretsManagerConfigDataLoaderIntegrationTests {
 	@SpringBootConfiguration
 	@EnableAutoConfiguration
 	static class App {
-
-		@Bean
-		ApplicationRunner applicationRunner(SecretsManagerClient client) {
-			return args -> {
-				System.out.println(client.listSecrets().secretList());
-				System.out.println("FOOO!");
-			};
-		}
-
 	}
 
 	static class AwsConfigurerClientConfiguration implements BootstrapRegistryInitializer {

--- a/spring-cloud-aws-samples/spring-cloud-aws-secrets-manager-sample/src/main/resources/application.yml
+++ b/spring-cloud-aws-samples/spring-cloud-aws-secrets-manager-sample/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 # importing single secret
-spring.config.import: aws-secretsmanager:/secrets/spring-cloud-aws-sample-app
-logging.level.io.awspring.cloud.secretsmanager: debug
+#spring.config.import: aws-secretsmanager:/secrets/spring-cloud-aws-sample-app
+logging.level:
+  io.awspring.cloud.secretsmanager: debug
 
 # LocalStack configuration
 spring.cloud.aws.endpoint: http://localhost:4566


### PR DESCRIPTION
Fixes #1016
