### PR TITLE
Enhance RegionProviderAutoConfiguration when trying to load RegionPro…

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/core/RegionProviderAutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/core/RegionProviderAutoConfigurationTests.java
@@ -85,6 +85,38 @@ class RegionProviderAutoConfigurationTests {
 	}
 
 	@Test
+	void regionProvider_credentialProfileNameAndPathConfigured_profileRegionProviderConfiguredWithCustomProfile()
+			throws IOException {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.credentials.profile.name:customProfile",
+				"spring.cloud.aws.credentials.profile.path:"
+						+ new ClassPathResource(getClass().getSimpleName() + "-profile", getClass()).getFile()
+								.getAbsolutePath())
+				.run((context) -> {
+					AwsRegionProvider awsRegionProvider = context.getBean("regionProvider",
+							AwsProfileRegionProvider.class);
+					assertThat(awsRegionProvider).isNotNull();
+					assertThat(awsRegionProvider.getRegion()).isEqualTo(Region.EU_WEST_1);
+				});
+	}
+
+	@Test
+	void regionProvider_credentialAndRegionProfileNameAndPathBothConfigured_profileRegionProviderConfiguredWithCustomProfile()
+			throws IOException {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.credentials.profile.name:noneProfile",
+				"spring.cloud.aws.credentials.profile.path:",
+				"spring.cloud.aws.region.profile.name:customProfile",
+				"spring.cloud.aws.region.profile.path:"
+						+ new ClassPathResource(getClass().getSimpleName() + "-profile", getClass()).getFile()
+								.getAbsolutePath())
+				.run((context) -> {
+					AwsRegionProvider awsRegionProvider = context.getBean("regionProvider",
+							AwsProfileRegionProvider.class);
+					assertThat(awsRegionProvider).isNotNull();
+					assertThat(awsRegionProvider.getRegion()).isEqualTo(Region.EU_WEST_1);
+				});
+	}
+
+	@Test
 	void regionProvider_instanceProfileConfigured_configuresInstanceProfileCredentialsProvider() {
 		this.contextRunner.withPropertyValues("spring.cloud.aws.region.instance-profile:true").run((context) -> {
 			AwsRegionProvider awsCredentialsProvider = context.getBean("regionProvider",


### PR DESCRIPTION
…file properties that don't exist; it will load CredentialsProperties instead.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
