### PR TITLE
Update labeler action to v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,33 +1,58 @@
 "component: core":
-  - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/core/*
-  - spring-cloud-aws-core/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/core/*
+      - spring-cloud-aws-core/**/*
 "component: cloudwatch":
-  - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/metrics/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/metrics/*
 "component: s3":
-  - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/s3/**/*
-  - spring-cloud-aws-s3-parent/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/s3/**/*
+      - spring-cloud-aws-s3-parent/**/*
 "component: parameter-store":
-  - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/config/parameterstore/*
-  - spring-cloud-aws-parameter-store/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/config/parameterstore/*
+      - spring-cloud-aws-parameter-store/**/*
 "component: secrets-manager":
-  - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/config/secretsmanager/*
-  - spring-cloud-aws-secrets-manager/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/config/secretsmanager/*
+      - spring-cloud-aws-secrets-manager/**/*
 "component: dynamodb":
-  - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/dynamodb/*
-  - spring-cloud-aws-dynamodb/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/dynamodb/*
+      - spring-cloud-aws-dynamodb/**/*
 "component: ses":
-  - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/ses/*
-  - spring-cloud-aws-ses/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/ses/*
+      - spring-cloud-aws-ses/**/*
 "component: sns":
-  - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/sns/*
-  - spring-cloud-aws-sns/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/sns/*
+      - spring-cloud-aws-sns/**/*
 "component: sqs":
-  - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/sqs/*
-  - spring-cloud-aws-sqs/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - spring-cloud-aws-autoconfigure/src/*/java/io/awspring/cloud/autoconfigure/sqs/*
+      - spring-cloud-aws-sqs/**/*
 "status: waiting-for-triage":
-  - ./*
-  - ./**/*
-"type: documentation": docs/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - ./*
+      - ./**/*
+"type: documentation":
+  - changed-files:
+    - any-glob-to-any-file:
+      - docs/**/*
 "type: dependency-upgrade":
-  - pom.xml
-  - spring-cloud-aws-dependencies/pom.xml
+  - changed-files:
+    - any-glob-to-any-file:
+      - pom.xml
+      - spring-cloud-aws-dependencies/pom.xml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,6 +12,7 @@ jobs:
       pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v2
+    - uses: actions/labeler@v5
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        sync-labels: true


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Updated Labeler Action to v5 (latest).

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently used Labeler Action v2 uses Node 12. That version of Node is deprecated, and produces warning when it is run.

## :green_heart: How did you test it?

I've updated the labeler config file according to its documentation. (I'm also using it in my projects).

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes