### PR TITLE
Add "type: maintenance" label for GitHub files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -56,3 +56,7 @@
     - any-glob-to-any-file:
       - pom.xml
       - spring-cloud-aws-dependencies/pom.xml
+"type: maintenance":
+  - changed-files:
+    - any-glob-to-any-file:
+      - .github/**/*


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring

## :scroll: Description
<!--- Describe your changes in detail -->
Labeler action will add "type: maintenance" label for GitHub files.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There was no label for PRs changing files in `.github` folder.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes

