### PR TITLE
Don't assume all messages have a `to` address in SES integration

### DIFF
--- a/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/SimpleEmailServiceMailSender.java
+++ b/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/SimpleEmailServiceMailSender.java
@@ -125,7 +125,9 @@ public class SimpleEmailServiceMailSender implements MailSender, DisposableBean 
 	private SendEmailRequest prepareMessage(SimpleMailMessage simpleMailMessage) {
 		Assert.notNull(simpleMailMessage, "simpleMailMessage are required");
 		Destination.Builder destinationBuilder = Destination.builder();
-		destinationBuilder.toAddresses(simpleMailMessage.getTo());
+		if (simpleMailMessage.getTo() != null) {
+			destinationBuilder.toAddresses(simpleMailMessage.getTo());
+		}
 
 		if (simpleMailMessage.getCc() != null) {
 			destinationBuilder.ccAddresses(simpleMailMessage.getCc());

--- a/spring-cloud-aws-ses/src/test/java/io/awspring/cloud/ses/SimpleEmailServiceMailSenderTest.java
+++ b/spring-cloud-aws-ses/src/test/java/io/awspring/cloud/ses/SimpleEmailServiceMailSenderTest.java
@@ -111,6 +111,32 @@ class SimpleEmailServiceMailSenderTest {
 	}
 
 	@Test
+	void testSendSimpleMailWithNoTo() {
+		SesClient emailService = mock(SesClient.class);
+		SimpleEmailServiceMailSender mailSender = new SimpleEmailServiceMailSender(emailService);
+
+		// Not using createSimpleMailMessage as we don't want the to address set.
+		SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
+		simpleMailMessage.setFrom("sender@domain.com");
+		simpleMailMessage.setSubject("message subject");
+		simpleMailMessage.setText("message body");
+
+		simpleMailMessage.setBcc("bcc@domain.com");
+
+		ArgumentCaptor<SendEmailRequest> request = ArgumentCaptor.forClass(SendEmailRequest.class);
+		when(emailService.sendEmail(request.capture()))
+			.thenReturn(SendEmailResponse.builder().messageId("123").build());
+
+		mailSender.send(simpleMailMessage);
+
+		SendEmailRequest sendEmailRequest = request.getValue();
+		assertThat(sendEmailRequest.message().subject().data()).isEqualTo(simpleMailMessage.getSubject());
+		assertThat(sendEmailRequest.message().body().text().data()).isEqualTo(simpleMailMessage.getText());
+		assertThat(sendEmailRequest.destination().bccAddresses().get(0))
+			.isEqualTo(Objects.requireNonNull(simpleMailMessage.getBcc())[0]);
+	}
+
+	@Test
 	void testSendMultipleMails() {
 		SesClient emailService = mock(SesClient.class);
 		SimpleEmailServiceMailSender mailSender = new SimpleEmailServiceMailSender(emailService);


### PR DESCRIPTION
It's valid to send an email message through SES that doesn't have a to address (just cc or bcc).

Fixes: #1173

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Only copies to address across if it's been set, this allows emails to be sent that don't have a to address (only cc and/or bcc).


## :bulb: Motivation and Context
#1173 


## :green_heart: How did you test it?

Unit test added in the PR.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
