### PR TITLE
Add client customizer interface for each supported integration.

### DIFF
--- a/docs/src/main/asciidoc/cloudwatch.adoc
+++ b/docs/src/main/asciidoc/cloudwatch.adoc
@@ -40,3 +40,30 @@ Following configuration properties are available to configure CloudWatch integra
 |
 |The specific region for CloudWatch integration.
 |===
+
+=== Client Customization
+
+`CloudWatchAsyncClient` can be further customized by providing a bean of type `CloudWatchAsyncClientCustomizer`:
+
+[source,java]
+----
+@Bean
+CloudWatchAsyncClientCustomizer customizer() {
+	return builder -> {
+		builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+			c.apiCallTimeout(Duration.ofMillis(1500));
+		}));
+	};
+}
+----
+
+[WARNING]
+====
+`builder.overrideConfiguration(..)` replaces the configuration object, so always make sure to use `builder.overrideConfiguration().copy(c -> ..)` to configure only certain properties and keep the already pre-configured values for others.
+====
+
+`CloudWatchAsyncClientCustomizer` is a functional interface that enables configuring `CloudWatchAsyncClientBuilder` before the `CloudWatchAsyncClient` is built in auto-configuration.
+
+There can be multiple `CloudWatchAsyncClientCustomizer` beans present in single application context. `@Order(..)` annotation can be used to define the order of the execution.
+
+Note that `CloudWatchAsyncClientCustomizer` beans are applied **after** `AwsAsyncClientCustomizer` beans and therefore can overwrite previously set configurations.

--- a/docs/src/main/asciidoc/core.adoc
+++ b/docs/src/main/asciidoc/core.adoc
@@ -214,38 +214,49 @@ To simplify using services with AWS compatible APIs, or running applications aga
 
 === Customizing AWS Clients
 
-To configure an AWS client with custom HTTP client or `ClientOverrideConfiguration`, define a bean of type `AwsClientConfigurer` with a type parameter indicating configured client builder.
+Properties cover the most common configuration needs. When more advanced configuration is required, Spring Cloud AWS offers a set of customizer beans that can be implemented to customize AWS clients.
+
+There are two types of AWS clients - synchronous and asynchronous. Each Spring Cloud AWS integration use one or the other type:
+
+[cols="2*", options="header"]
+|===
+|client type
+|integrations
+
+|synchronous
+|DynamoDB, SES, SNS, Parameter Store, Secrets Manager, S3
+
+|asynchronous
+|SQS, CloudWatch
+|===
+
+To customize every synchronous client, provide a bean of type `AwsSyncClientCustomizer`. For example:
 
 [source,java,indent=0]
 ----
-import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
-import org.springframework.context.annotation.Bean;
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
 
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.http.SdkHttpClient;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
-import software.amazon.awssdk.services.sns.SnsClientBuilder;
-
-import java.time.Duration;
-
-@Configuration
-class S3AwsClientConfigurerConfiguration {
-
-    @Bean
-    AwsClientCustomizer<S3ClientBuilder> s3ClientBuilderAwsClientConfigurer() {
-        return new S3AwsClientClientConfigurer();
-    }
-
-    static class S3AwsClientClientConfigurer implements AwsClientCustomizer<S3ClientBuilder> {
-        @Override
-        public ClientOverrideConfiguration overrideConfiguration() {
-            return ClientOverrideConfiguration.builder().apiCallTimeout(Duration.ofMillis(500)).build();
-        }
-
-        @Override
-        public SdkHttpClient httpClient() {
-            return ApacheHttpClient.builder().connectionTimeout(Duration.ofMillis(1000)).build();
-        }
-    }
+@Bean
+AwsSyncClientCustomizer awsSyncClientCustomizer() {
+	return builder -> {
+		builder.httpClient(ApacheHttpClient.builder().connectionTimeout(Duration.ofSeconds(1)).build());
+	};
 }
+----
+
+To customize every asynchronous client, provide a bean of type `AwsAsyncClientCustomizer`. For example:
+
+[source,java,indent=0]
+----
+@Bean
+AwsAsyncClientCustomizer awsAsyncClientCustomizer() {
+	return builder -> {
+		builder.httpClient(NettyNioAsyncHttpClient.builder().connectionTimeout(Duration.ofSeconds(1)).build());
+	};
+}
+----
+
+There can be multiple customizer beans present in single application context and all of them will be used to configure AWS clients. If order of customizer matters, use `@Order` annotation on customizer beans.
+
+
 ----

--- a/docs/src/main/asciidoc/core.adoc
+++ b/docs/src/main/asciidoc/core.adoc
@@ -214,7 +214,7 @@ To simplify using services with AWS compatible APIs, or running applications aga
 
 === Customizing AWS Clients
 
-Properties cover the most common configuration needs. When more advanced configuration is required, Spring Cloud AWS offers a set of customizer beans that can be implemented to customize AWS clients.
+Properties cover the most common configuration needs. When more advanced configuration is required, Spring Cloud AWS offers a set of customizer interfaces that can be implemented to customize AWS clients.
 
 There are two types of AWS clients - synchronous and asynchronous. Each Spring Cloud AWS integration use one or the other type:
 
@@ -258,5 +258,5 @@ AwsAsyncClientCustomizer awsAsyncClientCustomizer() {
 
 There can be multiple customizer beans present in single application context and all of them will be used to configure AWS clients. If order of customizer matters, use `@Order` annotation on customizer beans.
 
+Client-specific customizations can be applied through client-specific customizer interfaces (for example `S3ClientCustomizer` for S3). See integrations documentation for details.
 
-----

--- a/docs/src/main/asciidoc/dynamodb.adoc
+++ b/docs/src/main/asciidoc/dynamodb.adoc
@@ -150,6 +150,33 @@ The Spring Boot Starter for DynamoDb provides the following configuration option
 | `spring.cloud.aws.dynamodb.dax.skip-host-name-verification` | Skips hostname verification in url. | No |
 |===
 
+=== Client Customization
+
+`DynamoDbClient` can be further customized by providing a bean of type `DynamoDbClientCustomizer`:
+
+[source,java]
+----
+@Bean
+DynamoDbClientCustomizer customizer() {
+	return builder -> {
+		builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+			c.apiCallTimeout(Duration.ofMillis(1500));
+		}));
+	};
+}
+----
+
+[WARNING]
+====
+`builder.overrideConfiguration(..)` replaces the configuration object, so always make sure to use `builder.overrideConfiguration().copy(c -> ..)` to configure only certain properties and keep the already pre-configured values for others.
+====
+
+`DynamoDbClientCustomizer` is a functional interface that enables configuring `DynamoDbClientBuilder` before the `DynamoDbClient` is built in auto-configuration.
+
+There can be multiple `DynamoDbClientCustomizer` beans present in single application context. `@Order(..)` annotation can be used to define the order of the execution.
+
+Note that `DynamoDbClientCustomizer` beans are applied **after** `AwsSyncClientCustomizer` beans and therefore can overwrite previously set configurations.
+
 === IAM Permissions
 
 Since it depends on how you will use DynamoDb integration providing a list of IAM policies would be pointless since least privilege model should be used.

--- a/docs/src/main/asciidoc/parameter-store.adoc
+++ b/docs/src/main/asciidoc/parameter-store.adoc
@@ -94,7 +94,7 @@ The starter automatically configures and registers a `SsmClient` bean in the Spr
 
 [source,java]
 ----
-import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Autowired;
 import software.amazon.awssdk.services.ssm.SsmClient;
 ...
 @Autowired
@@ -139,14 +139,14 @@ Note that this class must be listed under `org.springframework.boot.BootstrapReg
 org.springframework.boot.BootstrapRegistryInitializer=com.app.ParameterStoreBootstrapConfiguration
 ----
 
-If you want to use autoconfigured `SsmClient` but change underlying SDKClient or ClientOverrideConfiguration you will need to register bean of type `AwsClientConfigurerParameterStore`:
+If you want to use autoconfigured `SsmClient` but change underlying `SDKClient` or `ClientOverrideConfiguration` you will need to register bean of type `SsmClientCustomizer`:
 Autoconfiguration will configure `SsmClient` Bean with provided values after that, for example:
 
 [source,java]
 ----
 package com.app;
 
-import io.awspring.cloud.autoconfigure.config.parameterstore.AwsParameterStoreClientCustomizer;
+import io.awspring.cloud.autoconfigure.config.parameterstore.SsmClientCustomizer;
 import java.time.Duration;
 import org.springframework.boot.BootstrapRegistry;
 import org.springframework.boot.BootstrapRegistryInitializer;
@@ -159,20 +159,11 @@ class ParameterStoreBootstrapConfiguration implements BootstrapRegistryInitializ
 
 	@Override
 	public void initialize(BootstrapRegistry registry) {
-		registry.register(AwsParameterStoreClientCustomizer.class,
-            context -> new AwsParameterStoreClientCustomizer() {
-
-                @Override
-                public ClientOverrideConfiguration overrideConfiguration() {
-                    return ClientOverrideConfiguration.builder().apiCallTimeout(Duration.ofMillis(500))
-                            .build();
-                }
-
-                @Override
-                public SdkHttpClient httpClient() {
-                    return ApacheHttpClient.builder().connectionTimeout(Duration.ofMillis(1000)).build();
-                }
-            });
+		registry.register(SsmClientCustomizer.class, context -> (builder -> {
+			builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+				c.apiCallTimeout(Duration.ofMillis(2000));
+			}));
+		}));
     }
 }
 ----

--- a/docs/src/main/asciidoc/s3.adoc
+++ b/docs/src/main/asciidoc/s3.adoc
@@ -254,6 +254,33 @@ The Spring Boot Starter for S3 provides the following configuration options:
 | `spring.cloud.aws.s3.transfer-manager.follow-symbolic-links` | Specifies whether to follow symbolic links when traversing the file tree in `S3TransferManager#uploadDirectory` operation | No | `null` (falls back to SDK default)
 |===
 
+=== Client Customization
+
+`S3Client` can be further customized by providing a bean of type `S3ClientCustomizer`:
+
+[source,java]
+----
+@Bean
+S3ClientCustomizer customizer() {
+	return builder -> {
+		builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+			c.apiCallTimeout(Duration.ofMillis(1500));
+		}));
+	};
+}
+----
+
+[WARNING]
+====
+`builder.overrideConfiguration(..)` replaces the configuration object, so always make sure to use `builder.overrideConfiguration().copy(c -> ..)` to configure only certain properties and keep the already pre-configured values for others.
+====
+
+`S3ClientCustomizer` is a functional interface that enables configuring `S3ClientBuilder` before the `S3Client` is built in auto-configuration.
+
+There can be multiple `S3ClientCustomizer` beans present in single application context. `@Order(..)` annotation can be used to define the order of the execution.
+
+Note that `S3ClientCustomizer` beans are applied **after** `AwsSyncClientCustomizer` beans and therefore can overwrite previously set configurations.
+
 === IAM Permissions
 
 Following IAM permissions are required by Spring Cloud AWS:

--- a/docs/src/main/asciidoc/secrets-manager.adoc
+++ b/docs/src/main/asciidoc/secrets-manager.adoc
@@ -145,7 +145,7 @@ The starter automatically configures and registers a `SecretsManagerClient` bean
 
 [source,java]
 ----
-import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Autowired;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
 ...
