### PR TITLE
Add SQS QueueNotFoundStrategy auto-configure support.

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -76,6 +76,7 @@
 |spring.cloud.aws.sqs.listener.max-concurrent-messages |  | The maximum concurrent messages that can be processed simultaneously for each queue. Note that if acknowledgement batching is being used, the actual maximum number of messages inflight might be higher.
 |spring.cloud.aws.sqs.listener.max-messages-per-poll |  | The maximum number of messages to be retrieved in a single poll to SQS.
 |spring.cloud.aws.sqs.listener.poll-timeout |  | The maximum amount of time for a poll to SQS.
+|spring.cloud.aws.sqs.options.queue-not-found-strategy | `+++CREATE+++` | Configures strategy when queue not found.
 |spring.cloud.aws.sqs.region |  | Overrides the default region.
 
 |===

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -29,6 +29,7 @@ import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
 import io.awspring.cloud.sqs.listener.errorhandler.ErrorHandler;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor;
+import io.awspring.cloud.sqs.listener.SqsContainerOptionsBuilder;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import io.awspring.cloud.sqs.operations.SqsTemplateBuilder;
 import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
@@ -51,6 +52,7 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClientBuilder;
  *
  * @author Tomaz Fernandes
  * @author Maciej Walkowiak
+ * @author Wei Jiang
  * @since 3.0
  */
 @AutoConfiguration
@@ -82,6 +84,9 @@ public class SqsAutoConfiguration {
 		SqsTemplateBuilder builder = SqsTemplate.builder().sqsAsyncClient(sqsAsyncClient);
 		objectMapperProvider
 				.ifAvailable(om -> builder.configureDefaultConverter(converter -> converter.setObjectMapper(om)));
+		builder.configure((options) -> {
+			options.queueNotFoundStrategy(sqsProperties.getOptions().getQueueNotFoundStrategy());
+		});
 		return builder.build();
 	}
 
@@ -113,6 +118,9 @@ public class SqsAutoConfiguration {
 	}
 
 	private void configureContainerOptions(ContainerOptionsBuilder<?, ?> options) {
+		SqsContainerOptionsBuilder sqsContainerOptions = (SqsContainerOptionsBuilder) options;
+		sqsContainerOptions.queueNotFoundStrategy(sqsProperties.getOptions().getQueueNotFoundStrategy());
+
 		PropertyMapper mapper = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		mapper.from(this.sqsProperties.getListener().getMaxConcurrentMessages()).to(options::maxConcurrentMessages);
 		mapper.from(this.sqsProperties.getListener().getMaxMessagesPerPoll()).to(options::maxMessagesPerPoll);

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
@@ -16,6 +16,8 @@
 package io.awspring.cloud.autoconfigure.sqs;
 
 import io.awspring.cloud.autoconfigure.AwsClientProperties;
+import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
+
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.lang.Nullable;
@@ -24,6 +26,7 @@ import org.springframework.lang.Nullable;
  * Properties related to AWS SQS.
  *
  * @author Tomaz Fernandes
+ * @author Wei Jiang
  * @since 3.0
  */
 @ConfigurationProperties(prefix = SqsProperties.PREFIX)
@@ -36,12 +39,22 @@ public class SqsProperties extends AwsClientProperties {
 
 	private Listener listener = new Listener();
 
+	private Options options = new Options();
+
 	public Listener getListener() {
 		return this.listener;
 	}
 
 	public void setListener(Listener listener) {
 		this.listener = listener;
+	}
+
+	public Options getOptions() {
+		return this.options;
+	}
+
+	public void setOptions(Options options) {
+		this.options = options;
 	}
 
 	public static class Listener {
@@ -91,6 +104,23 @@ public class SqsProperties extends AwsClientProperties {
 		public void setPollTimeout(Duration pollTimeout) {
 			this.pollTimeout = pollTimeout;
 		}
+	}
+
+	public static class Options {
+
+		/**
+		 * The default {@link QueueNotFoundStrategy}
+		 */
+		private QueueNotFoundStrategy queueNotFoundStrategy = QueueNotFoundStrategy.CREATE;
+
+		public QueueNotFoundStrategy getQueueNotFoundStrategy() {
+			return queueNotFoundStrategy;
+		}
+
+		public void setQueueNotFoundStrategy(QueueNotFoundStrategy queueNotFoundStrategy) {
+			this.queueNotFoundStrategy = queueNotFoundStrategy;
+		}
+
 	}
 
 }

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
@@ -32,6 +32,7 @@ import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration;
 import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
 import io.awspring.cloud.sqs.listener.ContainerOptions;
 import io.awspring.cloud.sqs.listener.ContainerOptionsBuilder;
+import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
 import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
@@ -60,6 +61,7 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClientBuilder;
  * Tests for {@link SqsAutoConfiguration}.
  *
  * @author Tomaz Fernandes
+ * @author Wei Jiang
  */
 class SqsAutoConfigurationTest {
 
@@ -107,6 +109,18 @@ class SqsAutoConfigurationTest {
 			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(SqsAsyncClient.class));
 			assertThat(client.getEndpoint()).isEqualTo(URI.create("http://localhost:8090"));
 			assertThat(client.isEndpointOverridden()).isTrue();
+		});
+	}
+
+	@Test
+	void withCustomQueueNotFoundStrategy() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.options.queue-not-found-strategy:fail").run(context -> {
+			assertThat(context).hasSingleBean(SqsProperties.class);
+			SqsProperties sqsProperties = context.getBean(SqsProperties.class);
+			assertThat(context).hasSingleBean(SqsAsyncClient.class);
+			assertThat(context).hasSingleBean(SqsTemplate.class);
+			assertThat(context).hasSingleBean(SqsMessageListenerContainerFactory.class);
+			assertThat(sqsProperties.getOptions().getQueueNotFoundStrategy()).isEqualTo(QueueNotFoundStrategy.FAIL);
 		});
 	}
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
By default, when using SQS, even if a queue doesn't exist or is mispelled, it will automatically create a new queue, and there are no autoconfiguration options supported for this feature. So add a new auto-configure option to control the behavior of this.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
