### PR TITLE
Remove `throws IOException` that is never thrown in `S3Resource` methods

### DIFF
--- a/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Resource.java
+++ b/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Resource.java
@@ -130,7 +130,7 @@ public class S3Resource extends AbstractResource implements WritableResource {
 	}
 
 	@Override
-	public long contentLength() throws IOException {
+	public long contentLength() {
 		if (headMetadata == null) {
 			fetchMetadata();
 		}
@@ -138,7 +138,7 @@ public class S3Resource extends AbstractResource implements WritableResource {
 	}
 
 	@Override
-	public long lastModified() throws IOException {
+	public long lastModified() {
 		if (headMetadata == null) {
 			fetchMetadata();
 		}
@@ -146,7 +146,7 @@ public class S3Resource extends AbstractResource implements WritableResource {
 	}
 
 	@Override
-	public File getFile() throws IOException {
+	public File getFile() {
 		throw new UnsupportedOperationException("Amazon S3 resource can not be resolved to java.io.File objects.Use "
 				+ "getInputStream() to retrieve the contents of the object!");
 	}

--- a/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ResourceIntegrationTests.java
+++ b/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ResourceIntegrationTests.java
@@ -122,7 +122,7 @@ class S3ResourceIntegrationTests {
 	}
 
 	@TestAvailableOutputStreamProviders
-	void objectHasContentLength(S3OutputStreamProvider s3OutputStreamProvider) throws IOException {
+	void objectHasContentLength(S3OutputStreamProvider s3OutputStreamProvider) {
 		String contents = "test-file-content";
 		client.putObject(PutObjectRequest.builder().bucket("first-bucket").key("test-file.txt").build(),
 				RequestBody.fromString(contents));


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fix https://github.com/awspring/spring-cloud-aws/issues/1108 



## :bulb: Motivation and Context
I want to use `contentLength` or `lastModified` metadata of `S3Resource` to sort list of resources, but I need to catch IOException in the comparator.

IOException are declared but never thrown (it comes from parent class `AbstractResource`).

@maciejwalkowiak I think several classes in sns project need to be formatted. I can add them to the PR if you want.

## :green_heart: How did you test it?
x

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
