### PR TITLE
Autoconfigure when using PodIdentity on EKS relate #984

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -11,6 +11,8 @@
 |spring.cloud.aws.credentials.sts.role-arn |  | ARN of IAM role associated with STS. If not provided this will be read from {@link software.amazon.awssdk.core.SdkSystemSetting}.
 |spring.cloud.aws.credentials.sts.role-session-name |  | Role session name that will be used by credentials provider. By default this is read from {@link software.amazon.awssdk.core.SdkSystemSetting}.
 |spring.cloud.aws.credentials.sts.web-identity-token-file |  | Absolute path to the web identity token file that will be used by credentials provider. By default this will be read from {@link software.amazon.awssdk.core.SdkSystemSetting}.
+|spring.cloud.aws.credentials.podIdentity.container-credentials-full-uri |  | Full URI to be used by credentials provider. By default this will be read from {@link software.amazon.awssdk.core.SdkSystemSetting}.
+|spring.cloud.aws.credentials.podIdentity.async-credentials-update | `+++false+++` | Enables provider to asynchronously fetch credentials in the background. Defaults to synchronous blocking if not specified otherwise.
 |spring.cloud.aws.defaults-mode |  | Sets the {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK. <a href= "https://aws.amazon.com/blogs/developer/introducing-smart-configuration-defaults-in-the-aws-sdk-for-java-v2/">Introducing Smart Configuration Defaults in the AWS SDK for Java v2</a>
 |spring.cloud.aws.dualstack-enabled |  | Configure whether the SDK should use the AWS dualstack endpoint.
 |spring.cloud.aws.dynamodb.dax.cluster-update-interval-millis |  | Interval between polling of cluster members for membership changes.

--- a/docs/src/main/asciidoc/core.adoc
+++ b/docs/src/main/asciidoc/core.adoc
@@ -26,11 +26,12 @@ public interface AwsCredentialsProvider {
 }
 ----
 
-There are 3 ways in which the `AwsCredentialsProvider` in Spring Cloud AWS can be configured:
+There are 4 ways in which the `AwsCredentialsProvider` in Spring Cloud AWS can be configured:
 
 1. `DefaultCredentialsProvider`
 2. `StsWebIdentityTokenFileCredentialsProvider` - recommended for EKS
-3. Custom `AwsCredentialsProvider`
+3. 'ContainerCredentialsProvider' - recommended for EKS
+4. Custom `AwsCredentialsProvider`
 
 If you are having problems with configuring credentials, consider enabling debug logging for more info:
 
@@ -111,6 +112,39 @@ STS credentials configuration supports following properties:
 | `spring.cloud.aws.credentials.sts.web-identity-token-file` | Absolute path to the web identity token file that will be used by credentials provider. | No | `null` (falls back to SDK default)
 | `spring.cloud.aws.credentials.sts.async-credentials-update` | Enables provider to asynchronously fetch credentials in the background. | No | `false`
 | `spring.cloud.aws.credentials.sts.role-session-name` | Role session name that will be used by credentials provider. | No | `null` (falls back to SDK default)
+|===
+
+==== ContainerCredentialsProvider
+
+The `ContainerCredentialsProvider` allows your application to assume an AWS IAM Role using a container authorization token file and installed Pod Identity Agent, which is especially useful in Kubernetes and AWS EKS environments.
+
+===== Prerequisites
+1. Create Amazon EKS Pod Identity Agent into Target EKS Cluster.
+2. Create a role that you want to assume.
+3. Create a container authorization token file for your application.
+
+In EKS, please follow this guide to set up service accounts https://docs.aws.amazon.com/eks/latest/userguide/pod-id-configure-pods.html
+
+The `ContainerCredentialsProvider` support is optional, so you need to include the following Maven dependency:
+[source,xml,indent=0]
+----
+<dependency>
+	<groupId>software.amazon.awssdk</groupId>
+	<artifactId>sts</artifactId>
+</dependency>
+----
+
+
+===== Configuring
+In EKS no additional configuration is required as the service account already configures the correct environment variables; however, they can be overridden.
+
+STS credentials configuration supports following properties:
+
+[cols="2,3,1,1"]
+|===
+| Name | Description | Required | Default value
+| `spring.cloud.aws.credentials.podIdentity.container-credentials-full-uri` | Full URI to be used by credentials provider. | No | `null` (falls back to SDK default)
+| `spring.cloud.aws.credentials.podIdentity.async-credentials-update` | Enables provider to asynchronously fetch credentials in the background. | No | `false`
 |===
 
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProperties.java
@@ -23,6 +23,7 @@ import org.springframework.lang.Nullable;
  * Properties related to AWS credentials.
  *
  * @author Tom Gianos
+ * @author YoungJin Jung
  * @since 2.0.2
  */
 @ConfigurationProperties(prefix = CredentialsProperties.PREFIX)
@@ -64,6 +65,10 @@ public class CredentialsProperties {
 	@NestedConfigurationProperty
 	@Nullable
 	private StsProperties sts;
+
+	@NestedConfigurationProperty
+	@Nullable
+	private PodIdentityProperties podIdentity;
 
 	@Nullable
 	public String getAccessKey() {
@@ -107,5 +112,12 @@ public class CredentialsProperties {
 
 	public void setSts(@Nullable StsProperties sts) {
 		this.sts = sts;
+	}
+
+	@Nullable
+	public PodIdentityProperties getPodIdentity() { return podIdentity; }
+
+	public void setPodIdentity(@Nullable PodIdentityProperties podIdentity) {
+		this.podIdentity = podIdentity;
 	}
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/PodIdentityProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/PodIdentityProperties.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.core;
+
+import org.springframework.lang.Nullable;
+/**
+ * Properties related to AWS Container Credentials for PodIdentity. The properties are not configured, it will default to the EKS values
+ * from: <a href="https://docs.aws.amazon.com/eks/latest/userguide/pod-id-configure-pods.html">
+ *
+ * @author YoungJin Jung
+ */
+public class PodIdentityProperties {
+	/**
+	 * The full URI path to a localhost metadata service that will be used by credentials provider. By default, this will be
+	 * read from {@link software.amazon.awssdk.core.SdkSystemSetting}.
+	 */
+	@Nullable
+	private String containerCredentialsFullUri;
+	/**
+	 * Enables provider to asynchronously fetch credentials in the background. Defaults to synchronous blocking if not
+	 * specified otherwise.
+	 */
+	private boolean asyncCredentialsUpdate = false;
+
+	@Nullable
+	public String getContainerCredentialsFullUri() {
+		return containerCredentialsFullUri;
+	}
+
+	public void setContainerCredentialsFullUri(@Nullable String containerCredentialsFullUri) {
+		this.containerCredentialsFullUri = containerCredentialsFullUri;
+	}
+
+	public boolean isAsyncCredentialsUpdate() {
+		return asyncCredentialsUpdate;
+	}
+
+	public void setAsyncCredentialsUpdate(boolean asyncCredentialsUpdate) {
+		this.asyncCredentialsUpdate = asyncCredentialsUpdate;
+	}
+}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/StsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/StsProperties.java
@@ -34,7 +34,7 @@ public class StsProperties {
 	private String roleArn;
 
 	/**
-	 * Absolute path to the web identity token file that will be used by credentials provider. By default this will be
+	 * Absolute path to the web identity token file that will be used by credentials provider. By default, this will be
 	 * read from {@link software.amazon.awssdk.core.SdkSystemSetting}.
 	 */
 	@Nullable
@@ -47,7 +47,7 @@ public class StsProperties {
 	private boolean asyncCredentialsUpdate = false;
 
 	/**
-	 * Role session name that will be used by credentials provider. By default this is read from
+	 * Role session name that will be used by credentials provider. By default, this is read from
 	 * {@link software.amazon.awssdk.core.SdkSystemSetting}.
 	 */
 	@Nullable


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
### Problem: 
When starting Spring Application using PodIdentity on EKS, startup failed because `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` and `AWS_CONTAINER_CREDENTIALS_FULL_URI` set to use PodIdentity could not be read.

### Solution
If the value is set using ContainerCredentialsProvider, a Provider has been added so that PodIdentity can be used.

### Related issue: 
https://github.com/awspring/spring-cloud-aws/issues/984

### Reference: 
https://github.com/aws/aws-sdk-java-v2/blob/master/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
https://docs.aws.amazon.com/ko_kr/eks/latest/userguide/pod-id-how-it-works.html

## :green_heart: How did you test it?
I executed the following tests:
- Ran unit test cases and made sure nothing failed.
- Still need to Tests.
We'd love to hear some initial feedback from the team on whether this is a good feature to add.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
