### PR TITLE
Fix MessagingMessageConverter to handle JSON string payload configured with the APPLICATION_JSON header (#1144)

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,8 @@ import org.springframework.util.Assert;
  * Base {@link MessagingMessageConverter} implementation.
  *
  * @author Tomaz Fernandes
+ * @author Dongha Kim
+ * 
  * @since 3.0
  * @see SqsHeaderMapper
  * @see SqsMessageConversionContext
@@ -185,6 +187,15 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 	@Nullable
 	private Class<?> getTargetType(Message<?> messagingMessage, @Nullable MessageConversionContext context) {
 		Class<?> classFromTypeMapper = this.payloadTypeMapper.apply(messagingMessage);
+
+        if(context != null && context.getPayloadClass() != null && !context.getPayloadClass().equals(String.class)) {
+			return context.getPayloadClass();
+		}
+
+		if(context != null && context.getPayloadClass() != null && classFromTypeMapper != null && !classFromTypeMapper.equals(String.class)) {
+			return classFromTypeMapper;
+		}
+
 		return classFromTypeMapper == null && context != null && context.getPayloadClass() != null
 				? context.getPayloadClass()
 				: classFromTypeMapper;

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
@@ -98,7 +98,7 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 		converter.setObjectMapper(objectMapper);
 	}
 
-	private Optional<MappingJackson2MessageConverter> getMappingJackson2MessageConverter() {
+	protected Optional<MappingJackson2MessageConverter> getMappingJackson2MessageConverter() {
 		return this.payloadMessageConverter instanceof CompositeMessageConverter compositeConverter
 				? compositeConverter.getConverters().stream()
 						.filter(converter -> converter instanceof MappingJackson2MessageConverter)

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverter.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.util.Assert;
 
 /**
@@ -34,12 +35,6 @@ import org.springframework.util.Assert;
 public class SqsMessagingMessageConverter
 		extends AbstractMessagingMessageConverter<software.amazon.awssdk.services.sqs.model.Message> {
 
-	private final ObjectMapper objectMapper;
-
-	public SqsMessagingMessageConverter() {
-		this.objectMapper = new ObjectMapper();
-	}
-
 	@Override
 	protected HeaderMapper<software.amazon.awssdk.services.sqs.model.Message> createDefaultHeaderMapper() {
 		return new SqsHeaderMapper();
@@ -48,6 +43,11 @@ public class SqsMessagingMessageConverter
 	@Override
 	protected Object getPayloadToDeserialize(software.amazon.awssdk.services.sqs.model.Message message) {
 		String body = message.body();
+
+		ObjectMapper objectMapper = getMappingJackson2MessageConverter()
+			.map(MappingJackson2MessageConverter::getObjectMapper)
+			.orElse(new ObjectMapper());
+
 		try {
 			ObjectNode jsonNode = objectMapper.readValue(body, ObjectNode.class);
 			return objectMapper.writeValueAsString(jsonNode);

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 package io.awspring.cloud.sqs.support.converter;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
@@ -22,6 +25,7 @@ import org.springframework.util.Assert;
  * {@link MessagingMessageConverter} implementation for converting SQS
  * {@link software.amazon.awssdk.services.sqs.model.Message} instances to Spring Messaging {@link Message} instances.
  *
+ * @author Dongha kim
  * @author Tomaz Fernandes
  * @since 3.0
  * @see SqsHeaderMapper
@@ -30,6 +34,12 @@ import org.springframework.util.Assert;
 public class SqsMessagingMessageConverter
 		extends AbstractMessagingMessageConverter<software.amazon.awssdk.services.sqs.model.Message> {
 
+	private final ObjectMapper objectMapper;
+
+	public SqsMessagingMessageConverter() {
+		this.objectMapper = new ObjectMapper();
+	}
+
 	@Override
 	protected HeaderMapper<software.amazon.awssdk.services.sqs.model.Message> createDefaultHeaderMapper() {
 		return new SqsHeaderMapper();
@@ -37,7 +47,19 @@ public class SqsMessagingMessageConverter
 
 	@Override
 	protected Object getPayloadToDeserialize(software.amazon.awssdk.services.sqs.model.Message message) {
-		return message.body();
+		String body = message.body();
+		try {
+			ObjectNode jsonNode = objectMapper.readValue(body, ObjectNode.class);
+			return objectMapper.writeValueAsString(jsonNode);
+		} catch (JsonProcessingException e) {
+			try {
+				String decodedBody = objectMapper.readValue(body, String.class);
+				ObjectNode jsonNode = objectMapper.readValue(decodedBody, ObjectNode.class);
+				return objectMapper.writeValueAsString(jsonNode);
+			} catch (JsonProcessingException e2) {
+				return body;
+			}
+		}
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.Assert;
@@ -56,6 +57,7 @@ import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
  *
  * @author Tomaz Fernandes
  * @author Mikhail Strokov
+ * @author Dongha Kim
  */
 @SpringBootTest
 class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
@@ -151,7 +153,20 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 		assertThat(latchContainer.resolvesPojoNotificationMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
-	private Map<String, Object> getHeaderMapping(Class<?> clazz) {
+	@Test
+	void shouldSendAndReceiveJsonString() throws Exception {
+		String messageBody = """
+            {
+              "firstField": "hello",
+              "secondField": "sqs!"
+            }
+            """;
+		sqsTemplate.send(to -> to.queue(RESOLVES_POJO_TYPES_QUEUE_NAME).payload(messageBody).header(MessageHeaders.CONTENT_TYPE, "application/json"));
+		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_TYPES_QUEUE_NAME, messageBody);
+		assertThat(latchContainer.resolvesPojoLatch.await(10, TimeUnit.SECONDS)).isTrue();
+	}
+
+		private Map<String, Object> getHeaderMapping(Class<?> clazz) {
 		return Collections.singletonMap(SqsHeaders.SQS_DEFAULT_TYPE_HEADER, clazz.getName());
 	}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
@@ -187,8 +187,8 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 		SqsOperations template = SqsTemplate.newSyncTemplate(this.asyncClient);
 		String jsonString = """
 			{
-			"propertyOne": "hello",
-			"propertyTwo": "sqs!"
+				"propertyOne": "hello",
+				"propertyTwo": "sqs!"
 			}
 			""";
 		SampleRecord expectedPayload = new SampleRecord("hello", "sqs!");

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
@@ -185,28 +185,18 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void shouldSendAndReceiveJsonString() {
 		SqsOperations template = SqsTemplate.newSyncTemplate(this.asyncClient);
-
 		String jsonString = """
-            {
-              "propertyOne": "hello",
-              "propertyTwo": "sqs!"
-            }
-            """;
-
+			{
+			"propertyOne": "hello",
+			"propertyTwo": "sqs!"
+			}
+			""";
 		SampleRecord expectedPayload = new SampleRecord("hello", "sqs!");
-
 		SendResult<Object> result = template.send(to -> to.queue(SENDS_AND_RECEIVES_MESSAGE_QUEUE_NAME)
-														  .payload(jsonString)
-														  .header(MessageHeaders.CONTENT_TYPE, "application/json"));
-
+				  .payload(jsonString).header(MessageHeaders.CONTENT_TYPE, "application/json"));
 		assertThat(result).isNotNull();
 		Optional<Message<SampleRecord>> receivedMessage = template.receive(from -> from.queue(SENDS_AND_RECEIVES_MESSAGE_QUEUE_NAME), SampleRecord.class);
-
-		assertThat(receivedMessage).isPresent();
-		Message<SampleRecord> message = receivedMessage.get();
-		SampleRecord actualPayload = message.getPayload();
-
-		assertThat(actualPayload).isEqualTo(expectedPayload);
+		assertThat(receivedMessage).isPresent().get().extracting(Message::getPayload).isEqualTo(expectedPayload);
 	}
 
 	@Test

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsTemplateIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,24 +15,10 @@
  */
 package io.awspring.cloud.sqs.integration;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.awspring.cloud.sqs.listener.SqsHeaders;
 import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement;
-import io.awspring.cloud.sqs.operations.SendResult;
-import io.awspring.cloud.sqs.operations.SqsOperations;
-import io.awspring.cloud.sqs.operations.SqsTemplate;
-import io.awspring.cloud.sqs.operations.SqsTemplateParameters;
-import io.awspring.cloud.sqs.operations.TemplateAcknowledgementMode;
+import io.awspring.cloud.sqs.operations.*;
 import io.awspring.cloud.sqs.support.converter.AbstractMessagingMessageConverter;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.IntStream;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -41,13 +27,22 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.StopWatch;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Tomaz Fernandes
+ * @author Dongha Kim
  */
 @SpringBootTest
 public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
@@ -188,6 +183,33 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 	}
 
 	@Test
+	void shouldSendAndReceiveJsonString() {
+		SqsOperations template = SqsTemplate.newSyncTemplate(this.asyncClient);
+
+		String jsonString = """
+            {
+              "propertyOne": "hello",
+              "propertyTwo": "sqs!"
+            }
+            """;
+
+		SampleRecord expectedPayload = new SampleRecord("hello", "sqs!");
+
+		SendResult<Object> result = template.send(to -> to.queue(SENDS_AND_RECEIVES_MESSAGE_QUEUE_NAME)
+														  .payload(jsonString)
+														  .header(MessageHeaders.CONTENT_TYPE, "application/json"));
+
+		assertThat(result).isNotNull();
+		Optional<Message<SampleRecord>> receivedMessage = template.receive(from -> from.queue(SENDS_AND_RECEIVES_MESSAGE_QUEUE_NAME), SampleRecord.class);
+
+		assertThat(receivedMessage).isPresent();
+		Message<SampleRecord> message = receivedMessage.get();
+		SampleRecord actualPayload = message.getPayload();
+
+		assertThat(actualPayload).isEqualTo(expectedPayload);
+	}
+
+	@Test
 	void shouldSendAndReceiveBatch() {
 		SqsOperations template = SqsTemplate.builder().sqsAsyncClient(this.asyncClient)
 				.configure(options -> options.acknowledgementMode(TemplateAcknowledgementMode.MANUAL))
@@ -313,6 +335,13 @@ public class SqsTemplateIntegrationTests extends BaseSqsIntegrationTest {
 		assertThat(result).isNotNull();
 		Optional<Message<SampleRecord>> receivedMessage = template
 				.receive(from -> from.queue(RECORD_WITHOUT_TYPE_HEADER_QUEUE_NAME), SampleRecord.class);
+
+
+		assertThat(receivedMessage).isPresent();
+		Message<SampleRecord> message = receivedMessage.get();
+		SampleRecord actualPayload = message.getPayload();
+
+
 		assertThat(receivedMessage).isPresent().get().extracting(Message::getPayload).isEqualTo(testRecord);
 	}
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
When creating a raw JSON string type payload in the SQS Template, if the header is set to CONTENT_TYPE as APPLICATION_JSON and sent to SQS, the listener could not read the object in the same format.

## :bulb: Motivation and Context
Implementation for issue #1144 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
