### PR TITLE
Add MessagingMessageConverter to SQS Auto-configuration (#1145)

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -94,7 +94,7 @@ public class SqsAutoConfiguration {
 			ObjectProvider<AsyncMessageInterceptor<Object>> asyncInterceptors,
 			ObjectProvider<MessageInterceptor<Object>> interceptors,
 			ObjectProvider<ObjectMapper> objectMapperProvider,
-			MessagingMessageConverter messagingMessageConverter) {
+			MessagingMessageConverter<?> messagingMessageConverter) {
 
 		SqsMessageListenerContainerFactory<Object> factory = new SqsMessageListenerContainerFactory<>();
 		factory.configure(this::configureContainerOptions);
@@ -109,12 +109,17 @@ public class SqsAutoConfiguration {
 
 	@ConditionalOnMissingBean
 	@Bean
-	public MessagingMessageConverter defaultMessageConverter() {
+	public MessagingMessageConverter<?> defaultMessageConverter() {
 		return new SqsMessagingMessageConverter();
 	}
 
-	private void setObjectMapper(SqsMessageListenerContainerFactory<Object> factory, ObjectMapper objectMapper, MessagingMessageConverter messagingMessageConverter) {
-		factory.configure(options -> options.messageConverter(messagingMessageConverter));
+	private void setObjectMapper(SqsMessageListenerContainerFactory<Object> factory, ObjectMapper objectMapper, MessagingMessageConverter<?> messagingMessageConverter) {
+		if(messagingMessageConverter instanceof SqsMessagingMessageConverter sqsMessagingMessageConverter) {
+			sqsMessagingMessageConverter.setObjectMapper(objectMapper);
+			factory.configure(options -> options.messageConverter(sqsMessagingMessageConverter));
+		} else {
+			factory.configure(options -> options.messageConverter(messagingMessageConverter));
+		}
 	}
 
 	private void configureContainerOptions(ContainerOptionsBuilder<?, ?> options) {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -114,12 +114,11 @@ public class SqsAutoConfiguration {
 	}
 
 	private void setObjectMapper(SqsMessageListenerContainerFactory<Object> factory, ObjectMapper objectMapper, MessagingMessageConverter<?> messagingMessageConverter) {
-		if(messagingMessageConverter instanceof SqsMessagingMessageConverter sqsMessagingMessageConverter) {
-			sqsMessagingMessageConverter.setObjectMapper(objectMapper);
-			factory.configure(options -> options.messageConverter(sqsMessagingMessageConverter));
-		} else {
-			factory.configure(options -> options.messageConverter(messagingMessageConverter));
+		if (messagingMessageConverter instanceof SqsMessagingMessageConverter) {
+			((SqsMessagingMessageConverter)messagingMessageConverter).setObjectMapper(objectMapper);
 		}
+
+		factory.configure(options -> options.messageConverter(messagingMessageConverter));
 	}
 
 	private void configureContainerOptions(ContainerOptionsBuilder<?, ?> options) {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClientBuilder;
  *
  * @author Tomaz Fernandes
  * @author Maciej Walkowiak
+ * @author Dongha Kim
  * @since 3.0
  */
 @AutoConfiguration

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -104,7 +104,14 @@ public class SqsAutoConfiguration {
 		errorHandler.ifAvailable(factory::setErrorHandler);
 		interceptors.forEach(factory::addMessageInterceptor);
 		asyncInterceptors.forEach(factory::addMessageInterceptor);
-		objectMapperProvider.ifAvailable(objectMapper -> setObjectMapper(factory, objectMapper, messagingMessageConverter));
+		objectMapperProvider.ifAvailable(objectMapper -> {
+			if (messagingMessageConverter instanceof SqsMessagingMessageConverter) {
+				((SqsMessagingMessageConverter) messagingMessageConverter).setObjectMapper(objectMapper);
+			}
+		});
+
+		factory.configure(options -> options.messageConverter(messagingMessageConverter));
+
 		return factory;
 	}
 
@@ -112,14 +119,6 @@ public class SqsAutoConfiguration {
 	@Bean
 	public MessagingMessageConverter<?> defaultMessageConverter() {
 		return new SqsMessagingMessageConverter();
-	}
-
-	private void setObjectMapper(SqsMessageListenerContainerFactory<Object> factory, ObjectMapper objectMapper, MessagingMessageConverter<?> messagingMessageConverter) {
-		if (messagingMessageConverter instanceof SqsMessagingMessageConverter) {
-			((SqsMessagingMessageConverter)messagingMessageConverter).setObjectMapper(objectMapper);
-		}
-
-		factory.configure(options -> options.messageConverter(messagingMessageConverter));
 	}
 
 	private void configureContainerOptions(ContainerOptionsBuilder<?, ?> options) {

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessagingMessageConverter.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.sqs.support.converter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.messaging.Message;
 
 /**
@@ -37,5 +38,7 @@ public interface MessagingMessageConverter<S> {
 	 * @return the system specific message.
 	 */
 	S fromMessagingMessage(Message<?> message);
+
+	void setObjectMapper(ObjectMapper objectMapper);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessagingMessageConverter.java
@@ -39,6 +39,4 @@ public interface MessagingMessageConverter<S> {
 	 */
 	S fromMessagingMessage(Message<?> message);
 
-	void setObjectMapper(ObjectMapper objectMapper);
-
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessagingMessageConverter.java
@@ -15,7 +15,6 @@
  */
 package io.awspring.cloud.sqs.support.converter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.messaging.Message;
 
 /**


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Changed to allow the creation of a MessagingMessageConverter bean, and to allow auto configuration to be used even if a custom MessagingMessageConverter bean is declared.


## :bulb: Motivation and Context
Implementation for issue #1145 


## :green_heart: How did you test it?
Pass SqsAutoConfigurationTest, SqsAutoConfigurationIntegrationTest

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
