### PR TITLE
Abort method for S3OutputStream for ability to cancel the upload midway through

### DIFF
--- a/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/InMemoryBufferingS3OutputStream.java
+++ b/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/InMemoryBufferingS3OutputStream.java
@@ -118,6 +118,19 @@ public class InMemoryBufferingS3OutputStream extends S3OutputStream {
 	}
 
 	@Override
+	public void abort() {
+		synchronized (this.monitor) {
+			if (isClosed()) {
+				throw new IllegalStateException("Stream is already closed. Too late to abort.");
+			}
+			if (isMultiPartUpload()) {
+				abortMultiPartUpload(multipartUploadResponse);
+			}
+			outputStream = null;
+		}
+	}
+
+	@Override
 	public void close() {
 		synchronized (this.monitor) {
 			if (isClosed()) {

--- a/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3OutputStream.java
+++ b/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3OutputStream.java
@@ -29,5 +29,6 @@ public abstract class S3OutputStream extends OutputStream {
 	/**
 	 * Cancels the upload and cleans up temporal resources (temp files, partial multipart upload).
 	 */
-	public abstract void abort() throws IOException;
+	public void abort() throws IOException {
+	}
 }

--- a/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3OutputStream.java
+++ b/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3OutputStream.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.s3;
 
+import java.io.IOException;
 import java.io.OutputStream;
 
 /**
@@ -25,4 +26,8 @@ import java.io.OutputStream;
  */
 public abstract class S3OutputStream extends OutputStream {
 
+	/**
+	 * Cancels the upload and cleans up temporal resources (temp files, partial multipart upload).
+	 */
+	public abstract void abort() throws IOException;
 }

--- a/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/DiskBufferingS3OutputStreamTests.java
+++ b/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/DiskBufferingS3OutputStreamTests.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -70,4 +71,16 @@ class DiskBufferingS3OutputStreamTests {
 		}
 	}
 
+	@Test
+	void abortsWhenExplicitlyInvoked() throws IOException {
+		S3Client s3Client = mock(S3Client.class);
+
+		try (DiskBufferingS3OutputStream diskBufferingS3OutputStream = new DiskBufferingS3OutputStream(
+			new Location("bucket", "key"), s3Client, null)) {
+			diskBufferingS3OutputStream.write("hello".getBytes(StandardCharsets.UTF_8));
+			diskBufferingS3OutputStream.abort();
+		}
+
+		verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+	}
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
`S3OutputStream#abort` method added, allowing to cancel the upload and clean up the temporal resources.


## :bulb: Motivation and Context
#1199 

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
**javadoc updated. Is it sufficient?**
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