@@ -191,14 +191,14 @@ Note that this class must be listed under `org.springframework.boot.BootstrapReg
 org.springframework.boot.BootstrapRegistryInitializer=com.app.SecretsManagerBootstrapConfiguration
 ----
 
-If you want to use autoconfigured `SecretsManagerClient` but change underlying SDKClient or ClientOverrideConfiguration you will need to register bean of type `AwsClientConfigurerSecretsManager`:
+If you want to use autoconfigured `SecretsManagerClient` but change underlying SDKClient or `ClientOverrideConfiguration` you will need to register bean of type `SecretsManagerClientCustomizer`:
 Autoconfiguration will configure `SecretsManagerClient` Bean with provided values after that, for example:
 
 [source,java]
 ----
 package com.app;
 
-import io.awspring.cloud.autoconfigure.config.secretsmanager.AwsSecretsManagerClientCustomizer;
+import io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerClientCustomizer;
 import java.time.Duration;
 import org.springframework.boot.BootstrapRegistry;
 import org.springframework.boot.BootstrapRegistryInitializer;
@@ -211,20 +211,11 @@ class SecretsManagerBootstrapConfiguration implements BootstrapRegistryInitializ
 
 	@Override
 	public void initialize(BootstrapRegistry registry) {
-		registry.register(AwsSecretsManagerClientCustomizer.class,
-            context -> new AwsSecretsManagerClientCustomizer() {
-
-                @Override
-                public ClientOverrideConfiguration overrideConfiguration() {
-                    return ClientOverrideConfiguration.builder().apiCallTimeout(Duration.ofMillis(500))
-                            .build();
-                }
-
-                @Override
-                public SdkHttpClient httpClient() {
-                    return ApacheHttpClient.builder().connectionTimeout(Duration.ofMillis(1000)).build();
-                }
-            });
+		registry.register(SecretsManagerClientCustomizer.class, context -> (builder -> {
+			builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+				c.apiCallTimeout(Duration.ofMillis(2001));
+			}));
+		}));
 	}
 }
 ----

--- a/docs/src/main/asciidoc/ses.adoc
+++ b/docs/src/main/asciidoc/ses.adoc
@@ -163,6 +163,33 @@ spring.cloud.aws.ses.from-arn=arn:aws:ses:eu-west-1:123456789012:identity/exampl
 spring.cloud.aws.ses.configuration-set-name=ConfigSet
 ----
 
+=== Client Customization
+
+`SesClient` can be further customized by providing a bean of type `SesClientCustomizer`:
+
+[source,java]
+----
+@Bean
+SesClientCustomizer customizer() {
+	return builder -> {
+		builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+			c.apiCallTimeout(Duration.ofMillis(1500));
+		}));
+	};
+}
+----
+
+[WARNING]
+====
+`builder.overrideConfiguration(..)` replaces the configuration object, so always make sure to use `builder.overrideConfiguration().copy(c -> ..)` to configure only certain properties and keep the already pre-configured values for others.
+====
+
+`SesClientCustomizer` is a functional interface that enables configuring `SesClientBuilder` before the `SesClient` is built in auto-configuration.
+
+There can be multiple `SesClientCustomizer` beans present in single application context. `@Order(..)` annotation can be used to define the order of the execution.
+
+Note that `SesClientCustomizer` beans are applied **after** `AwsSyncClientCustomizer` beans and therefore can overwrite previously set configurations.
+
 === IAM Permissions
 Following IAM permissions are required by Spring Cloud AWS:
 

--- a/docs/src/main/asciidoc/sns.adoc
+++ b/docs/src/main/asciidoc/sns.adoc
@@ -228,6 +228,33 @@ The Spring Boot Starter for SNS provides the following configuration options:
 | `spring.cloud.aws.sns.region` | Configures region used by `SnsClient`. | No | `eu-west-1`
 |===
 
+=== Client Customization
+
+`SnsClient` can be further customized by providing a bean of type `SnsClientCustomizer`:
+
+[source,java]
+----
+@Bean
+SnsClientCustomizer customizer() {
+	return builder -> {
+		builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+			c.apiCallTimeout(Duration.ofMillis(1500));
+		}));
+	};
+}
+----
+
+[WARNING]
+====
+`builder.overrideConfiguration(..)` replaces the configuration object, so always make sure to use `builder.overrideConfiguration().copy(c -> ..)` to configure only certain properties and keep the already pre-configured values for others.
+====
+
+`SnsClientCustomizer` is a functional interface that enables configuring `SnsClientBuilder` before the `SnsClient` is built in auto-configuration.
+
+There can be multiple `SnsClientCustomizer` beans present in single application context. `@Order(..)` annotation can be used to define the order of the execution.
+
+Note that `SnsClientCustomizer` beans are applied **after** `AwsSyncClientCustomizer` beans and therefore can overwrite previously set configurations.
+
 === IAM Permissions
 Following IAM permissions are required by Spring Cloud AWS:
 
@@ -237,7 +264,7 @@ Following IAM permissions are required by Spring Cloud AWS:
 | To publish notification you will also need | `sns:ListTopics`
 | To use Annotation-driven HTTP notification endpoint | `sns:ConfirmSubscription`
 | For resolving topic name to ARN | `sns:CreateTopic`
-| For validating topic existence by ARN | `sns:GetTopicAttributes` 
+| For validating topic existence by ARN | `sns:GetTopicAttributes`
 |===
 
 Sample IAM policy granting access to SNS:

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -1682,6 +1682,34 @@ When providing a custom executor, it's important that it's configured to support
 IMPORTANT: To avoid unnecessary thread hopping between blocking components, a `MessageExecutionThreadFactory` MUST be set to the executor.
 
 
+=== Client Customization
+
+`SqsAsyncClient` can be further customized by providing a bean of type `SqsAsyncClientCustomizer`:
+
+[source,java]
+----
+@Bean
+SqsAsyncClientCustomizer customizer() {
+	return builder -> {
+		builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+			c.apiCallTimeout(Duration.ofMillis(1500));
+		}));
+	};
+}
+----
+
+[WARNING]
+====
+`builder.overrideConfiguration(..)` replaces the configuration object, so always make sure to use `builder.overrideConfiguration().copy(c -> ..)` to configure only certain properties and keep the already pre-configured values for others.
+====
+
+`SqsAsyncClientCustomizer` is a functional interface that enables configuring `SqsAsyncClientBuilder` before the `SqsAsyncClient` is built in auto-configuration.
+
+There can be multiple `SqsAsyncClientCustomizer` beans present in single application context. `@Order(..)` annotation can be used to define the order of the execution.
+
+Note that `SqsAsyncClientCustomizer` beans are applied **after** `AwsAsyncClientCustomizer` beans and therefore can overwrite previously set configurations.
+
+
 === IAM Permissions
 Following IAM permissions are required by Spring Cloud AWS SQS:
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/AwsAsyncClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/AwsAsyncClientCustomizer.java
@@ -15,21 +15,21 @@
  */
 package io.awspring.cloud.autoconfigure;
 
-import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
+import software.amazon.awssdk.awscore.client.builder.AwsAsyncClientBuilder;
 
 /**
- * Callback interface that can be used to customize a {@link AwsSyncClientBuilder}.
+ * Callback interface that can be used to customize a {@link AwsAsyncClientBuilder}.
  * <p>
- * It gets applied to every configured synchronous AWS client bean.
+ * It gets applied to every configured asynchronous AWS client bean.
  *
  * @author Maciej Walkowiak
  * @since 3.3.0
  */
-public interface CommonAwsSyncClientCustomizer {
+public interface AwsAsyncClientCustomizer {
 	/**
-	 * Callback to customize a {@link AwsSyncClientBuilder} instance.
+	 * Callback to customize a {@link AwsAsyncClientBuilder} instance.
 	 *
 	 * @param builder the client builder to customize
 	 */
-	void customize(AwsSyncClientBuilder<?, ?> builder);
+	void customize(AwsAsyncClientBuilder<?, ?> builder);
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/AwsClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/AwsClientCustomizer.java
@@ -13,16 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.awspring.cloud.testcontainers;
+package io.awspring.cloud.autoconfigure;
 
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 
-/**
- * Provides convenient way to construct AWS SDK clients.
- *
- * @author Maciej Walkowiak
- * @since 3.2.0
- */
-public interface AwsClientFactory {
-	<CLIENT, BUILDER extends AwsClientBuilder<BUILDER, CLIENT>> CLIENT create(BUILDER builder);
+public interface AwsClientCustomizer<T extends AwsClientBuilder<?, ?>> {
+	void customize(T builder);
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/AwsClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/AwsClientCustomizer.java
@@ -17,6 +17,19 @@ package io.awspring.cloud.autoconfigure;
 
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 
+/**
+ * Base callback interface to be extended by customizers for specific AWS clients.
+ *
+ * @param <T> - type of AWS client builder to customize
+ * @author Maciej Walkowiak
+ * @since 3.3.0
+ */
 public interface AwsClientCustomizer<T extends AwsClientBuilder<?, ?>> {
+
+	/**
+	 * Callback to customize an instance of AWS client builder.
+	 *
+	 * @param builder the client builder to customize
+	 */
 	void customize(T builder);
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/AwsSyncClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/AwsSyncClientCustomizer.java
@@ -15,21 +15,21 @@
  */
 package io.awspring.cloud.autoconfigure;
 
-import software.amazon.awssdk.awscore.client.builder.AwsAsyncClientBuilder;
+import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
 
 /**
- * Callback interface that can be used to customize a {@link AwsAsyncClientBuilder}.
+ * Callback interface that can be used to customize a {@link AwsSyncClientBuilder}.
  * <p>
- * It gets applied to every configured asynchronous AWS client bean.
+ * It gets applied to every configured synchronous AWS client bean.
  *
  * @author Maciej Walkowiak
  * @since 3.3.0
  */
-public interface CommonAwsAsyncClientCustomizer {
+public interface AwsSyncClientCustomizer {
 	/**
-	 * Callback to customize a {@link AwsAsyncClientBuilder} instance.
+	 * Callback to customize a {@link AwsSyncClientBuilder} instance.
 	 *
 	 * @param builder the client builder to customize
 	 */
-	void customize(AwsAsyncClientBuilder<?, ?> builder);
+	void customize(AwsSyncClientBuilder<?, ?> builder);
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/CommonAwsAsyncClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/CommonAwsAsyncClientCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.awspring.cloud.autoconfigure.dynamodb;
+package io.awspring.cloud.autoconfigure;
 
-import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
-import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+import software.amazon.awssdk.awscore.client.builder.AwsAsyncClientBuilder;
 
 /**
- * Callback interface that can be used to customize a {@link DynamoDbClientBuilder}.
+ * Callback interface that can be used to customize a {@link AwsAsyncClientBuilder}.
+ * <p>
+ * It gets applied to every configured asynchronous AWS client bean.
  *
  * @author Maciej Walkowiak
  * @since 3.2.1
  */
-@FunctionalInterface
-public interface DynamoDbClientCustomizer extends AwsClientCustomizer<DynamoDbClientBuilder> {
+public interface CommonAwsAsyncClientCustomizer {
+	/**
+	 * Callback to customize a {@link AwsAsyncClientBuilder} instance.
+	 *
+	 * @param builder the client builder to customize
+	 */
+	void customize(AwsAsyncClientBuilder<?, ?> builder);
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/CommonAwsAsyncClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/CommonAwsAsyncClientCustomizer.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.awscore.client.builder.AwsAsyncClientBuilder;
  * It gets applied to every configured asynchronous AWS client bean.
  *
  * @author Maciej Walkowiak
- * @since 3.2.1
+ * @since 3.3.0
  */
 public interface CommonAwsAsyncClientCustomizer {
 	/**

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/CommonAwsSyncClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/CommonAwsSyncClientCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.awspring.cloud.autoconfigure.dynamodb;
+package io.awspring.cloud.autoconfigure;
 
-import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
 import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
 
 /**
- * Callback interface that can be used to customize a {@link DynamoDbClientBuilder}.
+ * Callback interface that can be used to customize a {@link AwsSyncClientBuilder}.
+ * <p>
+ * It gets applied to every configured synchronous AWS client bean.
  *
  * @author Maciej Walkowiak
  * @since 3.2.1
  */
-@FunctionalInterface
-public interface DynamoDbClientCustomizer extends AwsClientCustomizer<DynamoDbClientBuilder> {
+public interface CommonAwsSyncClientCustomizer {
+	/**
+	 * Callback to customize a {@link AwsSyncClientBuilder} instance.
+	 *
+	 * @param builder the client builder to customize
+	 */
+	void customize(AwsSyncClientBuilder<?, ?> builder);
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/CommonAwsSyncClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/CommonAwsSyncClientCustomizer.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
  * It gets applied to every configured synchronous AWS client bean.
  *
  * @author Maciej Walkowiak
- * @since 3.2.1
+ * @since 3.3.0
  */
 public interface CommonAwsSyncClientCustomizer {
 	/**

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/AwsParameterStoreClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/AwsParameterStoreClientCustomizer.java
@@ -19,8 +19,10 @@ import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
 import software.amazon.awssdk.services.ssm.SsmClientBuilder;
 
 /**
+ * @deprecated use {@link SsmClientCustomizer}
  * @author Matej Nedic
  * @since 3.0.0
  */
+@Deprecated(since = "3.3.0", forRemoval = true)
 public interface AwsParameterStoreClientCustomizer extends AwsClientCustomizer<SsmClientBuilder> {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.autoconfigure.config.parameterstore;
 
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
 import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
@@ -51,9 +52,12 @@ public class ParameterStoreAutoConfiguration {
 	public SsmClient ssmClient(ParameterStoreProperties properties,
 			AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 			ObjectProvider<AwsClientCustomizer<SsmClientBuilder>> customizers,
+			ObjectProvider<SsmClientCustomizer> ssmClientCustomizers,
+			ObjectProvider<AwsSyncClientCustomizer> awsSyncClientCustomizers,
 			ObjectProvider<AwsConnectionDetails> connectionDetails) {
-		return awsClientBuilderConfigurer.configure(SsmClient.builder(), properties, connectionDetails.getIfAvailable(),
-				customizers.getIfAvailable()).build();
+		return awsClientBuilderConfigurer.configureSyncClient(SsmClient.builder(), properties,
+				connectionDetails.getIfAvailable(), customizers.getIfAvailable(), ssmClientCustomizers.orderedStream(),
+				awsSyncClientCustomizers.orderedStream()).build();
 	}
 
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLocationResolver.java
@@ -100,6 +100,10 @@ public class ParameterStoreConfigDataLocationResolver
 			if (configurer != null) {
 				AwsClientCustomizer.apply(configurer, builder);
 			}
+			SsmClientCustomizer ssmClientCustomizer = context.get(SsmClientCustomizer.class);
+			if (ssmClientCustomizer != null) {
+				ssmClientCustomizer.customize(builder);
+			}
 		}
 		catch (IllegalStateException e) {
 			log.debug("Bean of type AwsClientConfigurerParameterStore is not registered: " + e.getMessage());

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLocationResolver.java
@@ -101,18 +101,31 @@ public class ParameterStoreConfigDataLocationResolver
 			if (configurer != null) {
 				AwsClientCustomizer.apply(configurer, builder);
 			}
+		}
+		catch (IllegalStateException e) {
+			log.debug("Bean of type AwsParameterStoreClientCustomizer is not registered: " + e.getMessage());
+		}
+
+		try {
 			AwsSyncClientCustomizer awsSyncClientCustomizer = context.get(AwsSyncClientCustomizer.class);
 			if (awsSyncClientCustomizer != null) {
 				awsSyncClientCustomizer.customize(builder);
 			}
+		}
+		catch (IllegalStateException e) {
+			log.debug("Bean of type AwsSyncClientCustomizer is not registered: " + e.getMessage());
+		}
+
+		try {
 			SsmClientCustomizer ssmClientCustomizer = context.get(SsmClientCustomizer.class);
 			if (ssmClientCustomizer != null) {
 				ssmClientCustomizer.customize(builder);
 			}
 		}
 		catch (IllegalStateException e) {
-			log.debug("Bean of type AwsClientConfigurerParameterStore is not registered: " + e.getMessage());
+			log.debug("Bean of type SsmClientCustomizer is not registered: " + e.getMessage());
 		}
+
 		return builder.build();
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLocationResolver.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.autoconfigure.config.parameterstore;
 
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
 import io.awspring.cloud.autoconfigure.config.AbstractAwsConfigDataLocationResolver;
 import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsProperties;
@@ -99,6 +100,10 @@ public class ParameterStoreConfigDataLocationResolver
 			AwsParameterStoreClientCustomizer configurer = context.get(AwsParameterStoreClientCustomizer.class);
 			if (configurer != null) {
 				AwsClientCustomizer.apply(configurer, builder);
+			}
+			AwsSyncClientCustomizer awsSyncClientCustomizer = context.get(AwsSyncClientCustomizer.class);
+			if (awsSyncClientCustomizer != null) {
+				awsSyncClientCustomizer.customize(builder);
 			}
 			SsmClientCustomizer ssmClientCustomizer = context.get(SsmClientCustomizer.class);
 			if (ssmClientCustomizer != null) {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/SsmClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/SsmClientCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2024 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.awspring.cloud.testcontainers;
+package io.awspring.cloud.autoconfigure.config.parameterstore;
 
-import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
+import software.amazon.awssdk.services.ssm.SsmClientBuilder;
 
-/**
- * Provides convenient way to construct AWS SDK clients.
- *
- * @author Maciej Walkowiak
- * @since 3.2.0
- */
-public interface AwsClientFactory {
-	<CLIENT, BUILDER extends AwsClientBuilder<BUILDER, CLIENT>> CLIENT create(BUILDER builder);
+@FunctionalInterface
+public interface SsmClientCustomizer extends AwsClientCustomizer<SsmClientBuilder> {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/SsmClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/SsmClientCustomizer.java
@@ -18,6 +18,12 @@ package io.awspring.cloud.autoconfigure.config.parameterstore;
 import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
 import software.amazon.awssdk.services.ssm.SsmClientBuilder;
 
+/**
+ * Callback interface that can be used to customize a {@link SsmClientBuilder}.
+ *
+ * @author Maciej Walkowiak
+ * @since 3.3.0
+ */
 @FunctionalInterface
 public interface SsmClientCustomizer extends AwsClientCustomizer<SsmClientBuilder> {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/AwsSecretsManagerClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/AwsSecretsManagerClientCustomizer.java
@@ -19,8 +19,10 @@ import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
 
 /**
+ * @deprecated use {@link SecretsManagerClientCustomizer}
  * @author Matej Nedic
  * @since 3.0.0
  */
+@Deprecated(since = "3.3.0", forRemoval = true)
 public interface AwsSecretsManagerClientCustomizer extends AwsClientCustomizer<SecretsManagerClientBuilder> {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerAutoConfiguration.java
@@ -15,8 +15,8 @@
  */
 package io.awspring.cloud.autoconfigure.config.secretsmanager;
 
-import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
+import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
 import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.autoconfigure.config.secretsmanager;
 
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
 import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;
@@ -51,8 +52,10 @@ public class SecretsManagerAutoConfiguration {
 			AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 			ObjectProvider<AwsClientCustomizer<SecretsManagerClientBuilder>> customizer,
 			ObjectProvider<AwsConnectionDetails> connectionDetails,
-			ObjectProvider<SecretsManagerClientCustomizer> customizers) {
-		return awsClientBuilderConfigurer.configure(SecretsManagerClient.builder(), properties,
-				connectionDetails.getIfAvailable(), customizer.getIfAvailable(), customizers.orderedStream()).build();
+			ObjectProvider<SecretsManagerClientCustomizer> secretsManagerClientCustomizers,
+			ObjectProvider<AwsSyncClientCustomizer> awsSyncClientCustomizers) {
+		return awsClientBuilderConfigurer.configureSyncClient(SecretsManagerClient.builder(), properties,
+				connectionDetails.getIfAvailable(), customizer.getIfAvailable(),
+				secretsManagerClientCustomizers.orderedStream(), awsSyncClientCustomizers.orderedStream()).build();
 	}
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerAutoConfiguration.java
@@ -50,8 +50,9 @@ public class SecretsManagerAutoConfiguration {
 	public SecretsManagerClient secretsManagerClient(SecretsManagerProperties properties,
 			AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 			ObjectProvider<AwsClientCustomizer<SecretsManagerClientBuilder>> customizer,
-			ObjectProvider<AwsConnectionDetails> connectionDetails) {
+			ObjectProvider<AwsConnectionDetails> connectionDetails,
+			ObjectProvider<SecretsManagerClientCustomizer> customizers) {
 		return awsClientBuilderConfigurer.configure(SecretsManagerClient.builder(), properties,
-				connectionDetails.getIfAvailable(), customizer.getIfAvailable()).build();
+				connectionDetails.getIfAvailable(), customizer.getIfAvailable(), customizers.orderedStream()).build();
 	}
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerClientCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2024 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.awspring.cloud.testcontainers;
+package io.awspring.cloud.autoconfigure.config.secretsmanager;
 
-import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
 
-/**
- * Provides convenient way to construct AWS SDK clients.
- *
- * @author Maciej Walkowiak
- * @since 3.2.0
- */
-public interface AwsClientFactory {
-	<CLIENT, BUILDER extends AwsClientBuilder<BUILDER, CLIENT>> CLIENT create(BUILDER builder);
+@FunctionalInterface
+public interface SecretsManagerClientCustomizer extends AwsClientCustomizer<SecretsManagerClientBuilder> {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerClientCustomizer.java
@@ -18,6 +18,12 @@ package io.awspring.cloud.autoconfigure.config.secretsmanager;
 import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
 
+/**
+ * Callback interface that can be used to customize a {@link SecretsManagerClientBuilder}.
+ *
+ * @author Maciej Walkowiak
+ * @since 3.3.0
+ */
 @FunctionalInterface
 public interface SecretsManagerClientCustomizer extends AwsClientCustomizer<SecretsManagerClientBuilder> {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLocationResolver.java
@@ -104,6 +104,10 @@ public class SecretsManagerConfigDataLocationResolver
 			if (configurer != null) {
 				AwsClientCustomizer.apply(configurer, builder);
 			}
+			SecretsManagerClientCustomizer clientCustomizer = context.get(SecretsManagerClientCustomizer.class);
+			if (clientCustomizer != null) {
+				clientCustomizer.customize(builder);
+			}
 		}
 		catch (IllegalStateException e) {
 			log.debug("Bean of type AwsClientConfigurerSecretsManager is not registered: " + e.getMessage());

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLocationResolver.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.autoconfigure.config.secretsmanager;
 
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
 import io.awspring.cloud.autoconfigure.config.AbstractAwsConfigDataLocationResolver;
 import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsProperties;
@@ -104,9 +105,14 @@ public class SecretsManagerConfigDataLocationResolver
 			if (configurer != null) {
 				AwsClientCustomizer.apply(configurer, builder);
 			}
-			SecretsManagerClientCustomizer clientCustomizer = context.get(SecretsManagerClientCustomizer.class);
-			if (clientCustomizer != null) {
-				clientCustomizer.customize(builder);
+			AwsSyncClientCustomizer awsSyncClientCustomizer = context.get(AwsSyncClientCustomizer.class);
+			if (awsSyncClientCustomizer != null) {
+				awsSyncClientCustomizer.customize(builder);
+			}
+			SecretsManagerClientCustomizer secretsManagerClientCustomizer = context
+					.get(SecretsManagerClientCustomizer.class);
+			if (secretsManagerClientCustomizer != null) {
+				secretsManagerClientCustomizer.customize(builder);
 			}
 		}
 		catch (IllegalStateException e) {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLocationResolver.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerConfigDataLocationResolver.java
@@ -105,10 +105,22 @@ public class SecretsManagerConfigDataLocationResolver
 			if (configurer != null) {
 				AwsClientCustomizer.apply(configurer, builder);
 			}
+		}
+		catch (IllegalStateException e) {
+			log.debug("Bean of type AwsParameterStoreClientCustomizer is not registered: " + e.getMessage());
+		}
+
+		try {
 			AwsSyncClientCustomizer awsSyncClientCustomizer = context.get(AwsSyncClientCustomizer.class);
 			if (awsSyncClientCustomizer != null) {
 				awsSyncClientCustomizer.customize(builder);
 			}
+		}
+		catch (IllegalStateException e) {
+			log.debug("Bean of type AwsSyncClientCustomizer is not registered: " + e.getMessage());
+		}
+
+		try {
 			SecretsManagerClientCustomizer secretsManagerClientCustomizer = context
 					.get(SecretsManagerClientCustomizer.class);
 			if (secretsManagerClientCustomizer != null) {
@@ -116,8 +128,9 @@ public class SecretsManagerConfigDataLocationResolver
 			}
 		}
 		catch (IllegalStateException e) {
-			log.debug("Bean of type AwsClientConfigurerSecretsManager is not registered: " + e.getMessage());
+			log.debug("Bean of type SecretsManagerClientCustomizer is not registered: " + e.getMessage());
 		}
+
 		return builder.build();
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsClientBuilderConfigurer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsClientBuilderConfigurer.java
@@ -15,10 +15,10 @@
  */
 package io.awspring.cloud.autoconfigure.core;
 
+import io.awspring.cloud.autoconfigure.AwsAsyncClientCustomizer;
 import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
 import io.awspring.cloud.autoconfigure.AwsClientProperties;
-import io.awspring.cloud.autoconfigure.CommonAwsAsyncClientCustomizer;
-import io.awspring.cloud.autoconfigure.CommonAwsSyncClientCustomizer;
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
 import io.awspring.cloud.core.SpringCloudClientConfiguration;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -103,7 +103,7 @@ public class AwsClientBuilderConfigurer {
 	public <T extends AwsClientBuilder<T, ?>> T configureSyncClient(T builder,
 			@Nullable AwsClientProperties clientProperties, @Nullable AwsConnectionDetails connectionDetails,
 			@Nullable Stream<? extends AwsClientCustomizer<T>> clientBuilderCustomizer,
-			@Nullable Stream<? extends CommonAwsSyncClientCustomizer> commonCustomizers) {
+			@Nullable Stream<? extends AwsSyncClientCustomizer> commonCustomizers) {
 		return configureSyncClient(builder, clientProperties, connectionDetails, null, clientBuilderCustomizer,
 				commonCustomizers);
 	}
@@ -111,7 +111,7 @@ public class AwsClientBuilderConfigurer {
 	public <T extends AwsClientBuilder<T, ?>> T configureAsyncClient(T builder,
 			@Nullable AwsClientProperties clientProperties, @Nullable AwsConnectionDetails connectionDetails,
 			@Nullable Stream<? extends AwsClientCustomizer<T>> clientBuilderCustomizer,
-			@Nullable Stream<? extends CommonAwsAsyncClientCustomizer> commonCustomizers) {
+			@Nullable Stream<? extends AwsAsyncClientCustomizer> commonCustomizers) {
 		return configureAsyncClient(builder, clientProperties, connectionDetails, null, clientBuilderCustomizer,
 				commonCustomizers);
 	}
@@ -133,7 +133,7 @@ public class AwsClientBuilderConfigurer {
 			@Nullable AwsClientProperties clientProperties, @Nullable AwsConnectionDetails connectionDetails,
 			@Nullable io.awspring.cloud.autoconfigure.core.AwsClientCustomizer<T> customizer,
 			@Nullable Stream<? extends AwsClientCustomizer<T>> clientBuilderCustomizer,
-			@Nullable Stream<? extends CommonAwsSyncClientCustomizer> commonBuilderCustomizer) {
+			@Nullable Stream<? extends AwsSyncClientCustomizer> commonBuilderCustomizer) {
 		T result = configure(builder, clientProperties, connectionDetails, customizer);
 		if (commonBuilderCustomizer != null && builder instanceof AwsSyncClientBuilder<?, ?>) {
 			commonBuilderCustomizer.forEach(it -> it.customize((AwsSyncClientBuilder<?, ?>) result));
@@ -149,7 +149,7 @@ public class AwsClientBuilderConfigurer {
 			@Nullable AwsClientProperties clientProperties, @Nullable AwsConnectionDetails connectionDetails,
 			@Nullable io.awspring.cloud.autoconfigure.core.AwsClientCustomizer<T> customizer,
 			@Nullable Stream<? extends AwsClientCustomizer<T>> clientBuilderCustomizer,
-			@Nullable Stream<? extends CommonAwsAsyncClientCustomizer> commonBuilderCustomizer) {
+			@Nullable Stream<? extends AwsAsyncClientCustomizer> commonBuilderCustomizer) {
 		T result = configure(builder, clientProperties, connectionDetails, customizer);
 		if (commonBuilderCustomizer != null && builder instanceof AwsAsyncClientBuilder<?, ?>) {
 			commonBuilderCustomizer.forEach(it -> it.customize((AwsAsyncClientBuilder<?, ?>) result));

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsClientCustomizer.java
@@ -27,7 +27,7 @@ import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
  * @author Matej Nedić
  * @since 3.0.0
  */
-@Deprecated
+@Deprecated(since = "3.3.0", forRemoval = true)
 public interface AwsClientCustomizer<T> {
 
 	@Nullable

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/AwsClientCustomizer.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
  * @author Matej Nedić
  * @since 3.0.0
  */
+@Deprecated
 public interface AwsClientCustomizer<T> {
 
 	@Nullable

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.autoconfigure.dynamodb;
 
+import io.awspring.cloud.autoconfigure.CommonAwsSyncClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
 import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;
@@ -115,9 +116,11 @@ public class DynamoDbAutoConfiguration {
 		public DynamoDbClient dynamoDbClient(AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 				ObjectProvider<AwsClientCustomizer<DynamoDbClientBuilder>> configurer,
 				ObjectProvider<AwsConnectionDetails> connectionDetails, DynamoDbProperties properties,
-				ObjectProvider<DynamoDbClientCustomizer> customizer) {
-			return awsClientBuilderConfigurer.configure(DynamoDbClient.builder(), properties,
-					connectionDetails.getIfAvailable(), configurer.getIfAvailable(), customizer.orderedStream()).build();
+				ObjectProvider<DynamoDbClientCustomizer> customizer,
+				ObjectProvider<CommonAwsSyncClientCustomizer> commonAwsClientCustomizers) {
+			return awsClientBuilderConfigurer.configureSyncClient(DynamoDbClient.builder(), properties,
+					connectionDetails.getIfAvailable(), configurer.getIfAvailable(), customizer.orderedStream(),
+					commonAwsClientCustomizers.orderedStream()).build();
 		}
 
 	}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfiguration.java
@@ -114,9 +114,10 @@ public class DynamoDbAutoConfiguration {
 		@Bean
 		public DynamoDbClient dynamoDbClient(AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 				ObjectProvider<AwsClientCustomizer<DynamoDbClientBuilder>> configurer,
-				ObjectProvider<AwsConnectionDetails> connectionDetails, DynamoDbProperties properties) {
+				ObjectProvider<AwsConnectionDetails> connectionDetails, DynamoDbProperties properties,
+				ObjectProvider<DynamoDbClientCustomizer> customizer) {
 			return awsClientBuilderConfigurer.configure(DynamoDbClient.builder(), properties,
-					connectionDetails.getIfAvailable(), configurer.getIfAvailable()).build();
+					connectionDetails.getIfAvailable(), configurer.getIfAvailable(), customizer.orderedStream()).build();
 		}
 
 	}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfiguration.java
@@ -15,7 +15,7 @@
  */
 package io.awspring.cloud.autoconfigure.dynamodb;
 
-import io.awspring.cloud.autoconfigure.CommonAwsSyncClientCustomizer;
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
 import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;
@@ -116,11 +116,11 @@ public class DynamoDbAutoConfiguration {
 		public DynamoDbClient dynamoDbClient(AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 				ObjectProvider<AwsClientCustomizer<DynamoDbClientBuilder>> configurer,
 				ObjectProvider<AwsConnectionDetails> connectionDetails, DynamoDbProperties properties,
-				ObjectProvider<DynamoDbClientCustomizer> customizer,
-				ObjectProvider<CommonAwsSyncClientCustomizer> commonAwsClientCustomizers) {
+				ObjectProvider<DynamoDbClientCustomizer> dynamoDbClientCustomizers,
+				ObjectProvider<AwsSyncClientCustomizer> awsSyncClientCustomizers) {
 			return awsClientBuilderConfigurer.configureSyncClient(DynamoDbClient.builder(), properties,
-					connectionDetails.getIfAvailable(), configurer.getIfAvailable(), customizer.orderedStream(),
-					commonAwsClientCustomizers.orderedStream()).build();
+					connectionDetails.getIfAvailable(), configurer.getIfAvailable(),
+					dynamoDbClientCustomizers.orderedStream(), awsSyncClientCustomizers.orderedStream()).build();
 		}
 
 	}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbClientCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2024 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.awspring.cloud.testcontainers;
+package io.awspring.cloud.autoconfigure.dynamodb;
 
-import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
 
-/**
- * Provides convenient way to construct AWS SDK clients.
- *
- * @author Maciej Walkowiak
- * @since 3.2.0
- */
-public interface AwsClientFactory {
-	<CLIENT, BUILDER extends AwsClientBuilder<BUILDER, CLIENT>> CLIENT create(BUILDER builder);
+@FunctionalInterface
+public interface DynamoDbClientCustomizer extends AwsClientCustomizer<DynamoDbClientBuilder> {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbClientCustomizer.java
@@ -16,7 +16,6 @@
 package io.awspring.cloud.autoconfigure.dynamodb;
 
 import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
-import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
 
 /**

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbClientCustomizer.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
  * Callback interface that can be used to customize a {@link DynamoDbClientBuilder}.
  *
  * @author Maciej Walkowiak
- * @since 3.2.1
+ * @since 3.3.0
  */
 @FunctionalInterface
 public interface DynamoDbClientCustomizer extends AwsClientCustomizer<DynamoDbClientBuilder> {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchAsyncClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchAsyncClientCustomizer.java
@@ -18,6 +18,12 @@ package io.awspring.cloud.autoconfigure.metrics;
 import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClientBuilder;
 
+/**
+ * Callback interface that can be used to customize a {@link CloudWatchAsyncClientBuilder}.
+ *
+ * @author Maciej Walkowiak
+ * @since 3.3.0
+ */
 @FunctionalInterface
 public interface CloudWatchAsyncClientCustomizer extends AwsClientCustomizer<CloudWatchAsyncClientBuilder> {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchAsyncClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchAsyncClientCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2024 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.awspring.cloud.testcontainers;
+package io.awspring.cloud.autoconfigure.metrics;
 
-import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClientBuilder;
 
-/**
- * Provides convenient way to construct AWS SDK clients.
- *
- * @author Maciej Walkowiak
- * @since 3.2.0
- */
-public interface AwsClientFactory {
-	<CLIENT, BUILDER extends AwsClientBuilder<BUILDER, CLIENT>> CLIENT create(BUILDER builder);
+@FunctionalInterface
+public interface CloudWatchAsyncClientCustomizer extends AwsClientCustomizer<CloudWatchAsyncClientBuilder> {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.autoconfigure.metrics;
 
+import io.awspring.cloud.autoconfigure.AwsAsyncClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
 import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;
@@ -70,9 +71,11 @@ public class CloudWatchExportAutoConfiguration {
 			AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 			ObjectProvider<AwsClientCustomizer<CloudWatchAsyncClientBuilder>> configurer,
 			ObjectProvider<AwsConnectionDetails> connectionDetails,
-			ObjectProvider<CloudWatchAsyncClientCustomizer> customizer) {
-		return awsClientBuilderConfigurer.configure(CloudWatchAsyncClient.builder(), properties,
-				connectionDetails.getIfAvailable(), configurer.getIfAvailable(), customizer.orderedStream()).build();
+			ObjectProvider<CloudWatchAsyncClientCustomizer> cloudWatchAsyncClientCustomizers,
+			ObjectProvider<AwsAsyncClientCustomizer> awsAsyncClientCustomizers) {
+		return awsClientBuilderConfigurer.configureAsyncClient(CloudWatchAsyncClient.builder(), properties,
+				connectionDetails.getIfAvailable(), configurer.getIfAvailable(),
+				cloudWatchAsyncClientCustomizers.orderedStream(), awsAsyncClientCustomizers.orderedStream()).build();
 	}
 
 	@Bean

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
@@ -69,9 +69,10 @@ public class CloudWatchExportAutoConfiguration {
 	public CloudWatchAsyncClient cloudWatchAsyncClient(CloudWatchProperties properties,
 			AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 			ObjectProvider<AwsClientCustomizer<CloudWatchAsyncClientBuilder>> configurer,
-			ObjectProvider<AwsConnectionDetails> connectionDetails) {
+			ObjectProvider<AwsConnectionDetails> connectionDetails,
+			ObjectProvider<CloudWatchAsyncClientCustomizer> customizer) {
 		return awsClientBuilderConfigurer.configure(CloudWatchAsyncClient.builder(), properties,
-				connectionDetails.getIfAvailable(), configurer.getIfAvailable()).build();
+				connectionDetails.getIfAvailable(), configurer.getIfAvailable(), customizer.orderedStream()).build();
 	}
 
 	@Bean

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfiguration.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.autoconfigure.s3;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
 import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;
@@ -70,9 +71,12 @@ public class S3AutoConfiguration {
 	@ConditionalOnMissingBean
 	S3ClientBuilder s3ClientBuilder(AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 			ObjectProvider<AwsClientCustomizer<S3ClientBuilder>> configurer,
-			ObjectProvider<AwsConnectionDetails> connectionDetails, ObjectProvider<S3ClientCustomizer> customizer) {
-		S3ClientBuilder builder = awsClientBuilderConfigurer.configure(S3Client.builder(), this.properties,
-				connectionDetails.getIfAvailable(), configurer.getIfAvailable(), customizer.orderedStream());
+			ObjectProvider<AwsConnectionDetails> connectionDetails,
+			ObjectProvider<S3ClientCustomizer> s3ClientCustomizers,
+			ObjectProvider<AwsSyncClientCustomizer> awsSyncClientCustomizers) {
+		S3ClientBuilder builder = awsClientBuilderConfigurer.configureSyncClient(S3Client.builder(), this.properties,
+				connectionDetails.getIfAvailable(), configurer.getIfAvailable(), s3ClientCustomizers.orderedStream(),
+				awsSyncClientCustomizers.orderedStream());
 
 		Optional.ofNullable(this.properties.getCrossRegionEnabled()).ifPresent(builder::crossRegionAccessEnabled);
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfiguration.java
@@ -70,9 +70,9 @@ public class S3AutoConfiguration {
 	@ConditionalOnMissingBean
 	S3ClientBuilder s3ClientBuilder(AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 			ObjectProvider<AwsClientCustomizer<S3ClientBuilder>> configurer,
-			ObjectProvider<AwsConnectionDetails> connectionDetails) {
+			ObjectProvider<AwsConnectionDetails> connectionDetails, ObjectProvider<S3ClientCustomizer> customizer) {
 		S3ClientBuilder builder = awsClientBuilderConfigurer.configure(S3Client.builder(), this.properties,
-				connectionDetails.getIfAvailable(), configurer.getIfAvailable());
+				connectionDetails.getIfAvailable(), configurer.getIfAvailable(), customizer.orderedStream());
 
 		Optional.ofNullable(this.properties.getCrossRegionEnabled()).ifPresent(builder::crossRegionAccessEnabled);
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3ClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3ClientCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2024 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.awspring.cloud.testcontainers;
+package io.awspring.cloud.autoconfigure.s3;
 
-import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
-/**
- * Provides convenient way to construct AWS SDK clients.
- *
- * @author Maciej Walkowiak
- * @since 3.2.0
- */
-public interface AwsClientFactory {
-	<CLIENT, BUILDER extends AwsClientBuilder<BUILDER, CLIENT>> CLIENT create(BUILDER builder);
+@FunctionalInterface
+public interface S3ClientCustomizer extends AwsClientCustomizer<S3ClientBuilder> {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3ClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3ClientCustomizer.java
@@ -18,6 +18,12 @@ package io.awspring.cloud.autoconfigure.s3;
 import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
+/**
+ * Callback interface that can be used to customize a {@link S3ClientBuilder}.
+ *
+ * @author Maciej Walkowiak
+ * @since 3.3.0
+ */
 @FunctionalInterface
 public interface S3ClientCustomizer extends AwsClientCustomizer<S3ClientBuilder> {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesAutoConfiguration.java
@@ -56,9 +56,9 @@ public class SesAutoConfiguration {
 	@ConditionalOnMissingBean
 	public SesClient sesClient(SesProperties properties, AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 			ObjectProvider<AwsClientCustomizer<SesClientBuilder>> configurer,
-			ObjectProvider<AwsConnectionDetails> connectionDetails) {
+			ObjectProvider<AwsConnectionDetails> connectionDetails, ObjectProvider<SesClientCustomizer> customizer) {
 		return awsClientBuilderConfigurer.configure(SesClient.builder(), properties, connectionDetails.getIfAvailable(),
-				configurer.getIfAvailable()).build();
+				configurer.getIfAvailable(), customizer.orderedStream()).build();
 	}
 
 	@Bean

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.autoconfigure.ses;
 
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
 import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;
@@ -56,9 +57,12 @@ public class SesAutoConfiguration {
 	@ConditionalOnMissingBean
 	public SesClient sesClient(SesProperties properties, AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 			ObjectProvider<AwsClientCustomizer<SesClientBuilder>> configurer,
-			ObjectProvider<AwsConnectionDetails> connectionDetails, ObjectProvider<SesClientCustomizer> customizer) {
-		return awsClientBuilderConfigurer.configure(SesClient.builder(), properties, connectionDetails.getIfAvailable(),
-				configurer.getIfAvailable(), customizer.orderedStream()).build();
+			ObjectProvider<AwsConnectionDetails> connectionDetails,
+			ObjectProvider<SesClientCustomizer> sesClientCustomizers,
+			ObjectProvider<AwsSyncClientCustomizer> awsSyncClientCustomizers) {
+		return awsClientBuilderConfigurer.configureSyncClient(SesClient.builder(), properties,
+				connectionDetails.getIfAvailable(), configurer.getIfAvailable(), sesClientCustomizers.orderedStream(),
+				awsSyncClientCustomizers.orderedStream()).build();
 	}
 
 	@Bean

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesClientCustomizer.java
@@ -19,6 +19,8 @@ import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
 import software.amazon.awssdk.services.ses.SesClientBuilder;
 
 /**
+ * Callback interface that can be used to customize a {@link SesClientBuilder}.
+ *
  * @author Maciej Walkowiak
  * @since 3.3.0
  */

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesClientCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2024 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.awspring.cloud.testcontainers;
+package io.awspring.cloud.autoconfigure.ses;
 
-import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
+import software.amazon.awssdk.services.ses.SesClientBuilder;
 
 /**
- * Provides convenient way to construct AWS SDK clients.
- *
  * @author Maciej Walkowiak
- * @since 3.2.0
+ * @since 3.2.1
  */
-public interface AwsClientFactory {
-	<CLIENT, BUILDER extends AwsClientBuilder<BUILDER, CLIENT>> CLIENT create(BUILDER builder);
+@FunctionalInterface
+public interface SesClientCustomizer extends AwsClientCustomizer<SesClientBuilder> {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesClientCustomizer.java
@@ -20,7 +20,7 @@ import software.amazon.awssdk.services.ses.SesClientBuilder;
 
 /**
  * @author Maciej Walkowiak
- * @since 3.2.1
+ * @since 3.3.0
  */
 @FunctionalInterface
 public interface SesClientCustomizer extends AwsClientCustomizer<SesClientBuilder> {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sns/SnsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sns/SnsAutoConfiguration.java
@@ -18,6 +18,7 @@ package io.awspring.cloud.autoconfigure.sns;
 import static io.awspring.cloud.sns.configuration.NotificationHandlerMethodArgumentResolverConfigurationUtils.getNotificationHandlerMethodArgumentResolver;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
 import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;
@@ -69,9 +70,12 @@ public class SnsAutoConfiguration {
 	@Bean
 	public SnsClient snsClient(SnsProperties properties, AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 			ObjectProvider<AwsClientCustomizer<SnsClientBuilder>> configurer,
-			ObjectProvider<AwsConnectionDetails> connectionDetails, ObjectProvider<SnsClientCustomizer> customizer) {
-		return awsClientBuilderConfigurer.configure(SnsClient.builder(), properties, connectionDetails.getIfAvailable(),
-				configurer.getIfAvailable(), customizer.orderedStream()).build();
+			ObjectProvider<AwsConnectionDetails> connectionDetails,
+			ObjectProvider<SnsClientCustomizer> snsClientCustomizers,
+			ObjectProvider<AwsSyncClientCustomizer> awsSyncClientCustomizers) {
+		return awsClientBuilderConfigurer.configureSyncClient(SnsClient.builder(), properties,
+				connectionDetails.getIfAvailable(), configurer.getIfAvailable(), snsClientCustomizers.orderedStream(),
+				awsSyncClientCustomizers.orderedStream()).build();
 	}
 
 	@ConditionalOnMissingBean(SnsOperations.class)

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sns/SnsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sns/SnsAutoConfiguration.java
@@ -69,9 +69,9 @@ public class SnsAutoConfiguration {
 	@Bean
 	public SnsClient snsClient(SnsProperties properties, AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 			ObjectProvider<AwsClientCustomizer<SnsClientBuilder>> configurer,
-			ObjectProvider<AwsConnectionDetails> connectionDetails) {
+			ObjectProvider<AwsConnectionDetails> connectionDetails, ObjectProvider<SnsClientCustomizer> customizer) {
 		return awsClientBuilderConfigurer.configure(SnsClient.builder(), properties, connectionDetails.getIfAvailable(),
-				configurer.getIfAvailable()).build();
+				configurer.getIfAvailable(), customizer.orderedStream()).build();
 	}
 
 	@ConditionalOnMissingBean(SnsOperations.class)

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sns/SnsClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sns/SnsClientCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2024 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.awspring.cloud.testcontainers;
+package io.awspring.cloud.autoconfigure.sns;
 
-import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
+import software.amazon.awssdk.services.sns.SnsClientBuilder;
 
 /**
- * Provides convenient way to construct AWS SDK clients.
- *
  * @author Maciej Walkowiak
- * @since 3.2.0
+ * @since 3.2.1
  */
-public interface AwsClientFactory {
-	<CLIENT, BUILDER extends AwsClientBuilder<BUILDER, CLIENT>> CLIENT create(BUILDER builder);
+@FunctionalInterface
+public interface SnsClientCustomizer extends AwsClientCustomizer<SnsClientBuilder> {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sns/SnsClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sns/SnsClientCustomizer.java
@@ -20,7 +20,7 @@ import software.amazon.awssdk.services.sns.SnsClientBuilder;
 
 /**
  * @author Maciej Walkowiak
- * @since 3.2.1
+ * @since 3.3.0
  */
 @FunctionalInterface
 public interface SnsClientCustomizer extends AwsClientCustomizer<SnsClientBuilder> {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sns/SnsClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sns/SnsClientCustomizer.java
@@ -19,6 +19,8 @@ import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
 import software.amazon.awssdk.services.sns.SnsClientBuilder;
 
 /**
+ * Callback interface that can be used to customize a {@link SnsClientBuilder}.
+ *
  * @author Maciej Walkowiak
  * @since 3.3.0
  */

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAsyncClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAsyncClientCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2024 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.awspring.cloud.testcontainers;
+package io.awspring.cloud.autoconfigure.sqs;
 
-import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
+import software.amazon.awssdk.services.sqs.SqsAsyncClientBuilder;
 
 /**
- * Provides convenient way to construct AWS SDK clients.
- *
  * @author Maciej Walkowiak
- * @since 3.2.0
+ * @since 3.2.1
  */
-public interface AwsClientFactory {
-	<CLIENT, BUILDER extends AwsClientBuilder<BUILDER, CLIENT>> CLIENT create(BUILDER builder);
+@FunctionalInterface
+public interface SqsAsyncClientCustomizer extends AwsClientCustomizer<SqsAsyncClientBuilder> {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAsyncClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAsyncClientCustomizer.java
@@ -19,6 +19,8 @@ import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
 import software.amazon.awssdk.services.sqs.SqsAsyncClientBuilder;
 
 /**
+ * Callback interface that can be used to customize a {@link SqsAsyncClientBuilder}.
+ *
  * @author Maciej Walkowiak
  * @since 3.3.0
  */

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAsyncClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAsyncClientCustomizer.java
@@ -20,7 +20,7 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClientBuilder;
 
 /**
  * @author Maciej Walkowiak
- * @since 3.2.1
+ * @since 3.3.0
  */
 @FunctionalInterface
 public interface SqsAsyncClientCustomizer extends AwsClientCustomizer<SqsAsyncClientBuilder> {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.autoconfigure.sqs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.autoconfigure.AwsAsyncClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
 import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;
@@ -76,9 +77,11 @@ public class SqsAutoConfiguration {
 	public SqsAsyncClient sqsAsyncClient(AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 			ObjectProvider<AwsClientCustomizer<SqsAsyncClientBuilder>> configurer,
 			ObjectProvider<AwsConnectionDetails> connectionDetails,
-			ObjectProvider<SqsAsyncClientCustomizer> customizer) {
-		return awsClientBuilderConfigurer.configure(SqsAsyncClient.builder(), this.sqsProperties,
-				connectionDetails.getIfAvailable(), configurer.getIfAvailable(), customizer.orderedStream()).build();
+			ObjectProvider<SqsAsyncClientCustomizer> sqsAsyncClientCustomizers,
+			ObjectProvider<AwsAsyncClientCustomizer> awsAsyncClientCustomizers) {
+		return awsClientBuilderConfigurer.configureAsyncClient(SqsAsyncClient.builder(), this.sqsProperties,
+				connectionDetails.getIfAvailable(), configurer.getIfAvailable(),
+				sqsAsyncClientCustomizers.orderedStream(), awsAsyncClientCustomizers.orderedStream()).build();
 	}
 
 	@ConditionalOnMissingBean

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -75,9 +75,10 @@ public class SqsAutoConfiguration {
 	@Bean
 	public SqsAsyncClient sqsAsyncClient(AwsClientBuilderConfigurer awsClientBuilderConfigurer,
 			ObjectProvider<AwsClientCustomizer<SqsAsyncClientBuilder>> configurer,
-			ObjectProvider<AwsConnectionDetails> connectionDetails) {
+			ObjectProvider<AwsConnectionDetails> connectionDetails,
+			ObjectProvider<SqsAsyncClientCustomizer> customizer) {
 		return awsClientBuilderConfigurer.configure(SqsAsyncClient.builder(), this.sqsProperties,
-				connectionDetails.getIfAvailable(), configurer.getIfAvailable()).build();
+				connectionDetails.getIfAvailable(), configurer.getIfAvailable(), customizer.orderedStream()).build();
 	}
 
 	@ConditionalOnMissingBean

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/ConfiguredAwsClient.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/ConfiguredAwsClient.java
@@ -66,6 +66,10 @@ public class ConfiguredAwsClient {
 		return clientConfigurationAttributes.get(SdkClientOption.API_CALL_TIMEOUT);
 	}
 
+	public Duration getApiCallAttemptTimeout() {
+		return clientConfigurationAttributes.get(SdkClientOption.API_CALL_ATTEMPT_TIMEOUT);
+	}
+
 	public SdkHttpClient getSyncHttpClient() {
 		return clientConfigurationAttributes.get(SdkClientOption.SYNC_HTTP_CLIENT);
 	}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/SsmClientCustomizerTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/SsmClientCustomizerTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.config.parameterstore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
+import io.awspring.cloud.autoconfigure.ConfiguredAwsClient;
+import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.services.ssm.SsmClient;
+
+/**
+ * Tests for {@link SsmClientCustomizer}.
+ *
+ * @author Maciej Walkowiak
+ */
+class SsmClientCustomizerTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withPropertyValues("spring.cloud.aws.region.static:eu-west-1",
+					"spring.cloud.aws.credentials.access-key:noop", "spring.cloud.aws.credentials.secret-key:noop")
+			.withConfiguration(AutoConfigurations.of(AwsAutoConfiguration.class, RegionProviderAutoConfiguration.class,
+					CredentialsProviderAutoConfiguration.class, ParameterStoreAutoConfiguration.class));
+
+	@Test
+	void customClientCustomizer() {
+		contextRunner.withUserConfiguration(CustomizerConfig.class).run(context -> {
+			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(SsmClient.class));
+			assertThat(client.getApiCallTimeout()).describedAs("sets property from first customizer")
+					.isEqualTo(Duration.ofMillis(2001));
+			assertThat(client.getApiCallAttemptTimeout()).describedAs("sets property from second customizer")
+					.isEqualTo(Duration.ofMillis(2002));
+			assertThat(client.getSyncHttpClient()).describedAs("sets property from common client customizer")
+					.isNotNull();
+		});
+	}
+
+	@Test
+	void customClientCustomizerWithOrder() {
+		contextRunner.withUserConfiguration(CustomizerConfigWithOrder.class).run(context -> {
+			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(SsmClient.class));
+			assertThat(client.getApiCallTimeout())
+					.describedAs("property from the customizer with higher order takes precedence")
+					.isEqualTo(Duration.ofMillis(2001));
+		});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfig {
+
+		@Bean
+		SsmClientCustomizer customizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		SsmClientCustomizer customizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallAttemptTimeout(Duration.ofMillis(2002));
+				}));
+			};
+		}
+
+		@Bean
+		AwsSyncClientCustomizer awsSyncClientCustomizer() {
+			return builder -> {
+				builder.httpClient(ApacheHttpClient.builder().connectionTimeout(Duration.ofMillis(1542)).build());
+			};
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfigWithOrder {
+
+		@Bean
+		@Order(2)
+		SsmClientCustomizer customizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		@Order(1)
+		SsmClientCustomizer customizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2000));
+				}));
+			};
+		}
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerClientCustomizerTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/secretsmanager/SecretsManagerClientCustomizerTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.config.secretsmanager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
+import io.awspring.cloud.autoconfigure.ConfiguredAwsClient;
+import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+
+/**
+ * Tests for {@link SecretsManagerClientCustomizer}.
+ *
+ * @author Maciej Walkowiak
+ */
+class SecretsManagerClientCustomizerTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withPropertyValues("spring.cloud.aws.region.static:eu-west-1",
+					"spring.cloud.aws.credentials.access-key:noop", "spring.cloud.aws.credentials.secret-key:noop")
+			.withConfiguration(AutoConfigurations.of(AwsAutoConfiguration.class, RegionProviderAutoConfiguration.class,
+					CredentialsProviderAutoConfiguration.class, SecretsManagerAutoConfiguration.class));
+
+	@Test
+	void customClientCustomizer() {
+		contextRunner.withUserConfiguration(CustomizerConfig.class).run(context -> {
+			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(SecretsManagerClient.class));
+			assertThat(client.getApiCallTimeout()).describedAs("sets property from first customizer")
+					.isEqualTo(Duration.ofMillis(2001));
+			assertThat(client.getApiCallAttemptTimeout()).describedAs("sets property from second customizer")
+					.isEqualTo(Duration.ofMillis(2002));
+			assertThat(client.getSyncHttpClient()).describedAs("sets property from common client customizer")
+					.isNotNull();
+		});
+	}
+
+	@Test
+	void customClientCustomizerWithOrder() {
+		contextRunner.withUserConfiguration(CustomizerConfigWithOrder.class).run(context -> {
+			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(SecretsManagerClient.class));
+			assertThat(client.getApiCallTimeout())
+					.describedAs("property from the customizer with higher order takes precedence")
+					.isEqualTo(Duration.ofMillis(2001));
+		});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfig {
+
+		@Bean
+		SecretsManagerClientCustomizer customizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		SecretsManagerClientCustomizer customizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallAttemptTimeout(Duration.ofMillis(2002));
+				}));
+			};
+		}
+
+		@Bean
+		AwsSyncClientCustomizer awsSyncClientCustomizer() {
+			return builder -> {
+				builder.httpClient(ApacheHttpClient.builder().connectionTimeout(Duration.ofMillis(1542)).build());
+			};
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfigWithOrder {
+
+		@Bean
+		@Order(2)
+		SecretsManagerClientCustomizer customizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		@Order(1)
+		SecretsManagerClientCustomizer customizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2000));
+				}));
+			};
+		}
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/core/AwsAutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/core/AwsAutoConfigurationTests.java
@@ -15,11 +15,11 @@
  */
 package io.awspring.cloud.autoconfigure.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link AwsAutoConfiguration}.

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfigurationTest.java
@@ -35,7 +35,6 @@ import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
 import org.springframework.lang.Nullable;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
@@ -128,28 +127,6 @@ class DynamoDbAutoConfigurationTest {
 						assertThat(dynamoDbClient.getApiCallTimeout()).isEqualTo(Duration.ofMillis(1999));
 						assertThat(dynamoDbClient.getSyncHttpClient()).isNotNull();
 					});
-		}
-
-		@Test
-		void customDynamoDbClientCustomizer() {
-			contextRunner.withUserConfiguration(DynamoDbAutoConfigurationTest.CustomizerConfig.class)
-				.run(context -> {
-					ConfiguredAwsClient dynamoDbClient = new ConfiguredAwsClient(
-						context.getBean(DynamoDbClient.class));
-					assertThat(dynamoDbClient.getApiCallTimeout()).isEqualTo(Duration.ofMillis(2001));
-					assertThat(dynamoDbClient.getApiCallAttemptTimeout()).isEqualTo(Duration.ofMillis(2002));
-					assertThat(dynamoDbClient.getSyncHttpClient()).isNotNull();
-				});
-		}
-
-		@Test
-		void customDynamoDbClientCustomizerWithOrder() {
-			contextRunner.withUserConfiguration(DynamoDbAutoConfigurationTest.CustomizerConfigWithOrder.class)
-				.run(context -> {
-					ConfiguredAwsClient dynamoDbClient = new ConfiguredAwsClient(
-						context.getBean(DynamoDbClient.class));
-					assertThat(dynamoDbClient.getApiCallTimeout()).isEqualTo(Duration.ofMillis(2001));
-				});
 		}
 
 		@Test
@@ -333,53 +310,6 @@ class DynamoDbAutoConfigurationTest {
 			}
 		}
 
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	static class CustomizerConfig {
-
-		@Bean
-		DynamoDbClientCustomizer dynamoDbClientCustomizer() {
-			return builder -> {
-				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
-					c.apiCallTimeout(Duration.ofMillis(2001));
-				}))
-				.httpClient(ApacheHttpClient.builder().connectionTimeout(Duration.ofMillis(1542)).build());
-			};
-		}
-
-		@Bean
-		DynamoDbClientCustomizer dynamoDbClientCustomizer2() {
-			return builder -> {
-				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
-					c.apiCallAttemptTimeout(Duration.ofMillis(2002));
-				}));
-			};
-		}
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	static class CustomizerConfigWithOrder {
-
-		@Bean
-		@Order(2)
-		DynamoDbClientCustomizer dynamoDbClientCustomizer() {
-			return builder -> {
-				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
-					c.apiCallTimeout(Duration.ofMillis(2001));
-				}));
-			};
-		}
-
-		@Bean
-		@Order(1)
-		DynamoDbClientCustomizer dynamoDbClientCustomizer2() {
-			return builder -> {
-				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
-					c.apiCallTimeout(Duration.ofMillis(2000));
-				}));
-			};
-		}
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfigurationTest.java
@@ -35,6 +35,7 @@ import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.lang.Nullable;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
@@ -127,6 +128,28 @@ class DynamoDbAutoConfigurationTest {
 						assertThat(dynamoDbClient.getApiCallTimeout()).isEqualTo(Duration.ofMillis(1999));
 						assertThat(dynamoDbClient.getSyncHttpClient()).isNotNull();
 					});
+		}
+
+		@Test
+		void customDynamoDbClientCustomizer() {
+			contextRunner.withUserConfiguration(DynamoDbAutoConfigurationTest.CustomizerConfig.class)
+				.run(context -> {
+					ConfiguredAwsClient dynamoDbClient = new ConfiguredAwsClient(
+						context.getBean(DynamoDbClient.class));
+					assertThat(dynamoDbClient.getApiCallTimeout()).isEqualTo(Duration.ofMillis(2001));
+					assertThat(dynamoDbClient.getApiCallAttemptTimeout()).isEqualTo(Duration.ofMillis(2002));
+					assertThat(dynamoDbClient.getSyncHttpClient()).isNotNull();
+				});
+		}
+
+		@Test
+		void customDynamoDbClientCustomizerWithOrder() {
+			contextRunner.withUserConfiguration(DynamoDbAutoConfigurationTest.CustomizerConfigWithOrder.class)
+				.run(context -> {
+					ConfiguredAwsClient dynamoDbClient = new ConfiguredAwsClient(
+						context.getBean(DynamoDbClient.class));
+					assertThat(dynamoDbClient.getApiCallTimeout()).isEqualTo(Duration.ofMillis(2001));
+				});
 		}
 
 		@Test
@@ -310,6 +333,53 @@ class DynamoDbAutoConfigurationTest {
 			}
 		}
 
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfig {
+
+		@Bean
+		DynamoDbClientCustomizer dynamoDbClientCustomizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}))
+				.httpClient(ApacheHttpClient.builder().connectionTimeout(Duration.ofMillis(1542)).build());
+			};
+		}
+
+		@Bean
+		DynamoDbClientCustomizer dynamoDbClientCustomizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallAttemptTimeout(Duration.ofMillis(2002));
+				}));
+			};
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfigWithOrder {
+
+		@Bean
+		@Order(2)
+		DynamoDbClientCustomizer dynamoDbClientCustomizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		@Order(1)
+		DynamoDbClientCustomizer dynamoDbClientCustomizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2000));
+				}));
+			};
+		}
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbClientCustomizerTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbClientCustomizerTests.java
@@ -17,7 +17,7 @@ package io.awspring.cloud.autoconfigure.dynamodb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.awspring.cloud.autoconfigure.CommonAwsSyncClientCustomizer;
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
 import io.awspring.cloud.autoconfigure.ConfiguredAwsClient;
 import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
@@ -90,7 +90,7 @@ class DynamoDbClientCustomizerTests {
 		}
 
 		@Bean
-		CommonAwsSyncClientCustomizer commonAwsSyncClientCustomizer() {
+		AwsSyncClientCustomizer commonAwsSyncClientCustomizer() {
 			return builder -> {
 				builder.httpClient(ApacheHttpClient.builder().connectionTimeout(Duration.ofMillis(1542)).build());
 			};

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbClientCustomizerTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbClientCustomizerTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.awspring.cloud.autoconfigure.CommonAwsSyncClientCustomizer;
+import io.awspring.cloud.autoconfigure.ConfiguredAwsClient;
+import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+/**
+ * Tests for {@link DynamoDbClientCustomizer}.
+ *
+ * @author Maciej Walkowiak
+ */
+class DynamoDbClientCustomizerTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withPropertyValues("spring.cloud.aws.region.static:eu-west-1",
+					"spring.cloud.aws.credentials.access-key:noop", "spring.cloud.aws.credentials.secret-key:noop")
+			.withConfiguration(AutoConfigurations.of(AwsAutoConfiguration.class, RegionProviderAutoConfiguration.class,
+					CredentialsProviderAutoConfiguration.class, DynamoDbAutoConfiguration.class));
+
+	@Test
+	void customDynamoDbClientCustomizer() {
+		contextRunner.withUserConfiguration(CustomizerConfig.class).run(context -> {
+			ConfiguredAwsClient dynamoDbClient = new ConfiguredAwsClient(context.getBean(DynamoDbClient.class));
+			assertThat(dynamoDbClient.getApiCallTimeout()).describedAs("sets property from first customizer")
+					.isEqualTo(Duration.ofMillis(2001));
+			assertThat(dynamoDbClient.getApiCallAttemptTimeout()).describedAs("sets property from second customizer")
+					.isEqualTo(Duration.ofMillis(2002));
+			assertThat(dynamoDbClient.getSyncHttpClient()).describedAs("sets property from common client customizer")
+					.isNotNull();
+		});
+	}
+
+	@Test
+	void customDynamoDbClientCustomizerWithOrder() {
+		contextRunner.withUserConfiguration(CustomizerConfigWithOrder.class).run(context -> {
+			ConfiguredAwsClient dynamoDbClient = new ConfiguredAwsClient(context.getBean(DynamoDbClient.class));
+			assertThat(dynamoDbClient.getApiCallTimeout())
+					.describedAs("property from the customizer with higher order takes precedence")
+					.isEqualTo(Duration.ofMillis(2001));
+		});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfig {
+
+		@Bean
+		DynamoDbClientCustomizer dynamoDbClientCustomizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		DynamoDbClientCustomizer dynamoDbClientCustomizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallAttemptTimeout(Duration.ofMillis(2002));
+				}));
+			};
+		}
+
+		@Bean
+		CommonAwsSyncClientCustomizer commonAwsSyncClientCustomizer() {
+			return builder -> {
+				builder.httpClient(ApacheHttpClient.builder().connectionTimeout(Duration.ofMillis(1542)).build());
+			};
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfigWithOrder {
+
+		@Bean
+		@Order(2)
+		DynamoDbClientCustomizer dynamoDbClientCustomizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		@Order(1)
+		DynamoDbClientCustomizer dynamoDbClientCustomizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2000));
+				}));
+			};
+		}
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchAsyncClientCustomizerTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchAsyncClientCustomizerTests.java
@@ -43,7 +43,8 @@ class CloudWatchAsyncClientCustomizerTests {
 			.withPropertyValues("spring.cloud.aws.region.static:eu-west-1",
 					"spring.cloud.aws.credentials.access-key:noop", "spring.cloud.aws.credentials.secret-key:noop")
 			.withConfiguration(AutoConfigurations.of(AwsAutoConfiguration.class, RegionProviderAutoConfiguration.class,
-					CredentialsProviderAutoConfiguration.class, CloudWatchExportAutoConfiguration.class));
+					CredentialsProviderAutoConfiguration.class, CloudWatchExportAutoConfiguration.class))
+			.withPropertyValues("management.cloudwatch.metrics.export.namespace:test");
 
 	@Test
 	void customClientCustomizer() {

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchAsyncClientCustomizerTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/metrics/CloudWatchAsyncClientCustomizerTests.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.awspring.cloud.autoconfigure.AwsAsyncClientCustomizer;
+import io.awspring.cloud.autoconfigure.ConfiguredAwsClient;
+import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+
+/**
+ * Tests for {@link CloudWatchAsyncClientCustomizer}.
+ *
+ * @author Maciej Walkowiak
+ */
+class CloudWatchAsyncClientCustomizerTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withPropertyValues("spring.cloud.aws.region.static:eu-west-1",
+					"spring.cloud.aws.credentials.access-key:noop", "spring.cloud.aws.credentials.secret-key:noop")
+			.withConfiguration(AutoConfigurations.of(AwsAutoConfiguration.class, RegionProviderAutoConfiguration.class,
+					CredentialsProviderAutoConfiguration.class, CloudWatchExportAutoConfiguration.class));
+
+	@Test
+	void customClientCustomizer() {
+		contextRunner.withUserConfiguration(CustomizerConfig.class).run(context -> {
+			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(CloudWatchAsyncClient.class));
+			assertThat(client.getApiCallTimeout()).describedAs("sets property from first customizer")
+					.isEqualTo(Duration.ofMillis(2001));
+			assertThat(client.getApiCallAttemptTimeout()).describedAs("sets property from second customizer")
+					.isEqualTo(Duration.ofMillis(2002));
+			assertThat(client.getAsyncHttpClient()).describedAs("sets property from common client customizer")
+					.isNotNull();
+		});
+	}
+
+	@Test
+	void customClientCustomizerWithOrder() {
+		contextRunner.withUserConfiguration(CustomizerConfigWithOrder.class).run(context -> {
+			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(CloudWatchAsyncClient.class));
+			assertThat(client.getApiCallTimeout())
+					.describedAs("property from the customizer with higher order takes precedence")
+					.isEqualTo(Duration.ofMillis(2001));
+		});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfig {
+
+		@Bean
+		CloudWatchAsyncClientCustomizer customizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		CloudWatchAsyncClientCustomizer customizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallAttemptTimeout(Duration.ofMillis(2002));
+				}));
+			};
+		}
+
+		@Bean
+		AwsAsyncClientCustomizer awsAsyncClientCustomizer() {
+			return builder -> {
+				builder.httpClient(
+						NettyNioAsyncHttpClient.builder().connectionTimeout(Duration.ofMillis(1542)).build());
+			};
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfigWithOrder {
+
+		@Bean
+		@Order(2)
+		CloudWatchAsyncClientCustomizer customizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		@Order(1)
+		CloudWatchAsyncClientCustomizer customizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2000));
+				}));
+			};
+		}
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3ClientCustomizerTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3ClientCustomizerTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
+import io.awspring.cloud.autoconfigure.ConfiguredAwsClient;
+import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.services.s3.S3Client;
+
+/**
+ * Tests for {@link S3ClientCustomizer}.
+ *
+ * @author Maciej Walkowiak
+ */
+class S3ClientCustomizerTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withPropertyValues("spring.cloud.aws.region.static:eu-west-1",
+					"spring.cloud.aws.credentials.access-key:noop", "spring.cloud.aws.credentials.secret-key:noop")
+			.withConfiguration(AutoConfigurations.of(AwsAutoConfiguration.class, RegionProviderAutoConfiguration.class,
+					CredentialsProviderAutoConfiguration.class, S3AutoConfiguration.class));
+
+	@Test
+	void customClientCustomizer() {
+		contextRunner.withUserConfiguration(CustomizerConfig.class).run(context -> {
+			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(S3Client.class));
+			assertThat(client.getApiCallTimeout()).describedAs("sets property from first customizer")
+					.isEqualTo(Duration.ofMillis(2001));
+			assertThat(client.getApiCallAttemptTimeout()).describedAs("sets property from second customizer")
+					.isEqualTo(Duration.ofMillis(2002));
+			assertThat(client.getSyncHttpClient()).describedAs("sets property from common client customizer")
+					.isNotNull();
+		});
+	}
+
+	@Test
+	void customClientCustomizerWithOrder() {
+		contextRunner.withUserConfiguration(CustomizerConfigWithOrder.class).run(context -> {
+			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(S3Client.class));
+			assertThat(client.getApiCallTimeout())
+					.describedAs("property from the customizer with higher order takes precedence")
+					.isEqualTo(Duration.ofMillis(2001));
+		});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfig {
+
+		@Bean
+		S3ClientCustomizer customizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		S3ClientCustomizer customizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallAttemptTimeout(Duration.ofMillis(2002));
+				}));
+			};
+		}
+
+		@Bean
+		AwsSyncClientCustomizer awsSyncClientCustomizer() {
+			return builder -> {
+				builder.httpClient(ApacheHttpClient.builder().connectionTimeout(Duration.ofMillis(1542)).build());
+			};
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfigWithOrder {
+
+		@Bean
+		@Order(2)
+		S3ClientCustomizer customizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		@Order(1)
+		S3ClientCustomizer customizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2000));
+				}));
+			};
+		}
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/ses/SesClientCustomizerTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/ses/SesClientCustomizerTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.ses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
+import io.awspring.cloud.autoconfigure.ConfiguredAwsClient;
+import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.services.ses.SesClient;
+
+/**
+ * Tests for {@link SesClientCustomizer}.
+ *
+ * @author Maciej Walkowiak
+ */
+class SesClientCustomizerTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withPropertyValues("spring.cloud.aws.region.static:eu-west-1",
+					"spring.cloud.aws.credentials.access-key:noop", "spring.cloud.aws.credentials.secret-key:noop")
+			.withConfiguration(AutoConfigurations.of(AwsAutoConfiguration.class, RegionProviderAutoConfiguration.class,
+					CredentialsProviderAutoConfiguration.class, SesAutoConfiguration.class));
+
+	@Test
+	void customClientCustomizer() {
+		contextRunner.withUserConfiguration(CustomizerConfig.class).run(context -> {
+			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(SesClient.class));
+			assertThat(client.getApiCallTimeout()).describedAs("sets property from first customizer")
+					.isEqualTo(Duration.ofMillis(2001));
+			assertThat(client.getApiCallAttemptTimeout()).describedAs("sets property from second customizer")
+					.isEqualTo(Duration.ofMillis(2002));
+			assertThat(client.getSyncHttpClient()).describedAs("sets property from common client customizer")
+					.isNotNull();
+		});
+	}
+
+	@Test
+	void customClientCustomizerWithOrder() {
+		contextRunner.withUserConfiguration(CustomizerConfigWithOrder.class).run(context -> {
+			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(SesClient.class));
+			assertThat(client.getApiCallTimeout())
+					.describedAs("property from the customizer with higher order takes precedence")
+					.isEqualTo(Duration.ofMillis(2001));
+		});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfig {
+
+		@Bean
+		SesClientCustomizer customizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		SesClientCustomizer customizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallAttemptTimeout(Duration.ofMillis(2002));
+				}));
+			};
+		}
+
+		@Bean
+		AwsSyncClientCustomizer awsSyncClientCustomizer() {
+			return builder -> {
+				builder.httpClient(ApacheHttpClient.builder().connectionTimeout(Duration.ofMillis(1542)).build());
+			};
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfigWithOrder {
+
+		@Bean
+		@Order(2)
+		SesClientCustomizer customizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		@Order(1)
+		SesClientCustomizer customizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2000));
+				}));
+			};
+		}
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sns/SnsClientCustomizerTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sns/SnsClientCustomizerTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.sns;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.awspring.cloud.autoconfigure.AwsSyncClientCustomizer;
+import io.awspring.cloud.autoconfigure.ConfiguredAwsClient;
+import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.services.sns.SnsClient;
+
+/**
+ * Tests for {@link SnsClientCustomizer}.
+ *
+ * @author Maciej Walkowiak
+ */
+class SnsClientCustomizerTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withPropertyValues("spring.cloud.aws.region.static:eu-west-1",
+					"spring.cloud.aws.credentials.access-key:noop", "spring.cloud.aws.credentials.secret-key:noop")
+			.withConfiguration(AutoConfigurations.of(AwsAutoConfiguration.class, RegionProviderAutoConfiguration.class,
+					CredentialsProviderAutoConfiguration.class, SnsAutoConfiguration.class));
+
+	@Test
+	void customClientCustomizer() {
+		contextRunner.withUserConfiguration(CustomizerConfig.class).run(context -> {
+			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(SnsClient.class));
+			assertThat(client.getApiCallTimeout()).describedAs("sets property from first customizer")
+					.isEqualTo(Duration.ofMillis(2001));
+			assertThat(client.getApiCallAttemptTimeout()).describedAs("sets property from second customizer")
+					.isEqualTo(Duration.ofMillis(2002));
+			assertThat(client.getSyncHttpClient()).describedAs("sets property from common client customizer")
+					.isNotNull();
+		});
+	}
+
+	@Test
+	void customClientCustomizerWithOrder() {
+		contextRunner.withUserConfiguration(CustomizerConfigWithOrder.class).run(context -> {
+			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(SnsClient.class));
+			assertThat(client.getApiCallTimeout())
+					.describedAs("property from the customizer with higher order takes precedence")
+					.isEqualTo(Duration.ofMillis(2001));
+		});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfig {
+
+		@Bean
+		SnsClientCustomizer customizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		SnsClientCustomizer customizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallAttemptTimeout(Duration.ofMillis(2002));
+				}));
+			};
+		}
+
+		@Bean
+		AwsSyncClientCustomizer awsSyncClientCustomizer() {
+			return builder -> {
+				builder.httpClient(ApacheHttpClient.builder().connectionTimeout(Duration.ofMillis(1542)).build());
+			};
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfigWithOrder {
+
+		@Bean
+		@Order(2)
+		SnsClientCustomizer customizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		@Order(1)
+		SnsClientCustomizer customizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2000));
+				}));
+			};
+		}
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAsyncClientCustomizerTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAsyncClientCustomizerTests.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.sqs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.awspring.cloud.autoconfigure.AwsAsyncClientCustomizer;
+import io.awspring.cloud.autoconfigure.ConfiguredAwsClient;
+import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+/**
+ * Tests for {@link SqsAsyncClientCustomizer}.
+ *
+ * @author Maciej Walkowiak
+ */
+class SqsAsyncClientCustomizerTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withPropertyValues("spring.cloud.aws.region.static:eu-west-1",
+					"spring.cloud.aws.credentials.access-key:noop", "spring.cloud.aws.credentials.secret-key:noop")
+			.withConfiguration(AutoConfigurations.of(AwsAutoConfiguration.class, RegionProviderAutoConfiguration.class,
+					CredentialsProviderAutoConfiguration.class, SqsAutoConfiguration.class));
+
+	@Test
+	void customClientCustomizer() {
+		contextRunner.withUserConfiguration(CustomizerConfig.class).run(context -> {
+			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(SqsAsyncClient.class));
+			assertThat(client.getApiCallTimeout()).describedAs("sets property from first customizer")
+					.isEqualTo(Duration.ofMillis(2001));
+			assertThat(client.getApiCallAttemptTimeout()).describedAs("sets property from second customizer")
+					.isEqualTo(Duration.ofMillis(2002));
+			assertThat(client.getAsyncHttpClient()).describedAs("sets property from common client customizer")
+					.isNotNull();
+		});
+	}
+
+	@Test
+	void customClientCustomizerWithOrder() {
+		contextRunner.withUserConfiguration(CustomizerConfigWithOrder.class).run(context -> {
+			ConfiguredAwsClient client = new ConfiguredAwsClient(context.getBean(SqsAsyncClient.class));
+			assertThat(client.getApiCallTimeout())
+					.describedAs("property from the customizer with higher order takes precedence")
+					.isEqualTo(Duration.ofMillis(2001));
+		});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfig {
+
+		@Bean
+		SqsAsyncClientCustomizer customizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		SqsAsyncClientCustomizer customizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallAttemptTimeout(Duration.ofMillis(2002));
+				}));
+			};
+		}
+
+		@Bean
+		AwsAsyncClientCustomizer awsAsyncClientCustomizer() {
+			return builder -> {
+				builder.httpClient(
+						NettyNioAsyncHttpClient.builder().connectionTimeout(Duration.ofMillis(1542)).build());
+			};
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomizerConfigWithOrder {
+
+		@Bean
+		@Order(2)
+		SqsAsyncClientCustomizer customizer() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2001));
+				}));
+			};
+		}
+
+		@Bean
+		@Order(1)
+		SqsAsyncClientCustomizer customizer2() {
+			return builder -> {
+				builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
+					c.apiCallTimeout(Duration.ofMillis(2000));
+				}));
+			};
+		}
+	}
+
+}

--- a/spring-cloud-aws-testcontainers/src/main/java/io/awspring/cloud/testcontainers/LocalstackAwsClientFactory.java
+++ b/spring-cloud-aws-testcontainers/src/main/java/io/awspring/cloud/testcontainers/LocalstackAwsClientFactory.java
@@ -38,7 +38,7 @@ public class LocalstackAwsClientFactory implements AwsClientFactory {
 	}
 
 	@Override
-	public <CLIENT, BUILDER extends AwsClientBuilder<?, CLIENT>> CLIENT create(BUILDER builder) {
+	public <CLIENT, BUILDER extends AwsClientBuilder<BUILDER, CLIENT>> CLIENT create(BUILDER builder) {
 		return configurer.configure(builder).build();
 	}
 


### PR DESCRIPTION
Fixes #562

- allows defining a customizer for each supported AWS client builder, for example, to configure `DynamoDbClientBuilder` user must define one or more `DynamoDbClientCustomizer`
- there can be multiple customizers for each builder, `@Order` is taken into consideration when applying customization
- to customize every SDK client (sync/async) - for example to configure a custom HTTP client applied to all SDK clients - users can define one or more `CommonAwsSyncClientCustomizer` (for sync) or `CommonAwsAsyncClientCustomizer` (for async) beans.

Example:

```java
@Bean
@Order(1)
DynamoDbClientCustomizer dynamoDbClientCustomizer() {
	return builder -> {
		builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
			c.apiCallTimeout(Duration.ofMillis(2001));
		}));
	};
}

@Bean
@Order(2)
DynamoDbClientCustomizer dynamoDbClientCustomizer2() {
	return builder -> {
		builder.overrideConfiguration(builder.overrideConfiguration().copy(c -> {
			c.apiCallAttemptTimeout(Duration.ofMillis(2002));
		}));
	};
}

@Bean
CommonAwsSyncClientCustomizer commonAwsSyncClientCustomizer() {
	return builder -> {
		builder.httpClient(ApacheHttpClient.builder().connectionTimeout(Duration.ofMillis(1542)).build());
	};
}
```