### PR TITLE
Fix minor typo in `DynamoDbOperations` interface

### DIFF
--- a/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DynamoDbOperations.java
+++ b/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DynamoDbOperations.java
@@ -38,7 +38,7 @@ public interface DynamoDbOperations {
 	<T> T save(T entity);
 
 	/**
-	 * Updated Entity to DynamoDB table.
+	 * Updates Entity to DynamoDB table.
 	 *
 	 * @param entity - Entity to be saved.
 	 * @param <T> Type of Entity object.


### PR DESCRIPTION
The documentation of other methods (`save`, `delete`, etc.) uses the present tense, so there could've been a typo with the documentation of `update`

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fixes a minor typo of the documentation of `io.awspring.cloud.dynamodb.DynamoDbOperations::update` from "updated" to"updates", because other methods, defined in the interface, use this form.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It's just a documentation fix.

## :green_heart: How did you test it?

I did not run any tests / doc build

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Please, let me know if anything else is required