### PR TITLE
Fix method name in S3 AsciiDoc

### DIFF
--- a/docs/src/main/asciidoc/s3.adoc
+++ b/docs/src/main/asciidoc/s3.adoc
@@ -208,7 +208,7 @@ s3Template.upload(BUCKET, "file.txt", is, ObjectMetadata.builder().contentType("
 Another feature of `S3Template` is the ability to generate signed URLs for getting/putting S3 objects in a single method call.
 [source,java]
 ----
-URL signedGetUrl = s3Template.createSignedGetUrl("bucket_name", "file.txt", Duration.ofMinutes(5));
+URL signedGetUrl = s3Template.createSignedGetURL("bucket_name", "file.txt", Duration.ofMinutes(5));
 ----
 
 `S3Template` also allows storing & retrieving Java objects.


### PR DESCRIPTION
This is most definitely a typo, the correct method is `S3Template#createSignedGetURL`.

## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
The current AsciiDoc refers to a non-existent method `S3Template#createSignedGetUrl`.


## :bulb: Motivation and Context
Corrects documentation.


## :green_heart: How did you test it?
No code changes.

## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
