### PR TITLE
Add support for Micrometer's Observation API for the SQS pipeline

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -355,6 +355,37 @@ Optional<Message<SampleRecord>> receivedMessage = template
 			.receive(queue, SampleRecord.class);
 ```
 
+==== Observability Support
+
+The framework instruments the codebase for sending messages to SQS to publish observations.
+This instrumentation will create 2 types of observations:
+
+* `sqs.single.message.publish` when a single SQS message is published by the service. It propagates the outbound tracing information by setting it up in `MessageHeaders`.
+* `sqs.batch.message.publish` when multiple SQS messages are published by the service. It propagates the outbound tracing information by setting it up in `MessageHeaders` of each SQS message.
+
+Additionally, both types of observations measure the time taken to publish SQS messages and create the following `KeyValues`:
+
+.Low cardinality Keys
+[cols="2"]
+|===
+| Name | Description
+| `messaging.operation` |The mode of SQS message publishing (values: `single message publish` or `batch message publish`).
+|===
+
+.High cardinality Keys
+[cols="2"]
+|===
+| Name | Description
+| `messaging.message.id` |The ID of either a single published SQS message or concatenation IDs of all SQS messages in the entire published batch.
+|===
+
+When using a `Spring Boot` application with `auto-configuration` and the default `SqsTemplate`, enabling this functionality requires only the `ObservationRegistry` bean to be available. In any other case, the `ObservationRegistry` needs to be set in the `SqsTemplate` builder:
+
+[source, java]
+----
+SqsTemplate.builder().observationRegistry(registry);
+----
+
 === Receiving Messages
 
 The framework offers the following options to receive messages from a queue.
@@ -1750,4 +1781,83 @@ Sample IAM policy granting access to SQS:
             ],
             "Resource": "yourARN"
         }
+----
+
+=== Observability Support
+
+The framework offers instrumentation for the SQS processing codebase to publish observations.
+This instrumentation is available with SQS polling and `SqsTemplate`.
+The observations measure the time taken to process SQS messages and create the following `KeyValues`:
+
+.High cardinality Keys
+[cols="2"]
+|===
+| Name | Description
+| `messaging.message.id` |The ID of either a single processed SQS message or the concatenation IDs of all SQS messages in the entire processed batch.
+|===
+
+.Low cardinality Keys for SQS polling
+[cols="2"]
+|===
+| Name | Description
+| `messaging.operation` |The mode of SQS message processing (values: `single message polling process` or `batch message polling process`).
+|===
+
+.Low cardinality Keys for `SqsTemplate`
+[cols="2"]
+|===
+| Name | Description
+| `messaging.operation` |The mode of SQS message processing (values: `single message manual process` or `batch message manual process`).
+|===
+
+
+==== SQS polling
+
+The instrumentation will create two types of observations:
+
+* `sqs.single.message.polling.process` when a SQS messages from the batch are processed by the service. They propagate the inbound tracing information by looking it up in `MessageHeaders`.
+* `sqs.batch.message.polling.process` when the entire received batch of SQS messages is processed by the service. They propagate the inbound tracing information in the form the of a list of tracing `Link` by looking it up in the `MessageHeaders` of incoming traces in the entire received batch.
+
+When using a `Spring Boot` application with `auto-configuration` and the default `SqsMessageListenerContainerFactory`, enabling this functionality requires only the `ObservationRegistry` bean to be available. In any other case, the `ObservationRegistry` needs to be set in the `MessageListenerContainerFactory`:
+
+[source, java]
+----
+@Bean
+SqsMessageListenerContainerFactory<Object> sqsListenerContainerFactory(SqsAsyncClient sqsAsyncClient, ObservationRegistry observationRegistry) {
+    return SqsMessageListenerContainerFactory
+        .builder()
+        .sqsAsyncClientSupplier(sqsAsyncClient)
+        .observationRegistry(observationRegistry)
+        .build();
+}
+----
+
+Or directly in the `MessageListenerContainer`:
+
+[source, java]
+----
+@Bean
+MessageListenerContainer<Object> listenerContainer(SqsAsyncClient sqsAsyncClient, ObservationRegistry observationRegistry) {
+    return SqsMessageListenerContainer
+            .builder()
+            .sqsAsyncClient(sqsAsyncClient)
+            .observationRegistry(observationRegistry)
+            .build();
+}
+----
+
+==== SqsTemplate
+
+The instrumentation will create two types of observations:
+
+* `sqs.single.message.manual.process` when an individual SQS message from the batch is processed by the service. The inbound tracing information is not propagated from messages, and a new tracing context is created instead.
+* `sqs.batch.message.manual.process` when the entire batch of received SQS messages is processed by the service. The inbound tracing information is not propagated from messages, and a new tracing context is created instead.
+
+*Note*: The inbound tracing information is not propagated, and a new tracing context is created because the user of SqsTemplate can invoke this API within the scope of an existing tracing context, where their trace ID should be reused. Additionally, the headers of received messages contain the required tracing information, allowing the user to decide whether to use the inbound tracing or not.
+
+When using a `Spring Boot` application with `auto-configuration` and the default `SqsTemplate`, enabling this functionality requires only the `ObservationRegistry` bean to be available. In any other case, the `ObservationRegistry` needs to be set in the `SqsTemplate` builder:
+
+[source, java]
+----
+SqsTemplate.builder().observationRegistry(registry);
 ----

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
@@ -35,9 +35,12 @@ import io.awspring.cloud.sqs.listener.ContainerOptionsBuilder;
 import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
 import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
+import io.awspring.cloud.sqs.observation.BatchMessageProcessTracingObservationHandler;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import io.awspring.cloud.sqs.support.converter.MessagingMessageConverter;
 import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
@@ -242,6 +245,13 @@ class SqsAutoConfigurationTest {
 				});
 	}
 
+	@Test
+	void configureSqsObservation() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.enabled:true")
+				.withUserConfiguration(TracingConfiguration.class)
+				.run(context -> assertThat(context).hasSingleBean(BatchMessageProcessTracingObservationHandler.class));
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	static class CustomComponentsConfiguration {
 
@@ -298,6 +308,21 @@ class SqsAutoConfigurationTest {
 				}
 			};
 		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class TracingConfiguration {
+
+		@Bean
+		Propagator propagator() {
+			return Propagator.NOOP;
+		}
+
+		@Bean
+		Tracer tracer() {
+			return Tracer.NOOP;
+		}
+
 	}
 
 }

--- a/spring-cloud-aws-sqs/pom.xml
+++ b/spring-cloud-aws-sqs/pom.xml
@@ -35,6 +35,10 @@
 			<artifactId>spring-retry</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
@@ -57,7 +61,26 @@
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-observation-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.zipkin.brave</groupId>
+			<artifactId>brave-tests</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/ContextScopeManager.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/ContextScopeManager.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs;
+
+import io.micrometer.context.ContextSnapshot;
+import io.micrometer.observation.ObservationRegistry;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
+
+/**
+ * @author Mariusz Sondecki
+ */
+public final class ContextScopeManager {
+
+	private static final Logger logger = LoggerFactory.getLogger(ContextScopeManager.class);
+
+	private final ContextSnapshot currentContextSnapshot;
+
+	@Nullable
+	private final ContextSnapshot previousContextSnapshot;
+
+	private final ObservationRegistry observationRegistry;
+
+	@Nullable
+	private ContextSnapshot.Scope currentScope;
+
+	public ContextScopeManager(ContextSnapshot currentContextSnapshot,
+			@Nullable ContextSnapshot previousContextSnapshot, ObservationRegistry observationRegistry) {
+		this.currentContextSnapshot = currentContextSnapshot;
+		this.previousContextSnapshot = previousContextSnapshot;
+		this.observationRegistry = observationRegistry;
+
+		logNoOpObservationRegistry();
+	}
+
+	public void restoreScope() {
+		if (observationRegistry.isNoop()) {
+			return;
+		}
+		closeCurrentScope(); // Ensure current scope is closed
+		if (observationRegistry.getCurrentObservationScope() == null && previousContextSnapshot != null) {
+			restorePreviousScope();
+		}
+		else {
+			logger.trace(
+					"Current observation scope is active or previous scope is not available; not restoring previous scope");
+		}
+	}
+
+	// @formatter:off
+	public <T, U> CompletableFuture<U> manageContextWhileComposing(CompletableFuture<T> future,
+														 Function<? super T, ? extends CompletableFuture<U>> fn) {
+		if (observationRegistry.isNoop()){
+			return future.thenCompose(fn);
+		}
+		return future
+			.whenComplete((t, throwable) -> closeCurrentScope())
+			.thenCompose(fn)
+			.whenComplete((u, throwable) -> openCurrentScope());
+	}
+	// @formatter:on
+
+	private void restorePreviousScope() {
+		logger.trace("Restoring previous scope");
+		previousContextSnapshot.setThreadLocals();
+		logger.debug("Previous scope restored successfully");
+	}
+
+	private void openCurrentScope() {
+		logger.trace("Opening scope");
+		currentScope = currentContextSnapshot.setThreadLocals();
+		logger.debug("Scope opened successfully");
+	}
+
+	private void closeCurrentScope() {
+		if (currentScope != null && observationRegistry.getCurrentObservationScope() != null) {
+			try {
+				logger.trace("Closing scope");
+				currentScope.close();
+				currentScope = null;
+				logger.debug("Scope closed successfully");
+			}
+			catch (Exception e) {
+				logger.error("Failed to close scope", e);
+			}
+		}
+		else {
+			logger.trace("No scope to close");
+		}
+	}
+
+	private void logNoOpObservationRegistry() {
+		if (observationRegistry.isNoop()) {
+			logger.trace("ObservationRegistry is in No-Op mode");
+		}
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
@@ -21,6 +21,7 @@ import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
 import io.awspring.cloud.sqs.listener.errorhandler.ErrorHandler;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor;
+import io.micrometer.observation.ObservationRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -70,6 +71,8 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 	};
 
 	private int phase = DEFAULT_PHASE;
+
+	private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
 
 	/**
 	 * Create an instance with the provided {@link ContainerOptions}
@@ -172,6 +175,10 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 		this.phase = phase;
 	}
 
+	public void setObservationRegistry(ObservationRegistry observationRegistry) {
+		this.observationRegistry = observationRegistry;
+	}
+
 	/**
 	 * Returns the {@link ContainerOptions} instance for this container. Changed options will take effect on container
 	 * restart.
@@ -264,6 +271,10 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 
 	public int getPhase() {
 		return this.phase;
+	}
+
+	public ObservationRegistry getObservationRegistry() {
+		return this.observationRegistry;
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractPipelineMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractPipelineMessageListenerContainer.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.support.ContextPropagatingTaskDecorator;
 import org.springframework.lang.Nullable;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
@@ -66,6 +67,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  * restart.
  *
  * @author Tomaz Fernandes
+ * @author Mariusz Sondecki
  * @since 3.0
  */
 public abstract class AbstractPipelineMessageListenerContainer<T, O extends ContainerOptions<O, B>, B extends ContainerOptionsBuilder<B, O>>
@@ -246,6 +248,9 @@ public abstract class AbstractPipelineMessageListenerContainer<T, O extends Cont
 		executor.setQueueCapacity(poolSize);
 		executor.setAllowCoreThreadTimeOut(true);
 		executor.setThreadFactory(createThreadFactory());
+		if (!getObservationRegistry().isNoop()) {
+			executor.setTaskDecorator(new ContextPropagatingTaskDecorator());
+		}
 		executor.afterPropertiesSet();
 		return executor;
 	}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ObservationRegistryAware.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ObservationRegistryAware.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener;
+
+import io.micrometer.observation.ObservationRegistry;
+
+/**
+ * Implementations are enabled to receive a {@link ObservationRegistry} instance.
+ *
+ * @author Mariusz Sondecki
+ * @since 3.2
+ */
+public interface ObservationRegistryAware {
+
+	/**
+	 * Set the {@link ObservationRegistry} instance.
+	 * @param observationRegistry the instance.
+	 */
+	void setObservationRegistry(ObservationRegistry observationRegistry);
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/sink/BatchMessageSink.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/sink/BatchMessageSink.java
@@ -25,13 +25,15 @@ import org.springframework.messaging.Message;
  * {@link io.awspring.cloud.sqs.listener.pipeline.MessageProcessingPipeline}.
  *
  * @author Tomaz Fernandes
+ * @author Mariusz Sondecki
  * @since 3.0
  */
 public class BatchMessageSink<T> extends AbstractMessageProcessingPipelineSink<T> {
 
 	@Override
 	protected CompletableFuture<Void> doEmit(Collection<Message<T>> messages, MessageProcessingContext<T> context) {
-		return execute(messages, context).exceptionally(t -> logError(t, messages));
+		return tryObservedCompletableFuture(() -> execute(messages, context).exceptionally(t -> logError(t, messages)),
+				messages);
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/sink/adapter/AbstractDelegatingMessageListeningSinkAdapter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/sink/adapter/AbstractDelegatingMessageListeningSinkAdapter.java
@@ -18,11 +18,13 @@ package io.awspring.cloud.sqs.listener.sink.adapter;
 import io.awspring.cloud.sqs.ConfigUtils;
 import io.awspring.cloud.sqs.LifecycleHandler;
 import io.awspring.cloud.sqs.listener.ContainerOptions;
+import io.awspring.cloud.sqs.listener.ObservationRegistryAware;
 import io.awspring.cloud.sqs.listener.SqsAsyncClientAware;
 import io.awspring.cloud.sqs.listener.TaskExecutorAware;
 import io.awspring.cloud.sqs.listener.pipeline.MessageProcessingPipeline;
 import io.awspring.cloud.sqs.listener.sink.MessageProcessingPipelineSink;
 import io.awspring.cloud.sqs.listener.sink.MessageSink;
+import io.micrometer.observation.ObservationRegistry;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.util.Assert;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
@@ -31,10 +33,11 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClient;
  * {@link MessageProcessingPipelineSink} implementation that delegates method invocations to the provided delegate.
  *
  * @author Tomaz Fernandes
+ * @author Mariusz Sondecki
  * @since 3.0
  */
 public abstract class AbstractDelegatingMessageListeningSinkAdapter<T>
-		implements MessageProcessingPipelineSink<T>, TaskExecutorAware, SqsAsyncClientAware {
+		implements MessageProcessingPipelineSink<T>, TaskExecutorAware, SqsAsyncClientAware, ObservationRegistryAware {
 
 	private final MessageSink<T> delegate;
 
@@ -64,6 +67,12 @@ public abstract class AbstractDelegatingMessageListeningSinkAdapter<T>
 	public void setSqsAsyncClient(SqsAsyncClient sqsAsyncClient) {
 		ConfigUtils.INSTANCE.acceptIfInstance(this.delegate, SqsAsyncClientAware.class,
 				saca -> saca.setSqsAsyncClient(sqsAsyncClient));
+	}
+
+	@Override
+	public void setObservationRegistry(ObservationRegistry observationRegistry) {
+		ConfigUtils.INSTANCE.acceptIfInstance(this.delegate, ObservationRegistryAware.class,
+				ea -> ea.setObservationRegistry(observationRegistry));
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/BatchMessageManualProcessObservationConvention.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/BatchMessageManualProcessObservationConvention.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+/**
+ * Default implementation for {@link MessageObservationConvention} for the manual process of batch.
+ *
+ * @author Mariusz Sondecki
+ */
+public class BatchMessageManualProcessObservationConvention extends MessageManualProcessObservationConvention
+		implements MessageObservationConvention<MessageManualProcessObservationContext> {
+	@Override
+	public MessagingOperationType getMessageType() {
+		return MessagingOperationType.BATCH_MANUAL_PROCESS;
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/BatchMessagePollingProcessObservationContext.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/BatchMessagePollingProcessObservationContext.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import io.micrometer.observation.transport.ReceiverContext;
+import java.util.Collection;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Context that holds information for observation metadata collection during the
+ * {@link MessageObservationDocumentation#BATCH_MESSAGE_POLLING_PROCESS processing of the whole received batch of SQS
+ * messages}.
+ * <p>
+ * The inbound tracing information is propagated in the form of a list of {@link io.micrometer.tracing.Link} by looking
+ * it up in {@link MessageHeaders#get(Object, Class) incoming SQS message headers} of the entire received batch.
+ *
+ * @author Mariusz Sondecki
+ */
+public class BatchMessagePollingProcessObservationContext extends ReceiverContext<Collection<MessageHeaders>> {
+
+	public BatchMessagePollingProcessObservationContext(Collection<MessageHeaders> messageHeaders) {
+		super((carrier, key) -> null);
+		setCarrier(messageHeaders);
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/BatchMessagePollingProcessObservationConvention.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/BatchMessagePollingProcessObservationConvention.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import io.micrometer.observation.Observation;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Default implementation for {@link MessageObservationConvention} for the polling process of batch.
+ *
+ * @author Mariusz Sondecki
+ */
+public class BatchMessagePollingProcessObservationConvention
+		implements MessageObservationConvention<BatchMessagePollingProcessObservationContext> {
+
+	@Override
+	public String getMessageId(BatchMessagePollingProcessObservationContext context) {
+		return context.getCarrier().stream().map(MessageHeaders::getId).filter(Objects::nonNull).map(UUID::toString)
+				.collect(Collectors.joining("; "));
+	}
+
+	@Override
+	public MessagingOperationType getMessageType() {
+		return MessagingOperationType.BATCH_POLLING_PROCESS;
+	}
+
+	@Override
+	public boolean supportsContext(Observation.Context context) {
+		return context instanceof BatchMessagePollingProcessObservationContext;
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/BatchMessageProcessTracingObservationHandler.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/BatchMessageProcessTracingObservationHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import io.micrometer.tracing.Link;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.PropagatingReceiverTracingObservationHandler;
+import io.micrometer.tracing.propagation.Propagator;
+import java.util.function.Supplier;
+
+/**
+ * A TracingObservationHandler called when receiving occurred - e.g. batches of messages.
+ *
+ * @author Mariusz Sondecki
+ */
+public class BatchMessageProcessTracingObservationHandler
+		extends PropagatingReceiverTracingObservationHandler<BatchMessagePollingProcessObservationContext> {
+
+	private final Supplier<Propagator> propagatorSupplier;
+
+	/**
+	 * Creates a new instance of {@link BatchMessageProcessTracingObservationHandler}.
+	 *
+	 * @param tracer the tracer to use to record events
+	 * @param propagator the mechanism to propagate tracing information from the carrier
+	 */
+	public BatchMessageProcessTracingObservationHandler(Tracer tracer, Propagator propagator) {
+		super(tracer, propagator);
+		this.propagatorSupplier = () -> propagator;
+	}
+
+	@Override
+	public Span.Builder customizeExtractedSpan(BatchMessagePollingProcessObservationContext context,
+			Span.Builder builder) {
+		context.getCarrier().forEach(messageHeaders -> {
+			TraceContext traceContext = this.propagatorSupplier.get()
+					.extract(messageHeaders, (carrier, key) -> carrier.get(key, String.class)).start().context();
+			String newParentSpanId = traceContext.parentId(); // newParentSpanId should be a span ID of received message
+			if (newParentSpanId != null) {// add only when received message contains tracing information
+				builder.addLink(new Link(traceContext));
+			}
+		});
+		return super.customizeExtractedSpan(context, builder);
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/BatchMessagePublishObservationContext.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/BatchMessagePublishObservationContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import io.micrometer.observation.transport.SenderContext;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Context that holds information for observation metadata collection during the
+ * {@link MessageObservationDocumentation#BATCH_MESSAGE_PUBLISH publication of the whole batch of SQS messages}.
+ * <p>
+ * The outbound tracing information is propagated by setting it up in {@link Map#put(Object, Object) outgoing additional
+ * SQS message headers} of the entire received batch.
+ *
+ * @author Mariusz Sondecki
+ */
+public class BatchMessagePublishObservationContext extends SenderContext<Map<String, Object>> {
+
+	private Collection<MessageHeaders> messageHeaders = Collections.emptyList();
+
+	public BatchMessagePublishObservationContext() {
+		super((carrier, key, value) -> carrier.put(key, value));
+		setCarrier(new HashMap<>());
+	}
+
+	public void setMessageHeaders(Collection<MessageHeaders> messageHeaders) {
+		this.messageHeaders = messageHeaders;
+	}
+
+	public Collection<MessageHeaders> getMessageHeaders() {
+		return messageHeaders;
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/BatchMessagePublishObservationConvention.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/BatchMessagePublishObservationConvention.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+
+/**
+ * {@link ObservationConvention} interface for {@link MessageObservationDocumentation#BATCH_MESSAGE_PUBLISH SQS message
+ * publish} operations.
+ *
+ * @author Mariusz Sondecki
+ */
+public interface BatchMessagePublishObservationConvention
+		extends MessageObservationConvention<BatchMessagePublishObservationContext> {
+
+	@Override
+	default boolean supportsContext(Observation.Context context) {
+		return context instanceof BatchMessagePublishObservationContext;
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/DefaultBatchMessagePublishObservationConvention.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/DefaultBatchMessagePublishObservationConvention.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Default implementation for {@link BatchMessagePublishObservationConvention}.
+ *
+ * @author Mariusz Sondecki
+ */
+public class DefaultBatchMessagePublishObservationConvention implements BatchMessagePublishObservationConvention {
+
+	@Override
+	public String getMessageId(BatchMessagePublishObservationContext context) {
+		return context.getMessageHeaders().stream().map(MessageHeaders::getId).filter(Objects::nonNull)
+				.map(UUID::toString).collect(Collectors.joining("; "));
+	}
+
+	@Override
+	public MessagingOperationType getMessageType() {
+		return MessagingOperationType.BATCH_PUBLISH;
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/DefaultSingleMessagePublishObservationConvention.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/DefaultSingleMessagePublishObservationConvention.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Default implementation for {@link SingleMessagePublishObservationConvention}.
+ *
+ * @author Mariusz Sondecki
+ */
+public class DefaultSingleMessagePublishObservationConvention implements SingleMessagePublishObservationConvention {
+
+	@Override
+	public String getMessageId(SingleMessagePublishObservationContext context) {
+		return Optional.ofNullable(context.getMessageHeaders()).map(MessageHeaders::getId).map(UUID::toString)
+				.orElse(null);
+	}
+
+	@Override
+	public MessagingOperationType getMessageType() {
+		return MessagingOperationType.SINGLE_PUBLISH;
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/MessageManualProcessObservationContext.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/MessageManualProcessObservationContext.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import io.micrometer.observation.Observation;
+import java.util.Collection;
+import java.util.Collections;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Context that holds information for observation metadata collection during the manual process of SQS messages.
+ *
+ * @author Mariusz Sondecki
+ */
+public class MessageManualProcessObservationContext extends Observation.Context {
+
+	private Collection<MessageHeaders> messageHeaders = Collections.emptyList();
+
+	public Collection<MessageHeaders> getMessageHeaders() {
+		return messageHeaders;
+	}
+
+	public void setMessageHeaders(Collection<MessageHeaders> messageHeaders) {
+		this.messageHeaders = messageHeaders;
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/MessageManualProcessObservationConvention.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/MessageManualProcessObservationConvention.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import io.micrometer.observation.Observation;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * {@link MessageObservationConvention} base class for manual SQS message operations.
+ *
+ * @author Mariusz Sondecki
+ */
+abstract class MessageManualProcessObservationConvention
+		implements MessageObservationConvention<MessageManualProcessObservationContext> {
+
+	@Override
+	public String getMessageId(MessageManualProcessObservationContext context) {
+		return context.getMessageHeaders().stream().map(MessageHeaders::getId).filter(Objects::nonNull)
+				.map(UUID::toString).collect(Collectors.joining("; "));
+	}
+
+	@Override
+	public boolean supportsContext(Observation.Context context) {
+		return context instanceof MessageManualProcessObservationContext;
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/MessageObservationConvention.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/MessageObservationConvention.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import org.springframework.lang.Nullable;
+
+/**
+ * {@link ObservationConvention} interface for SQS message operations.
+ *
+ * @author Mariusz Sondecki
+ */
+public interface MessageObservationConvention<T extends Observation.Context> extends ObservationConvention<T> {
+
+	@Nullable
+	String getMessageId(T context);
+
+	MessagingOperationType getMessageType();
+
+	default String getOrDefault(String value) {
+		if (value == null) {
+			return KeyValue.NONE_VALUE;
+		}
+		return value;
+	}
+
+	default KeyValue getId(T context) {
+		String messageId = getOrDefault(getMessageId(context));
+		return KeyValue.of(MessageObservationDocumentation.HighCardinalityKeyNames.MESSAGE_ID, messageId);
+	}
+
+	@Override
+	default String getContextualName(T context) {
+		return "%s %s".formatted(getId(context).getValue(), getMessageType().getValue());
+	}
+
+	@Override
+	default KeyValues getHighCardinalityKeyValues(T context) {
+		return KeyValues.of(getId(context));
+	}
+
+	@Override
+	default KeyValues getLowCardinalityKeyValues(T context) {
+		return KeyValues.of(KeyValue.of(MessageObservationDocumentation.LowCardinalityKeyNames.OPERATION,
+				getMessageType().getValue()));
+	}
+
+	@Override
+	default String getName() {
+		return "sqs." + getMessageType().getValue().replace(" ", ".");
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/MessageObservationDocumentation.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/MessageObservationDocumentation.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import io.awspring.cloud.sqs.listener.sink.MessageProcessingPipelineSink;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.docs.ObservationDocumentation;
+import org.springframework.messaging.Message;
+
+/**
+ * Documented {@link io.micrometer.common.KeyValue KeyValues} for the observations on
+ * {@link MessageProcessingPipelineSink processing} of {@link Message SQS messages}.
+ *
+ * @author Mariusz Sondecki
+ */
+public enum MessageObservationDocumentation implements ObservationDocumentation {
+
+	SINGLE_MESSAGE_POLLING_PROCESS {
+		@Override
+		public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+			return SingleMessagePollingProcessObservationConvention.class;
+		}
+	},
+	SINGLE_MESSAGE_MANUAL_PROCESS {
+		@Override
+		public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+			return SingleMessageManualProcessObservationConvention.class;
+		}
+	},
+	BATCH_MESSAGE_POLLING_PROCESS {
+		@Override
+		public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+			return BatchMessagePollingProcessObservationConvention.class;
+		}
+	},
+	BATCH_MESSAGE_MANUAL_PROCESS {
+		@Override
+		public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+			return BatchMessageManualProcessObservationConvention.class;
+		}
+	},
+	SINGLE_MESSAGE_PUBLISH {
+		@Override
+		public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+			return DefaultSingleMessagePublishObservationConvention.class;
+		}
+	},
+	BATCH_MESSAGE_PUBLISH {
+		@Override
+		public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+			return DefaultBatchMessagePublishObservationConvention.class;
+		}
+	};
+
+	@Override
+	public KeyName[] getHighCardinalityKeyNames() {
+		return HighCardinalityKeyNames.values();
+	}
+
+	@Override
+	public KeyName[] getLowCardinalityKeyNames() {
+		return LowCardinalityKeyNames.values();
+	}
+
+	public enum HighCardinalityKeyNames implements KeyName {
+
+		MESSAGE_ID {
+			@Override
+			public String asString() {
+				return "messaging.message.id";
+			}
+		}
+
+	}
+
+	public enum LowCardinalityKeyNames implements KeyName {
+		OPERATION {
+			public String asString() {
+				return "messaging.operation";
+			}
+		}
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/MessagingOperationType.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/MessagingOperationType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+/**
+ * @author Mariusz Sondecki
+ */
+public enum MessagingOperationType {
+	// @formatter:off
+	SINGLE_MANUAL_PROCESS("single message manual process"),
+	SINGLE_POLLING_PROCESS("single message polling process"),
+	BATCH_MANUAL_PROCESS("batch message manual process"),
+	BATCH_POLLING_PROCESS("batch message polling process"),
+	SINGLE_PUBLISH("single message publish"),
+	BATCH_PUBLISH("batch message publish");
+	// @formatter:on
+
+	private final String value;
+
+	MessagingOperationType(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return value;
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/SingleMessageManualProcessObservationConvention.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/SingleMessageManualProcessObservationConvention.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+/**
+ * Default implementation for {@link MessageObservationConvention} for the manual process.
+ *
+ * @author Mariusz Sondecki
+ */
+public class SingleMessageManualProcessObservationConvention extends MessageManualProcessObservationConvention
+		implements MessageObservationConvention<MessageManualProcessObservationContext> {
+
+	@Override
+	public MessagingOperationType getMessageType() {
+		return MessagingOperationType.SINGLE_MANUAL_PROCESS;
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/SingleMessagePollingProcessObservationContext.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/SingleMessagePollingProcessObservationContext.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import io.micrometer.observation.transport.ReceiverContext;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Context that holds information for observation metadata collection during the
+ * {@link MessageObservationDocumentation#SINGLE_MESSAGE_POLLING_PROCESS process of received SQS messages}.
+ * <p>
+ * The inbound tracing information is propagated by looking it up in {@link MessageHeaders#get(Object, Class) incoming
+ * SQS message headers}.
+ *
+ * @author Mariusz Sondecki
+ */
+public class SingleMessagePollingProcessObservationContext extends ReceiverContext<MessageHeaders> {
+
+	public SingleMessagePollingProcessObservationContext(MessageHeaders messageHeaders) {
+		super((carrier, key) -> carrier.get(key, String.class));
+		setCarrier(messageHeaders);
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/SingleMessagePollingProcessObservationConvention.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/SingleMessagePollingProcessObservationConvention.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import io.micrometer.observation.Observation;
+import java.util.UUID;
+
+/**
+ * Default implementation for {@link MessageObservationConvention} for the polling process.
+ *
+ * @author Mariusz Sondecki
+ */
+public class SingleMessagePollingProcessObservationConvention
+		implements MessageObservationConvention<SingleMessagePollingProcessObservationContext> {
+
+	@Override
+	public String getMessageId(SingleMessagePollingProcessObservationContext context) {
+		UUID id = context.getCarrier().getId();
+		return id != null ? id.toString() : null;
+	}
+
+	@Override
+	public MessagingOperationType getMessageType() {
+		return MessagingOperationType.SINGLE_POLLING_PROCESS;
+	}
+
+	@Override
+	public boolean supportsContext(Observation.Context context) {
+		return context instanceof SingleMessagePollingProcessObservationContext;
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/SingleMessagePublishObservationContext.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/SingleMessagePublishObservationContext.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import io.micrometer.observation.transport.SenderContext;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Context that holds information for observation metadata collection during the
+ * {@link MessageObservationDocumentation#SINGLE_MESSAGE_PUBLISH publication of SQS messages}.
+ * <p>
+ * The outbound tracing information is propagated by setting it up in {@link Map#put(Object, Object) outgoing additional
+ * SQS message headers}.
+ *
+ * @author Mariusz Sondecki
+ */
+public class SingleMessagePublishObservationContext extends SenderContext<Map<String, Object>> {
+
+	private MessageHeaders messageHeaders;
+
+	public SingleMessagePublishObservationContext() {
+		super((carrier, key, value) -> carrier.put(key, value));
+		setCarrier(new HashMap<>());
+	}
+
+	public MessageHeaders getMessageHeaders() {
+		return messageHeaders;
+	}
+
+	public void setMessageHeaders(MessageHeaders messageHeaders) {
+		this.messageHeaders = messageHeaders;
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/SingleMessagePublishObservationConvention.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/observation/SingleMessagePublishObservationConvention.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+
+/**
+ * {@link ObservationConvention} interface for {@link MessageObservationDocumentation#SINGLE_MESSAGE_PUBLISH SQS message
+ * publish} operations.
+ *
+ * @author Mariusz Sondecki
+ */
+public interface SingleMessagePublishObservationConvention
+		extends MessageObservationConvention<SingleMessagePublishObservationContext> {
+
+	@Override
+	default boolean supportsContext(Observation.Context context) {
+		return context instanceof SingleMessagePublishObservationContext;
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateBuilder.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateBuilder.java
@@ -17,6 +17,7 @@ package io.awspring.cloud.sqs.operations;
 
 import io.awspring.cloud.sqs.support.converter.MessagingMessageConverter;
 import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
+import io.micrometer.observation.ObservationRegistry;
 import java.util.function.Consumer;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.Message;
@@ -82,4 +83,11 @@ public interface SqsTemplateBuilder {
 	 */
 	SqsOperations buildSyncTemplate();
 
+	/**
+	 * Set the {@link ObservationRegistry} to be used by the {@link SqsTemplate}.
+	 *
+	 * @param observationRegistry the instance.
+	 * @return the builder.
+	 */
+	SqsTemplateBuilder observationRegistry(ObservationRegistry observationRegistry);
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsObservationIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsObservationIntegrationTests.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.awspring.cloud.sqs.CompletableFutures;
+import io.awspring.cloud.sqs.MessageHeaderUtils;
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration;
+import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.listener.StandardSqsComponentFactory;
+import io.awspring.cloud.sqs.listener.acknowledgement.BatchingAcknowledgementProcessor;
+import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementMode;
+import io.awspring.cloud.sqs.listener.errorhandler.ErrorHandler;
+import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
+import io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import io.awspring.cloud.sqs.support.converter.MessagingMessageHeaders;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.ObservationContextAssert;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.support.MessageBuilder;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
+
+/**
+ * Integration tests for the SQS Observation API.
+ *
+ * @author Mariusz Sondecki
+ */
+@SpringBootTest
+class SqsObservationIntegrationTests extends BaseSqsIntegrationTest {
+
+	private static final Logger logger = LoggerFactory.getLogger(SqsObservationIntegrationTests.class);
+
+	static final String RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME = "observability_on_components_test_queue";
+
+	static final String RECEIVES_CHANGED_MESSAGE_ON_ERROR_QUEUE_NAME = "observability_on_error_test_queue";
+
+	static final String SHOULD_CHANGE_PAYLOAD = "should-change-payload";
+
+	private static final String CHANGED_PAYLOAD = "Changed payload";
+
+	private static final UUID CHANGED_ID = UUID.fromString("0009f2c8-1dc4-e211-cc99-9f9c62b5e66b");
+
+	@Autowired
+	LatchContainer latchContainer;
+
+	@Autowired
+	SqsTemplate sqsTemplate;
+
+	@Autowired(required = false)
+	ReceivesChangedPayloadOnErrorListener receivesChangedPayloadOnErrorListener;
+
+	@Autowired
+	TestObservationRegistry observationRegistry;
+
+	@BeforeAll
+	static void beforeTests() {
+		SqsAsyncClient client = createAsyncClient();
+		CompletableFuture.allOf(createQueue(client, RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME),
+				createQueue(client, RECEIVES_CHANGED_MESSAGE_ON_ERROR_QUEUE_NAME)).join();
+	}
+
+	@Test
+	@DisplayName("Should correctly instrument and propagate observations across different threads")
+	void shouldInstrumentObservationsAcrossThreads() throws Exception {
+		sqsTemplate.send(RECEIVES_CHANGED_MESSAGE_ON_ERROR_QUEUE_NAME, SHOULD_CHANGE_PAYLOAD);
+		assertThat(latchContainer.receivesChangedMessageOnErrorLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(receivesChangedPayloadOnErrorListener.receivedMessages).containsExactly(CHANGED_PAYLOAD);
+		assertThat(latchContainer.receivesChangedMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		TestObservationRegistryAssert.then(observationRegistry).hasNumberOfObservationsEqualTo(9)
+				.hasHandledContextsThatSatisfy(contexts -> {
+					ObservationContextAssert.then(contexts.get(0)).hasNameEqualTo("sqs.single.message.publish")
+							.doesNotHaveParentObservation();
+
+					ObservationContextAssert.then(contexts.get(1)).hasNameEqualTo("sqs.single.message.polling.process")
+							.doesNotHaveParentObservation();
+					ObservationContextAssert.then(contexts.get(2)).hasNameEqualTo("blockingInterceptor.intercept")
+							.hasParentObservationContextMatching(
+									contextView -> contextView.getName().equals("sqs.single.message.polling.process"));
+					ObservationContextAssert.then(contexts.get(3)).hasNameEqualTo("listener.listen")
+							.hasParentObservationContextMatching(
+									contextView -> contextView.getName().equals("sqs.single.message.polling.process"));
+					ObservationContextAssert.then(contexts.get(4)).hasNameEqualTo("sqs.single.message.publish")
+							.hasParentObservationContextMatching(
+									contextView -> contextView.getName().equals("sqs.single.message.polling.process"));
+					ObservationContextAssert.then(contexts.get(5)).hasNameEqualTo("errorHandler.handle")
+							.hasParentObservationContextMatching(
+									contextView -> contextView.getName().equals("sqs.single.message.polling.process"));
+
+					ObservationContextAssert.then(contexts.get(6)).hasNameEqualTo("asyncInterceptor1.afterProcessing")
+							.hasParentObservationContextMatching(
+									contextView -> contextView.getName().equals("sqs.single.message.polling.process"));
+					ObservationContextAssert.then(contexts.get(7)).hasNameEqualTo("sqs.single.message.manual.process")
+							.hasParentObservationContextMatching(
+									contextView -> contextView.getName().equals("asyncInterceptor1.afterProcessing"));
+					ObservationContextAssert.then(contexts.get(8)).hasNameEqualTo("asyncInterceptor2.afterProcessing")
+							.hasParentObservationContextMatching(
+									contextView -> contextView.getName().equals("asyncInterceptor1.afterProcessing"));
+				});
+	}
+
+	static class ReceivesChangedPayloadOnErrorListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		SqsTemplate sqsTemplate;
+
+		@Autowired
+		ObservationRegistry observationRegistry;
+
+		Collection<String> receivedMessages = Collections.synchronizedList(new ArrayList<>());
+
+		@SqsListener(queueNames = RECEIVES_CHANGED_MESSAGE_ON_ERROR_QUEUE_NAME, id = "receives-changed-payload-on-error")
+		CompletableFuture<Void> listen(Message<String> message,
+				@Header(SqsHeaders.SQS_QUEUE_NAME_HEADER) String queueName) {
+			Observation.createNotStarted("listener.listen", observationRegistry).observe(() -> {
+				logger.debug("Received message {} with id {} from queue {}", message.getPayload(),
+						MessageHeaderUtils.getId(message), queueName);
+				if (isChangedPayload(message)) {
+					receivedMessages.add(message.getPayload());
+					latchContainer.receivesChangedMessageOnErrorLatch.countDown();
+				}
+			});
+			return sqsTemplate.sendAsync(RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME, message.getPayload())
+					.thenAccept(result -> logger.debug("Sent message by SqsTemplate#sendAsync: {}", result.messageId()))
+					.thenCompose(result -> CompletableFutures.failedFuture(
+							new RuntimeException("Expected exception from receives-changed-payload-on-error")));
+		}
+	}
+
+	static class BlockingErrorHandler implements ErrorHandler<String> {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		ObservationRegistry observationRegistry;
+
+		@Override
+		public void handle(Message<String> message, Throwable t) {
+			Observation.createNotStarted("errorHandler.handle", observationRegistry).observe(() -> {
+				logger.debug("BlockingErrorHandler - handle: {}", MessageHeaderUtils.getId(message));
+				if (isChangedPayload(message)) {
+					latchContainer.receivesChangedMessageOnErrorLatch.countDown();
+				}
+			});
+		}
+	}
+
+	static class ReceivesChangedMessageInterceptor implements AsyncMessageInterceptor<String> {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		SqsTemplate sqsTemplate;
+
+		@Autowired
+		ObservationRegistry observationRegistry;
+
+		@Override
+		public CompletableFuture<Void> afterProcessing(Message<String> message, Throwable t) {
+			return Observation.createNotStarted("asyncInterceptor1.afterProcessing", observationRegistry)
+					.observe(() -> {
+						logger.debug("ReceivesChangedMessageInterceptor - afterProcessing: {}",
+								MessageHeaderUtils.getId(message));
+						return sqsTemplate.receiveAsync(RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME, String.class)
+								.thenAccept(result -> {
+									logger.debug("Received message with SqsTemplate#receiveAsync: {}",
+											result.map(MessageHeaderUtils::getId).orElse("empty"));
+									result.ifPresent(msg -> latchContainer.receivesChangedMessageLatch.countDown());
+								});
+					});
+		}
+	}
+
+	static class ReceivesChangedPayloadOnErrorInterceptor implements AsyncMessageInterceptor<String> {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		ObservationRegistry observationRegistry;
+
+		@Override
+		public CompletableFuture<Void> afterProcessing(Message<String> message, Throwable t) {
+			return Observation.createNotStarted("asyncInterceptor2.afterProcessing", observationRegistry)
+					.observe(() -> {
+						logger.debug("ReceivesChangedPayloadOnErrorInterceptor - afterProcessing: {}",
+								MessageHeaderUtils.getId(message));
+						if (isChangedPayload(message)) {
+							latchContainer.receivesChangedMessageOnErrorLatch.countDown();
+						}
+						return CompletableFuture.completedFuture(null);
+					});
+		}
+	}
+
+	static class BlockingInterceptor implements MessageInterceptor<String> {
+
+		@Autowired
+		ObservationRegistry observationRegistry;
+
+		@Override
+		public Message<String> intercept(Message<String> message) {
+			return Observation.createNotStarted("blockingInterceptor.intercept", observationRegistry).observe(() -> {
+				logger.debug("BlockingInterceptor - intercept: {}", MessageHeaderUtils.getId(message));
+				if (message.getPayload().equals(SHOULD_CHANGE_PAYLOAD)) {
+					MessagingMessageHeaders headers = new MessagingMessageHeaders(message.getHeaders(), CHANGED_ID);
+					return MessageBuilder.createMessage(CHANGED_PAYLOAD, headers);
+				}
+				return message;
+			});
+		}
+	}
+
+	static class LatchContainer {
+
+		final CountDownLatch receivesChangedMessageLatch = new CountDownLatch(1);
+
+		final CountDownLatch receivesChangedMessageOnErrorLatch = new CountDownLatch(3);
+
+	}
+
+	@Import(SqsBootstrapConfiguration.class)
+	@Configuration
+	static class SQSConfiguration {
+
+		LatchContainer latchContainer = new LatchContainer();
+
+		// @formatter:off
+		@Bean
+		SqsMessageListenerContainerFactory<String> defaultSqsListenerContainerFactory() {
+			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
+			factory.configure(options -> options
+				.maxDelayBetweenPolls(Duration.ofSeconds(1))
+				.queueAttributeNames(Collections.singletonList(QueueAttributeName.QUEUE_ARN))
+				.acknowledgementMode(AcknowledgementMode.ALWAYS)
+				.pollTimeout(Duration.ofSeconds(3)));
+			factory.setSqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient);
+			factory.setObservationRegistry(observationRegistry());
+			factory.addMessageInterceptor(asyncInterceptor1());
+			factory.addMessageInterceptor(asyncInterceptor2());
+			factory.addMessageInterceptor(blockingInterceptor());
+			factory.setErrorHandler(blockErrorHandler());
+			factory.setContainerComponentFactories(Collections.singletonList(getContainerComponentFactory()));
+			return factory;
+		}
+		// @formatter:on
+
+		@Bean
+		BlockingErrorHandler blockErrorHandler() {
+			return new BlockingErrorHandler();
+		}
+
+		@Bean
+		ReceivesChangedPayloadOnErrorListener receivesChangedPayloadOnErrorListener() {
+			return new ReceivesChangedPayloadOnErrorListener();
+		}
+
+		@Bean
+		LatchContainer latchContainer() {
+			return this.latchContainer;
+		}
+
+		@Bean
+		TestObservationRegistry observationRegistry() {
+			return TestObservationRegistry.create();
+		}
+
+		@Bean
+		SqsTemplate sqsTemplate() {
+			return SqsTemplate.builder().observationRegistry(observationRegistry())
+					.sqsAsyncClient(BaseSqsIntegrationTest.createAsyncClient()).build();
+		}
+
+		@Bean
+		ReceivesChangedMessageInterceptor asyncInterceptor1() {
+			return new ReceivesChangedMessageInterceptor();
+		}
+
+		@Bean
+		ReceivesChangedPayloadOnErrorInterceptor asyncInterceptor2() {
+			return new ReceivesChangedPayloadOnErrorInterceptor();
+		}
+
+		@Bean
+		BlockingInterceptor blockingInterceptor() {
+			return new BlockingInterceptor();
+		}
+
+		private StandardSqsComponentFactory<String> getContainerComponentFactory() {
+			return new StandardSqsComponentFactory<>() {
+				@Override
+				protected BatchingAcknowledgementProcessor<String> createBatchingProcessorInstance() {
+					return new BatchingAcknowledgementProcessor<>() {
+						@Override
+						protected CompletableFuture<Void> sendToExecutor(Collection<Message<String>> messagesToAck) {
+							return super.sendToExecutor(messagesToAck).whenComplete((v, t) -> {
+								if (messagesToAck.stream().allMatch(SqsObservationIntegrationTests::isChangedPayload)) {
+									latchContainer.receivesChangedMessageOnErrorLatch.countDown();
+								}
+							});
+						}
+					};
+				}
+			};
+		}
+
+	}
+
+	private static boolean isChangedPayload(Message<?> message) {
+		return message != null && message.getPayload().equals(CHANGED_PAYLOAD)
+				&& MessageHeaderUtils.getId(message).equals(CHANGED_ID.toString());
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainerTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainerTests.java
@@ -24,6 +24,7 @@ import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
 import io.awspring.cloud.sqs.listener.errorhandler.ErrorHandler;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor;
+import io.micrometer.observation.ObservationRegistry;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -74,6 +75,8 @@ class AbstractMessageListenerContainerTests {
 				.extracting("blockingMessageInterceptor").isEqualTo(interceptor);
 
 		assertThat(container.getPhase()).isEqualTo(MessageListenerContainer.DEFAULT_PHASE);
+
+		assertThat(container.getObservationRegistry()).isEqualTo(ObservationRegistry.NOOP);
 	}
 
 	@Test
@@ -103,6 +106,7 @@ class AbstractMessageListenerContainerTests {
 		assertThat(container.getContainerComponentFactories()).containsExactlyElementsOf(componentFactories);
 		assertThat(container.getMessageInterceptors()).containsExactly(interceptor);
 		assertThat(container.getPhase()).isEqualTo(MessageListenerContainer.DEFAULT_PHASE);
+		assertThat(container.getObservationRegistry()).isEqualTo(ObservationRegistry.NOOP);
 
 	}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/sink/BatchMessageListeningSinkTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/sink/BatchMessageListeningSinkTests.java
@@ -26,6 +26,7 @@ import io.awspring.cloud.sqs.observation.MessagingOperationType;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
@@ -34,45 +35,45 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 
 /**
- * Tests for {@link OrderedMessageSink}.
+ * Tests for {@link BatchMessageSink}.
  *
- * @author Tomaz Fernandes
  * @author Mariusz Sondecki
  */
-class OrderedMessageListeningSinkTests {
+class BatchMessageListeningSinkTests {
 
 	@Test
-	void shouldEmitInOrder() {
+	void shouldEmitBatchMessages() {
 		TestObservationRegistry registry = TestObservationRegistry.create();
-		int numberOfMessagesToEmit = 1000;
+		int numberOfMessagesToEmit = 10;
 		List<Message<Integer>> messagesToEmit = IntStream.range(0, numberOfMessagesToEmit)
 				.mapToObj(index -> MessageBuilder.withPayload(index).build()).collect(toList());
 		List<Message<Integer>> received = new ArrayList<>(numberOfMessagesToEmit);
-		AbstractMessageProcessingPipelineSink<Integer> sink = new OrderedMessageSink<>();
+		AbstractMessageProcessingPipelineSink<Integer> sink = new BatchMessageSink<>();
 		sink.setObservationRegistry(registry);
 		sink.setTaskExecutor(Runnable::run);
 		sink.setMessagePipeline(getMessageProcessingPipeline(received));
 		sink.start();
 		sink.emit(messagesToEmit, MessageProcessingContext.create()).join();
 		sink.stop();
-		assertThat(received).containsSequence(messagesToEmit);
+		assertThat(received).containsExactlyElementsOf(messagesToEmit);
 		TestObservationRegistryAssert.assertThat(registry)
-				.hasNumberOfObservationsWithNameEqualTo("sqs.single.message.polling.process", numberOfMessagesToEmit)
-				.forAllObservationsWithNameEqualTo("sqs.single.message.polling.process",
+				.hasNumberOfObservationsWithNameEqualTo("sqs.batch.message.polling.process", 1)
+				.forAllObservationsWithNameEqualTo("sqs.batch.message.polling.process",
 						observationContextAssert -> observationContextAssert
 								.hasHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.MESSAGE_ID.asString())
 								.hasLowCardinalityKeyValue(
 										MessageObservationDocumentation.LowCardinalityKeyNames.OPERATION.asString(),
-										MessagingOperationType.SINGLE_POLLING_PROCESS.getValue()));
+										MessagingOperationType.BATCH_POLLING_PROCESS.getValue()));
 	}
 
 	private MessageProcessingPipeline<Integer> getMessageProcessingPipeline(List<Message<Integer>> received) {
 		return new MessageProcessingPipeline<>() {
+
 			@Override
-			public CompletableFuture<Message<Integer>> process(Message<Integer> message,
+			public CompletableFuture<Collection<Message<Integer>>> process(Collection<Message<Integer>> messages,
 					MessageProcessingContext<Integer> context) {
-				received.add(message);
-				return CompletableFuture.completedFuture(message);
+				received.addAll(messages);
+				return CompletableFuture.completedFuture(messages);
 			}
 		};
 	}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/sink/FanOutMessageListeningSinkTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/sink/FanOutMessageListeningSinkTests.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.sink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import brave.Tracing;
+import brave.handler.MutableSpan;
+import brave.test.TestSpanHandler;
+import io.awspring.cloud.sqs.listener.AsyncMessageListener;
+import io.awspring.cloud.sqs.listener.MessageProcessingContext;
+import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementHandler;
+import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
+import io.awspring.cloud.sqs.listener.pipeline.*;
+import io.awspring.cloud.sqs.observation.MessageObservationDocumentation;
+import io.awspring.cloud.sqs.observation.MessagingOperationType;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.ObservationContextAssert;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.brave.bridge.BraveBaggageManager;
+import io.micrometer.tracing.brave.bridge.BraveCurrentTraceContext;
+import io.micrometer.tracing.brave.bridge.BravePropagator;
+import io.micrometer.tracing.brave.bridge.BraveTracer;
+import io.micrometer.tracing.handler.PropagatingReceiverTracingObservationHandler;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.support.ContextPropagatingTaskDecorator;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * Tests for {@link FanOutMessageSink}.
+ *
+ * @author Mariusz Sondecki
+ */
+class FanOutMessageListeningSinkTests {
+
+	private static final String TRACE_ID_HEADER = "X-B3-TraceId";
+
+	private static final String SPAN_ID_HEADER = "X-B3-SpanId";
+
+	private static final String PARENT_SPAN_ID_HEADER = "X-B3-ParentSpanId";
+
+	@Test
+	void shouldEmitInNestedObservation() {
+		// GIVEN
+		TestObservationRegistry registry = TestObservationRegistry.create();
+		Message<String> messageToEmit = MessageBuilder.withPayload("foo").build();
+		List<Message<String>> received = new ArrayList<>(1);
+
+		MessageProcessingConfiguration.Builder<String> configuration = MessageProcessingConfiguration.<String> builder()
+				.interceptors(List.of(getInterceptor(registry, Collections.emptyList(), null)))
+				.messageListener(getListener(received, registry));
+
+		// WHEN
+		emitMessage(registry, Runnable::run, messageToEmit, configuration);
+
+		// THEN
+		assertThat(received).containsExactly(messageToEmit);
+		TestObservationRegistryAssert.then(registry).hasNumberOfObservationsEqualTo(3)
+				.hasHandledContextsThatSatisfy(contexts -> {
+					ObservationContextAssert.then(contexts.get(0)).hasNameEqualTo("sqs.single.message.polling.process")
+							.hasHighCardinalityKeyValueWithKey(
+									MessageObservationDocumentation.HighCardinalityKeyNames.MESSAGE_ID.asString())
+							.hasLowCardinalityKeyValue(
+									MessageObservationDocumentation.LowCardinalityKeyNames.OPERATION.asString(),
+									MessagingOperationType.SINGLE_POLLING_PROCESS.getValue())
+							.doesNotHaveParentObservation();
+
+					ObservationContextAssert.then(contexts.get(1)).hasNameEqualTo("sqs.interceptor.process")
+							.hasParentObservationContextMatching(
+									contextView -> contextView.getName().equals("sqs.single.message.polling.process"));
+
+					ObservationContextAssert.then(contexts.get(2)).hasNameEqualTo("sqs.listener.process")
+							.hasHighCardinalityKeyValue("payload", "foo").hasParentObservationContextMatching(
+									contextView -> contextView.getName().equals("sqs.interceptor.process"));
+				});
+	}
+
+	@Test
+	void shouldEmitWithTracingContextFromMessage() {
+		// GIVEN
+		SimpleAsyncTaskExecutor taskExecutor = new SimpleAsyncTaskExecutor();
+		taskExecutor.setTaskDecorator(new ContextPropagatingTaskDecorator());
+
+		TestSpanHandler testSpanHandler = new TestSpanHandler();
+		Tracing tracing = Tracing.newBuilder().addSpanHandler(testSpanHandler).build();
+		io.micrometer.tracing.Tracer tracer = new BraveTracer(tracing.tracer(),
+				new BraveCurrentTraceContext(tracing.currentTraceContext()), new BraveBaggageManager());
+
+		ObservationRegistry registry = ObservationRegistry.create();
+		registry.observationConfig().observationHandler(
+				new PropagatingReceiverTracingObservationHandler<>(tracer, new BravePropagator(tracing)));
+
+		TraceContext b3TraceContext = tracer.nextSpan().context();
+		String traceId = b3TraceContext.traceId();
+		String spanId = b3TraceContext.spanId();
+		List<Map<String, String>> contexts = new ArrayList<>();
+		Message<String> messageToEmit = MessageBuilder.withPayload("")
+				.copyHeaders(Map.of(TRACE_ID_HEADER, traceId, SPAN_ID_HEADER, spanId, PARENT_SPAN_ID_HEADER, spanId))
+				.build();
+
+		MessageProcessingConfiguration.Builder<String> configuration = MessageProcessingConfiguration.<String> builder()
+				.interceptors(List.of(getInterceptor(registry, contexts, tracer)))
+				.messageListener(getListener(contexts, registry, tracer));
+
+		// WHEN
+		emitMessage(registry, taskExecutor, messageToEmit, configuration);
+
+		// THEN
+		MutableSpan finishedSpan = testSpanHandler.get(0);
+		Map<String, String> context = contexts.get(0);
+		assertThat(finishedSpan.traceId()).isEqualTo(traceId).isEqualTo(context.get(TRACE_ID_HEADER));
+		assertThat(finishedSpan.id()).isNotEqualTo(spanId).isEqualTo(context.get(SPAN_ID_HEADER));
+		assertThat(finishedSpan.parentId()).isEqualTo(spanId).isEqualTo(context.get(PARENT_SPAN_ID_HEADER));
+	}
+
+	private void emitMessage(ObservationRegistry registry, TaskExecutor taskExecutor, Message<String> messageToEmit,
+			MessageProcessingConfiguration.Builder<String> configuration) {
+		AcknowledgementHandler<String> dummyAcknowledgementHandler = new AcknowledgementHandler<>() {
+		};
+
+		MessageProcessingPipeline<String> messageProcessingPipeline = MessageProcessingPipelineBuilder
+				.<String> first(BeforeProcessingInterceptorExecutionStage::new).then(MessageListenerExecutionStage::new)
+				.thenInTheFuture(AfterProcessingInterceptorExecutionStage::new)
+				.build(configuration.ackHandler(dummyAcknowledgementHandler).build());
+
+		AbstractMessageProcessingPipelineSink<String> sink = new FanOutMessageSink<>();
+		sink.setObservationRegistry(registry);
+		sink.setTaskExecutor(taskExecutor);
+		sink.setMessagePipeline(messageProcessingPipeline);
+		sink.start();
+		sink.emit(List.of(messageToEmit), MessageProcessingContext.create()).join();
+		sink.stop();
+	}
+
+	private AsyncMessageInterceptor<String> getInterceptor(ObservationRegistry registry,
+			List<Map<String, String>> contexts, io.micrometer.tracing.Tracer tracer) {
+		return new AsyncMessageInterceptor<>() {
+			@Override
+			public CompletableFuture<Message<String>> intercept(Message<String> message) {
+				Observation.createNotStarted("sqs.interceptor.process", registry).start().openScope();
+				if (tracer != null) {
+					Span span = tracer.currentSpan();
+					if (span != null) {
+						TraceContext traceContext = span.context();
+						contexts.add(Map.of(TRACE_ID_HEADER, traceContext.traceId(), SPAN_ID_HEADER,
+								traceContext.spanId(), PARENT_SPAN_ID_HEADER, traceContext.parentId()));
+					}
+				}
+				return AsyncMessageInterceptor.super.intercept(message);
+			}
+
+			@Override
+			public CompletableFuture<Void> afterProcessing(Message<String> message, Throwable t) {
+				Observation observation = registry.getCurrentObservation();
+				if (observation != null) {
+					Observation.Scope currentScope = observation.getEnclosingScope();
+					if (currentScope != null) {
+						currentScope.close();
+					}
+					else {
+						fail("A scope for current observation expected");
+					}
+					observation.stop();
+				}
+				return AsyncMessageInterceptor.super.afterProcessing(message, t);
+			}
+		};
+	}
+
+	private AsyncMessageListener<String> getListener(List<Message<String>> received, ObservationRegistry registry) {
+		return message -> Objects.requireNonNull(Observation.createNotStarted("sqs.listener.process", registry)
+				.highCardinalityKeyValue("payload", message.getPayload()).observe(() -> {
+					received.add(message);
+					return CompletableFuture.completedFuture(null);
+				}));
+	}
+
+	private AsyncMessageListener<String> getListener(List<Map<String, String>> contexts, ObservationRegistry registry,
+			io.micrometer.tracing.Tracer tracer) {
+		return message -> Objects
+				.requireNonNull(Observation.createNotStarted("sqs.listener.process", registry).observe(() -> {
+					Span span = tracer.currentSpan();
+					if (span != null) {
+						TraceContext traceContext = span.context();
+						contexts.add(Map.of(TRACE_ID_HEADER, traceContext.traceId(), SPAN_ID_HEADER,
+								traceContext.spanId(), PARENT_SPAN_ID_HEADER, traceContext.parentId()));
+					}
+					return CompletableFuture.completedFuture(null);
+				}));
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/observation/BatchMessageProcessTracingObservationHandlerTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/observation/BatchMessageProcessTracingObservationHandlerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.observation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import brave.Tracing;
+import brave.handler.MutableSpan;
+import brave.test.TestSpanHandler;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.brave.bridge.BraveBaggageManager;
+import io.micrometer.tracing.brave.bridge.BraveCurrentTraceContext;
+import io.micrometer.tracing.brave.bridge.BravePropagator;
+import io.micrometer.tracing.brave.bridge.BraveTracer;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Tests for {@link BatchMessageProcessTracingObservationHandler}.
+ *
+ * @author Mariusz Sondecki
+ */
+class BatchMessageProcessTracingObservationHandlerTest {
+
+	private static final String TRACE_ID_HEADER = "X-B3-TraceId";
+
+	private static final String SPAN_ID_HEADER = "X-B3-SpanId";
+
+	private static final String PARENT_SPAN_ID_HEADER = "X-B3-ParentSpanId";
+
+	private final TestSpanHandler testSpanHandler = new TestSpanHandler();
+
+	private final Tracing tracing = Tracing.newBuilder().addSpanHandler(testSpanHandler).build();
+
+	private final io.micrometer.tracing.Tracer tracer = new BraveTracer(tracing.tracer(),
+			new BraveCurrentTraceContext(tracing.currentTraceContext()), new BraveBaggageManager());
+
+	private final BatchMessageProcessTracingObservationHandler handler = new BatchMessageProcessTracingObservationHandler(
+			tracer, new BravePropagator(tracing));
+
+	@Test
+	void shouldCreateLinksForAllMessages() {
+		// GIVEN
+		TraceContext traceContext1 = tracer.nextSpan().context();
+		TraceContext traceContext2 = tracer.nextSpan().context();
+		String traceId1 = traceContext1.traceId();
+		String spanId1 = traceContext1.spanId();
+		String traceId2 = traceContext2.traceId();
+		String spanId2 = traceContext2.spanId();
+		Collection<MessageHeaders> receivedMessageHeaders = List.of(
+				new MessageHeaders(
+						Map.of(TRACE_ID_HEADER, traceId1, SPAN_ID_HEADER, spanId1, PARENT_SPAN_ID_HEADER, spanId1)),
+				new MessageHeaders(
+						Map.of(TRACE_ID_HEADER, traceId2, SPAN_ID_HEADER, spanId2, PARENT_SPAN_ID_HEADER, spanId2)));
+		BatchMessagePollingProcessObservationContext context = new BatchMessagePollingProcessObservationContext(
+				receivedMessageHeaders);
+
+		// WHEN
+		handler.onStart(context);
+		handler.onStop(context);
+
+		// THEN
+		MutableSpan finishedSpan = testSpanHandler.get(0);
+		assertThat(traceId1).isNotEqualTo(traceId2);
+		assertThat(finishedSpan.traceId()).isNotEmpty().withFailMessage(
+				"A trace ID of the process of the whole batch should differ from trace IDs of received messages")
+				.isNotIn(traceId1, traceId2);
+		assertThat(finishedSpan.tags()).containsEntry("links[0].traceId", traceId1)
+				.containsEntry("links[1].traceId", traceId2)
+				.withFailMessage(
+						"""
+								"links[*].spanId" tags should differ from span IDs of received messages (which will be parent span IDs)""")
+				.doesNotContainEntry("links[0].spanId", spanId1).doesNotContainEntry("links[1].spanId", spanId2);
+	}
+}

--- a/spring-cloud-aws-sqs/src/test/resources/logback.xml
+++ b/spring-cloud-aws-sqs/src/test/resources/logback.xml
@@ -46,6 +46,7 @@
 	<logger name="io.awspring.cloud.sqs.integration.SqsInterceptorIntegrationTests" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.integration.SqsMessageConversionIntegrationTests" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.integration.SqsTemplateIntegrationTests" level="INFO"/>
+	<logger name="io.awspring.cloud.sqs.integration.SqsObservationIntegrationTests" level="INFO"/>
 
 	<root level="warn">
 		<appender-ref ref="STDOUT"/>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Added Micrometer's Observability support instruments SQS processing out of the box, while additionally propagating the inbound tracing information by looking it up in MessageHeaders.
Closes https://github.com/awspring/spring-cloud-aws/issues/646


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
