### PR TITLE
Autoconfigure SsmClient even if config import is not used

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.autoconfigure.config.parameterstore;
 
+import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
 import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
 import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;
@@ -40,7 +41,8 @@ import software.amazon.awssdk.services.ssm.SsmClientBuilder;
 @AutoConfiguration
 @EnableConfigurationProperties(ParameterStoreProperties.class)
 @ConditionalOnClass({ SsmClient.class })
-@AutoConfigureAfter({ CredentialsProviderAutoConfiguration.class, RegionProviderAutoConfiguration.class })
+@AutoConfigureAfter({ CredentialsProviderAutoConfiguration.class, RegionProviderAutoConfiguration.class,
+		AwsAutoConfiguration.class })
 @ConditionalOnProperty(name = "spring.cloud.aws.parameterstore.enabled", havingValue = "true", matchIfMissing = true)
 public class ParameterStoreAutoConfiguration {
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreAutoConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.config.parameterstore;
+
+import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
+import io.awspring.cloud.autoconfigure.core.AwsClientCustomizer;
+import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;
+import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.SsmClientBuilder;
+
+/**
+ * {@link AutoConfiguration Auto-Configuration} for AWS Parameter Store integration.
+ *
+ * @author Oleh Onufryk
+ * @since 3.3.0
+ */
+@AutoConfiguration
+@EnableConfigurationProperties(ParameterStoreProperties.class)
+@ConditionalOnClass({ SsmClient.class })
+@AutoConfigureAfter({ CredentialsProviderAutoConfiguration.class, RegionProviderAutoConfiguration.class })
+@ConditionalOnProperty(name = "spring.cloud.aws.parameterstore.enabled", havingValue = "true", matchIfMissing = true)
+public class ParameterStoreAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	public SsmClient ssmClient(ParameterStoreProperties properties,
+			AwsClientBuilderConfigurer awsClientBuilderConfigurer,
+			ObjectProvider<AwsClientCustomizer<SsmClientBuilder>> customizers,
+			ObjectProvider<AwsConnectionDetails> connectionDetails) {
+		return awsClientBuilderConfigurer.configure(SsmClient.builder(), properties, connectionDetails.getIfAvailable(),
+				customizers.getIfAvailable()).build();
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -13,3 +13,4 @@ io.awspring.cloud.autoconfigure.dynamodb.DynamoDbAutoConfiguration
 io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerReloadAutoConfiguration
 io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerAutoConfiguration
 io.awspring.cloud.autoconfigure.config.parameterstore.ParameterStoreReloadAutoConfiguration
+io.awspring.cloud.autoconfigure.config.parameterstore.ParameterStoreAutoConfiguration

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreAutoConfigurationTest.java
@@ -1,0 +1,63 @@
+package io.awspring.cloud.autoconfigure.config.parameterstore;
+
+import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.mockito.internal.util.MockUtil;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import software.amazon.awssdk.services.ssm.SsmClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link ParameterStoreAutoConfiguration}
+ */
+class ParameterStoreAutoConfigurationTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withPropertyValues("spring.cloud.aws.region.static:eu-west-1")
+		.withConfiguration(AutoConfigurations.of(RegionProviderAutoConfiguration.class,
+			CredentialsProviderAutoConfiguration.class, ParameterStoreAutoConfiguration.class,
+			AwsAutoConfiguration.class));
+
+	@Test
+	void parameterStoreAutoConfigurationIsDisabled() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.parameterstore.enabled:false")
+			.run(context -> assertThat(context).doesNotHaveBean(SsmClient.class));
+	}
+
+	@Test
+	void parameterStoreAutoConfigurationIsEnabled() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.parameterstore.enabled:true")
+			.run(context -> assertThat(context).hasSingleBean(SsmClient.class));
+	}
+
+	@Test
+	void createsClientBeanByDefault() {
+		this.contextRunner.run(context -> assertThat(context).hasSingleBean(SsmClient.class));
+	}
+
+	@Test
+	void usesCustomBeanWhenProvided() {
+		this.contextRunner.withUserConfiguration(CustomParameterStoreConfiguration.class).run(context -> {
+			assertThat(context).hasSingleBean(SsmClient.class);
+			assertThat(MockUtil.isMock(context.getBean(SsmClient.class))).isTrue();
+		});
+	}
+
+	@TestConfiguration
+	static class CustomParameterStoreConfiguration {
+
+		@Bean
+		SsmClient ssmClient() {
+			return mock(SsmClient.class);
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreAutoConfigurationTest.java
@@ -1,4 +1,22 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.autoconfigure.config.parameterstore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
@@ -11,30 +29,27 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import software.amazon.awssdk.services.ssm.SsmClient;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-
 /**
  * Tests for {@link ParameterStoreAutoConfiguration}
  */
 class ParameterStoreAutoConfigurationTest {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-		.withPropertyValues("spring.cloud.aws.region.static:eu-west-1")
-		.withConfiguration(AutoConfigurations.of(RegionProviderAutoConfiguration.class,
-			CredentialsProviderAutoConfiguration.class, ParameterStoreAutoConfiguration.class,
-			AwsAutoConfiguration.class));
+			.withPropertyValues("spring.cloud.aws.region.static:eu-west-1")
+			.withConfiguration(AutoConfigurations.of(RegionProviderAutoConfiguration.class,
+					CredentialsProviderAutoConfiguration.class, ParameterStoreAutoConfiguration.class,
+					AwsAutoConfiguration.class));
 
 	@Test
 	void parameterStoreAutoConfigurationIsDisabled() {
 		this.contextRunner.withPropertyValues("spring.cloud.aws.parameterstore.enabled:false")
-			.run(context -> assertThat(context).doesNotHaveBean(SsmClient.class));
+				.run(context -> assertThat(context).doesNotHaveBean(SsmClient.class));
 	}
 
 	@Test
 	void parameterStoreAutoConfigurationIsEnabled() {
 		this.contextRunner.withPropertyValues("spring.cloud.aws.parameterstore.enabled:true")
-			.run(context -> assertThat(context).hasSingleBean(SsmClient.class));
+				.run(context -> assertThat(context).hasSingleBean(SsmClient.class));
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Implements #1231 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR solves the issue described in #1231 It creates autoconfiguration for the SsmClient 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
