### PR TITLE
Add BatchVisibility listener method parameter (#832)

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -677,6 +677,7 @@ AcknowledgementMode must be set to `MANUAL` (see <<Acknowledging Messages>>)
 - `BatchAcknowledgement` - provides methods for manually acknowledging partial or whole message batches for batch listeners.
 AcknowledgementMode must be set to `MANUAL` (see <<Acknowledging Messages>>)
 - `Visibility` - provides the `changeTo()` method that enables changing the message's visibility to the provided value.
+- `BatchVisibility` - provides `changeTo()` methods that enables changing partial or whole message batches visibility to the provided value.
 - `QueueAttributes` - provides queue attributes for the queue that received the message.
 See <<Retrieving Attributes from SQS>> for how to specify the queue attributes that will be fetched from `SQS`
 - `software.amazon.awssdk.services.sqs.model.Message` - provides the original `Message` from `SQS`
@@ -699,7 +700,7 @@ public void listen(Message<MyPojo> message, MyPojo pojo, MessageHeaders headers,
 }
 ----
 
-IMPORTANT: Batch listeners support a single `List<MyPojo>` and `List<Message<MyPojo>>` method arguments, and an optional `BatchAcknowledgement` or `AsyncBatchAcknowledgement` arguments.
+IMPORTANT: Batch listeners support a single `List<MyPojo>` and `List<Message<MyPojo>>` method arguments, and optional `BatchAcknowledgement` (or `AsyncBatchAcknowledgement`) and `BatchVisibility` arguments.
 `MessageHeaders` should be extracted from the `Message` instances through the `getHeaders()` method.
 
 ==== Batch Processing
@@ -711,7 +712,9 @@ When batch mode is enabled, the framework will serve the entire result of a poll
 If a value greater than 10 is provided for `maxMessagesPerPoll`, the result of multiple polls will be combined and up to the respective amount of messages will be served to the listener.
 
 To enable batch processing using `@SqsListener`, a single `List<MyPojo>` or `List<Message<MyPojo>>` method argument should be provided in the listener method.
-The listener method can also have an optional `BatchAcknowledgement` argument for `AcknowledgementMode.MANUAL`.
+The listener method can also have:
+- an optional `BatchAcknowledgement` argument for `AcknowledgementMode.MANUAL`
+- an optional `BatchVisibility` argument
 
 Alternatively, `SqsContainerOptions` can be set to `ListenerMode.BATCH` in the `SqsContainerOptions` in the factory or container.
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/CollectionUtils.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/CollectionUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class CollectionUtils {
+
+	public static <T> List<Collection<T>> partition(Collection<T> messagesToAck, int pageSize) {
+		List<T> messagesToUse = getAsList(messagesToAck);
+		int totalSize = messagesToUse.size();
+		return IntStream.rangeClosed(0, (totalSize - 1) / pageSize)
+				.mapToObj(index -> messagesToUse.subList(index * pageSize, Math.min((index + 1) * pageSize, totalSize)))
+				.collect(Collectors.toList());
+	}
+
+	private static <T> List<T> getAsList(Collection<T> elements) {
+		return elements instanceof List ? (List<T>) elements : new ArrayList<>(elements);
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListener.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListener.java
@@ -124,9 +124,8 @@ public @interface SqsListener {
 	String pollTimeoutSeconds() default "";
 
 	/**
-	 * The maximum number of messages to poll from SQS. If a value greater than 10 is provided, the result of
-	 * multiple polls will be combined, which can be useful for
-	 * {@link io.awspring.cloud.sqs.listener.ListenerMode#BATCH}
+	 * The maximum number of messages to poll from SQS. If a value greater than 10 is provided, the result of multiple
+	 * polls will be combined, which can be useful for {@link io.awspring.cloud.sqs.listener.ListenerMode#BATCH}
 	 * @return the maximum messages per poll.
 	 */
 	String maxMessagesPerPoll() default "";

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
@@ -19,11 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.sqs.config.Endpoint;
 import io.awspring.cloud.sqs.config.SqsBeanNames;
 import io.awspring.cloud.sqs.config.SqsEndpoint;
-import io.awspring.cloud.sqs.listener.SqsHeaders;
-import io.awspring.cloud.sqs.support.resolver.NotificationMessageArgumentResolver;
-import io.awspring.cloud.sqs.support.resolver.QueueAttributesMethodArgumentResolver;
-import io.awspring.cloud.sqs.support.resolver.SqsMessageMethodArgumentResolver;
-import io.awspring.cloud.sqs.support.resolver.VisibilityHandlerMethodArgumentResolver;
+import io.awspring.cloud.sqs.support.resolver.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -72,8 +68,9 @@ public class SqsListenerAnnotationBeanPostProcessor extends AbstractListenerAnno
 
 	@Override
 	protected Collection<HandlerMethodArgumentResolver> createAdditionalArgumentResolvers() {
-		return Arrays.asList(new VisibilityHandlerMethodArgumentResolver(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER),
-				new SqsMessageMethodArgumentResolver(), new QueueAttributesMethodArgumentResolver());
+		return Arrays.asList(new VisibilityHandlerMethodArgumentResolver(),
+				new BatchVisibilityHandlerMethodArgumentResolver(), new SqsMessageMethodArgumentResolver(),
+				new QueueAttributesMethodArgumentResolver());
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/AbstractEndpoint.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/AbstractEndpoint.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.sqs.config;
 
 import io.awspring.cloud.sqs.listener.AsyncMessageListener;
+import io.awspring.cloud.sqs.listener.BatchVisibility;
 import io.awspring.cloud.sqs.listener.ListenerMode;
 import io.awspring.cloud.sqs.listener.MessageListener;
 import io.awspring.cloud.sqs.listener.MessageListenerContainer;
@@ -29,6 +30,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.springframework.core.BridgeMethodResolver;
 import org.springframework.core.MethodParameter;
 import org.springframework.lang.Nullable;
@@ -112,28 +114,33 @@ public abstract class AbstractEndpoint implements HandlerMethodEndpoint {
 		List<MethodParameter> parameters = getMethodParameters();
 		boolean batch = hasParameterOfType(parameters, List.class);
 		boolean batchAckParameter = hasParameterOfType(parameters, BatchAcknowledgement.class);
-		Assert.isTrue(hasValidParameters(batch, batchAckParameter, parameters.size()), getInvalidParametersMessage());
+		boolean batchVisibilityParameter = hasParameterOfType(parameters, BatchVisibility.class);
+		Assert.isTrue(hasValidParameters(batch, batchAckParameter, batchVisibilityParameter, parameters.size()),
+				getInvalidParametersMessage());
 		consumer.accept(batch ? ListenerMode.BATCH : ListenerMode.SINGLE_MESSAGE);
 	}
 
-	private boolean hasValidParameters(boolean batch, boolean batchAckParameter, int size) {
-		return hasValidSingleMessageParameters(batch, batchAckParameter)
-				|| hasValidBatchParameters(batchAckParameter, size);
+	private boolean hasValidParameters(boolean batch, boolean batchAckParameter, boolean batchVisibilityParameter,
+			int size) {
+		return hasValidSingleMessageParameters(batch, batchAckParameter, batchVisibilityParameter)
+				|| hasValidBatchParameters(batchAckParameter, batchVisibilityParameter, size);
 	}
 
-	private boolean hasValidSingleMessageParameters(boolean batch, boolean batchAckParameter) {
-		return !batch && !batchAckParameter;
+	private boolean hasValidSingleMessageParameters(boolean batch, boolean batchAckParameter,
+			boolean batchVisibilityParameter) {
+		return !batch && !batchAckParameter && !batchVisibilityParameter;
 	}
 
-	private boolean hasValidBatchParameters(boolean batchAckParameter, int size) {
-		return size == 1 || (size == 2 && batchAckParameter);
+	private boolean hasValidBatchParameters(boolean batchAckParameter, boolean batchVisibilityParameter, int size) {
+		long expectedAdditionalParams = Stream.of(batchAckParameter, batchVisibilityParameter).filter(b -> b).count();
+		return size == expectedAdditionalParams + 1;
 	}
 
 	private String getInvalidParametersMessage() {
 		return String.format(
 				"Method %s from class %s in endpoint %s has invalid parameters for batch processing. "
 						+ "Batch methods must have a single List parameter, either of Message<T> or T types,"
-						+ "and optionally a BatchAcknowledgement or AsyncAcknowledgement parameter.",
+						+ "and optionally BatchAcknowledgement and BatchVisibility parameters.",
 				this.method.getName(), this.method.getDeclaringClass(), this.id);
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/BatchVisibility.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/BatchVisibility.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.messaging.Message;
+
+/**
+ * BatchVisibility interface that can be injected as parameter into a listener method. The purpose of this interface is
+ * to provide a way for the listener methods to extend the visibility timeout of the messages being currently processed.
+ *
+ * @author Clement Denis
+ * @since 3.3
+ */
+public interface BatchVisibility<T> {
+
+	/**
+	 * Asynchronously changes all messages visibility to the provided value. // * @param seconds number of seconds to
+	 * set the visibility of all messages to.
+	 * @return a completable future.
+	 */
+	CompletableFuture<Void> changeToAsync(int seconds);
+
+	/**
+	 * Changes all messages visibility to the provided value.
+	 * @param seconds number of seconds to set the visibility of all messages to.
+	 */
+	default void changeTo(int seconds) {
+		changeToAsync(seconds).join();
+	}
+
+	/**
+	 * Asynchronously changes the provided messages visibility to the provided value. // * @param seconds number of
+	 * seconds to set the visibility of provided messages to.
+	 * @return a completable future.
+	 */
+	CompletableFuture<Void> changeToAsync(Collection<Message<T>> messages, int seconds);
+
+	/**
+	 * Changes the provided messages visibility to the provided value.
+	 * @param seconds number of seconds to set the visibility of the provided messages to.
+	 */
+	default void changeTo(Collection<Message<T>> messages, int seconds) {
+		changeToAsync(messages, seconds).join();
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/QueueMessageBatchVisibility.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/QueueMessageBatchVisibility.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.messaging.Message;
+
+/**
+ * {@link BatchVisibility} implementation for SQS messages.
+ *
+ * @author Clement Denis
+ * @since 3.3
+ */
+public class QueueMessageBatchVisibility<T> implements BatchVisibility<T> {
+
+	private final Collection<Message<T>> messages;
+
+	/**
+	 * Create an instance for changing the visibility in batch for the provided queue.
+	 *
+	 * @param messages the messages in the batch
+	 */
+	public QueueMessageBatchVisibility(Collection<Message<T>> messages) {
+		this.messages = messages;
+	}
+
+	@Override
+	public CompletableFuture<Void> changeToAsync(int seconds) {
+		return changeToAsync(messages, seconds);
+	}
+
+	@Override
+	public CompletableFuture<Void> changeToAsync(Collection<Message<T>> messages, int seconds) {
+		QueueMessageVisibility first = QueueMessageVisibility.fromMessage(messages.iterator().next());
+		return first.changeToAsyncBatch(seconds, messages);
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/QueueMessageVisibility.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/QueueMessageVisibility.java
@@ -15,10 +15,14 @@
  */
 package io.awspring.cloud.sqs.listener;
 
+import io.awspring.cloud.sqs.CollectionUtils;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.messaging.Message;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchRequestEntry;
 
 /**
  * {@link Visibility} implementation for SQS messages.
@@ -57,4 +61,33 @@ public class QueueMessageVisibility implements Visibility {
 				.thenRun(() -> logger.trace("Changed the visibility of message {} to {} seconds", this.receiptHandle,
 						seconds));
 	}
+
+	// TODO this is used by QueueMessageBatchVisibility to change visibility of multiple messages.
+	// This design is far from ideal, but it is very simple and minimizes changes.
+	// It is public so BatchVisibilityArgumentResolverTests can access the method.
+	public CompletableFuture<Void> changeToAsyncBatch(int seconds, Collection<? extends Message<?>> messages) {
+		CollectionUtils.partition(messages, 10).forEach(batch -> sqsAsyncClient
+				.changeMessageVisibilityBatch(req -> req.queueUrl(queueUrl)
+						.entries(batch.stream().map(QueueMessageVisibility::fromMessage)
+								.map(v -> ChangeMessageVisibilityBatchRequestEntry.builder()
+										.receiptHandle(v.receiptHandle).visibilityTimeout(seconds).build())
+								.toList()))
+				.thenRun(() -> logger.trace("Changed the visibility of {} message to {} seconds", batch.size(),
+						seconds)));
+		return CompletableFuture.completedFuture(null);
+	}
+
+	public static QueueMessageVisibility fromMessage(Message<?> message) {
+		Object visibilityObject = message.getHeaders().get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER);
+		if (visibilityObject == null) {
+			throw new IllegalArgumentException("No visibility object found for message header: '"
+					+ SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER + "'");
+		}
+		if (!(visibilityObject instanceof QueueMessageVisibility)) {
+			throw new IllegalArgumentException(
+					"Visibility object not of expected  " + QueueMessageBatchVisibility.class);
+		}
+		return (QueueMessageVisibility) visibilityObject;
+	}
+
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/BatchVisibilityHandlerMethodArgumentResolver.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/BatchVisibilityHandlerMethodArgumentResolver.java
@@ -15,29 +15,34 @@
  */
 package io.awspring.cloud.sqs.support.resolver;
 
-import io.awspring.cloud.sqs.listener.QueueMessageVisibility;
-import io.awspring.cloud.sqs.listener.Visibility;
+import io.awspring.cloud.sqs.listener.BatchVisibility;
+import io.awspring.cloud.sqs.listener.QueueMessageBatchVisibility;
+import java.util.Collection;
 import org.springframework.core.MethodParameter;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
 /**
- * {@link HandlerMethodArgumentResolver} for {@link Visibility} method parameters.
+ * {@link HandlerMethodArgumentResolver} for {@link BatchVisibility} method parameters.
  *
- * @author Szymon Dembek
- * @since 1.3
+ * @author Clement Denis
+ * @since 3.3
  */
-public class VisibilityHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+public class BatchVisibilityHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
 
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
-		return ClassUtils.isAssignable(Visibility.class, parameter.getParameterType());
+		return ClassUtils.isAssignable(BatchVisibility.class, parameter.getParameterType());
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public Object resolveArgument(MethodParameter parameter, Message<?> message) {
-		return QueueMessageVisibility.fromMessage(message);
+		Object payloadObject = message.getPayload();
+		Assert.isInstanceOf(Collection.class, payloadObject, "Payload must be instance of Collection");
+		return new QueueMessageBatchVisibility<>((Collection<Message<Object>>) payloadObject);
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
@@ -26,6 +26,7 @@ import io.awspring.cloud.sqs.annotation.SqsListener;
 import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration;
 import io.awspring.cloud.sqs.config.SqsListenerConfigurer;
 import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
+import io.awspring.cloud.sqs.listener.BatchVisibility;
 import io.awspring.cloud.sqs.listener.ContainerComponentFactory;
 import io.awspring.cloud.sqs.listener.MessageListenerContainer;
 import io.awspring.cloud.sqs.listener.QueueAttributes;
@@ -360,7 +361,8 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		LatchContainer latchContainer;
 
 		@SqsListener(queueNames = RECEIVES_MESSAGE_BATCH_QUEUE_NAME, factory = MANUAL_ACK_FACTORY, id = "receivesMessageBatchListener")
-		CompletableFuture<Void> listen(List<String> messages, BatchAcknowledgement<String> acknowledgement) {
+		CompletableFuture<Void> listen(List<String> messages, BatchAcknowledgement<String> acknowledgement,
+				BatchVisibility<String> visibility) {
 			logger.debug("Received messages in listener: " + messages);
 			latchContainer.receivesMessageBatchLatch.countDown();
 			return acknowledgement.acknowledgeAsync();

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/resolver/BatchVisibilityArgumentResolverTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/resolver/BatchVisibilityArgumentResolverTests.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.support.resolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import io.awspring.cloud.sqs.listener.BatchVisibility;
+import io.awspring.cloud.sqs.listener.QueueMessageVisibility;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.listener.Visibility;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+
+/**
+ * Tests for {@link BatchVisibilityHandlerMethodArgumentResolver}.
+ *
+ * @author Clement Denis
+ */
+@SuppressWarnings("unchecked")
+class BatchVisibilityArgumentResolverTests {
+
+	@Test
+	void shouldConvertAndAcknowledge() throws Exception {
+		QueueMessageVisibility visibility = mock(QueueMessageVisibility.class);
+		Message<Object> message1 = mock(Message.class);
+		Message<Object> message2 = mock(Message.class);
+		Message<Object> message3 = mock(Message.class);
+		List<Message<Object>> batch = Arrays.asList(message1, message2, message3);
+		MessageHeaders headers = new MessageHeaders(getMessageHeaders(visibility));
+		Message<Collection<Message<Object>>> rootMessage = mock(Message.class);
+		given(rootMessage.getPayload()).willReturn(batch);
+		given(message1.getHeaders()).willReturn(headers);
+		given(message2.getHeaders()).willReturn(headers);
+		given(message3.getHeaders()).willReturn(headers);
+		given(visibility.changeToAsyncBatch(anyInt(), anyList())).willReturn(CompletableFuture.completedFuture(null));
+		HandlerMethodArgumentResolver resolver = new BatchVisibilityHandlerMethodArgumentResolver();
+		Object result = resolver.resolveArgument(null, rootMessage);
+		assertThat(result).isNotNull().isInstanceOf(BatchVisibility.class);
+		((BatchVisibility<Object>) result).changeTo(10);
+		then(visibility).should().changeToAsyncBatch(10, batch);
+	}
+
+	@Test
+	void shouldConvertAndAcknowledgePartialBatch() throws Exception {
+		QueueMessageVisibility visibility = mock(QueueMessageVisibility.class);
+		Message<Object> message1 = mock(Message.class);
+		Message<Object> message2 = mock(Message.class);
+		Message<Object> message3 = mock(Message.class);
+		List<Message<Object>> batch = Arrays.asList(message1, message2, message3);
+		MessageHeaders headers = new MessageHeaders(getMessageHeaders(visibility));
+		Message<Collection<Message<Object>>> rootMessage = mock(Message.class);
+		given(rootMessage.getPayload()).willReturn(batch);
+		given(message1.getHeaders()).willReturn(headers);
+		given(message2.getHeaders()).willReturn(headers);
+		given(message3.getHeaders()).willReturn(headers);
+		given(visibility.changeToAsyncBatch(anyInt(), anyList())).willReturn(CompletableFuture.completedFuture(null));
+		HandlerMethodArgumentResolver resolver = new BatchVisibilityHandlerMethodArgumentResolver();
+		Object result = resolver.resolveArgument(null, rootMessage);
+		assertThat(result).isNotNull().isInstanceOf(BatchVisibility.class);
+		List<Message<Object>> changeVisibilityOn = Collections.singletonList(message1);
+		((BatchVisibility<Object>) result).changeTo(changeVisibilityOn, 10);
+		then(visibility).should().changeToAsyncBatch(10, changeVisibilityOn);
+	}
+
+	@Test
+	void shouldConvertAndAcknowledgeAsync() throws Exception {
+		QueueMessageVisibility visibility = mock(QueueMessageVisibility.class);
+		Message<Object> message1 = mock(Message.class);
+		Message<Object> message2 = mock(Message.class);
+		Message<Object> message3 = mock(Message.class);
+		List<Message<Object>> batch = Arrays.asList(message1, message2, message3);
+		MessageHeaders headers = new MessageHeaders(getMessageHeaders(visibility));
+		Message<Collection<Message<Object>>> rootMessage = mock(Message.class);
+		given(rootMessage.getPayload()).willReturn(batch);
+		given(message1.getHeaders()).willReturn(headers);
+		given(message2.getHeaders()).willReturn(headers);
+		given(message3.getHeaders()).willReturn(headers);
+		given(visibility.changeToAsyncBatch(anyInt(), anyList())).willReturn(CompletableFuture.completedFuture(null));
+		HandlerMethodArgumentResolver resolver = new BatchVisibilityHandlerMethodArgumentResolver();
+		Object result = resolver.resolveArgument(null, rootMessage);
+		assertThat(result).isNotNull().isInstanceOf(BatchVisibility.class);
+		((BatchVisibility<Object>) result).changeToAsync(10);
+		then(visibility).should().changeToAsyncBatch(10, batch);
+	}
+
+	@Test
+	void shouldConvertAndAcknowledgePartialBatchAsync() throws Exception {
+		QueueMessageVisibility visibility = mock(QueueMessageVisibility.class);
+		Message<Object> message1 = mock(Message.class);
+		Message<Object> message2 = mock(Message.class);
+		Message<Object> message3 = mock(Message.class);
+		List<Message<Object>> batch = Arrays.asList(message1, message2, message3);
+		MessageHeaders headers = new MessageHeaders(getMessageHeaders(visibility));
+		Message<Collection<Message<Object>>> rootMessage = mock(Message.class);
+		given(rootMessage.getPayload()).willReturn(batch);
+		given(message1.getHeaders()).willReturn(headers);
+		given(message2.getHeaders()).willReturn(headers);
+		given(message3.getHeaders()).willReturn(headers);
+		given(visibility.changeToAsyncBatch(anyInt(), anyList())).willReturn(CompletableFuture.completedFuture(null));
+		HandlerMethodArgumentResolver resolver = new BatchVisibilityHandlerMethodArgumentResolver();
+		Object result = resolver.resolveArgument(null, rootMessage);
+		assertThat(result).isNotNull().isInstanceOf(BatchVisibility.class);
+		List<Message<Object>> changeVisibilityOn = Collections.singletonList(message1);
+		((BatchVisibility<Object>) result).changeToAsync(changeVisibilityOn, 10);
+		then(visibility).should().changeToAsyncBatch(10, changeVisibilityOn);
+	}
+
+	@NotNull
+	private MessageHeaders getMessageHeaders(Visibility visibility) {
+		return new MessageHeaders(Collections.singletonMap(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, visibility));
+	}
+
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Implementation for #832

This is only a crude implementation (see TODO in QueueMessageVisibility) but should work good enough.

Note: there's an API change on the VisibilityHandlerMethodArgumentResolver constructor, but there shouldn't be any reason to use this class directly.

## :bulb: Motivation and Context
See #832


## :green_heart: How did you test it?
Through unit / integration tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
Maybe rework QueueMessage(Batch)Visibility to be more similar to acknowledgment design (using a callback).
