### PR TITLE
Update setup-java action to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,56 +11,34 @@ permissions:
 
 jobs:
   build:
-    name: "Test with ${{ matrix.version }}"
+    name: Test with JDK ${{ matrix.version }}
     strategy:
       matrix:
-        version: [ 17.0.1-tem, 21-tem ]
+        version: [ 17.0.12, 21.0.4 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
+      - name: Set up JDK ${{ matrix.version }}
+        uses: actions/setup-java@v4
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
-      - name: Download ${{ matrix.version }}
-        uses: sdkman/sdkman-action@master
-        id: sdkman
-        with:
-          candidate: java
-          version: ${{ matrix.version }}
-      - name: Set up ${{ matrix.version }}
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-          jdkFile: ${{ steps.sdkman.outputs.file }}
+          distribution: temurin
+          java-version: ${{ matrix.version }}
+          cache: maven
       - name: Build with Maven
         run: ./mvnw -V -B verify -Pspring
   sonar:
-    name: "Run Sonar Analysis"
+    name: Run Sonar Analysis
     runs-on: ubuntu-latest
     # Disable Sonar for foreign PRs
     if: (github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository))
     steps:
       - uses: actions/checkout@v4
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
-      - name: Download JDK
-        uses: sdkman/sdkman-action@master
-        id: sdkman
-        with:
-          candidate: java
-          version: 17.0.1-tem
-      - name: Set up JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-          jdkFile: ${{ steps.sdkman.outputs.file }}
+          distribution: temurin
+          java-version: 17.0.12
+          cache: maven
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,30 +19,19 @@ permissions:
 
 jobs:
   build:
-    name: "Release"
+    name: Release
     strategy:
       matrix:
-        version: [ 17.0.1-tem ]
+        version: [ 17.0.12 ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
+      - name: Set up JDK ${{ matrix.version }}
+        uses: actions/setup-java@v4
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
-      - name: Download ${{ matrix.version }}
-        uses: sdkman/sdkman-action@master
-        id: sdkman
-        with:
-          candidate: java
-          version: ${{ matrix.version }}
-      - name: Set up ${{ matrix.version }}
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-          jdkFile: ${{ steps.sdkman.outputs.file }}
+          distribution: temurin
+          java-version: ${{ matrix.version }}
+          cache: maven
           server-id: ossrh-awspring
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD

--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -26,22 +26,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: sdkman/sdkman-action@master
-        id: sdkman
+        uses: actions/setup-java@v4
         with:
-          candidate: java
-          version: '17.0.1-tem'
-      - name: Set up JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-          jdkFile: ${{ steps.sdkman.outputs.file }}
-      - uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          distribution: temurin
+          java-version: 17.0.12
+          cache: maven
       - name: Build docs
         run: ./mvnw clean package javadoc:aggregate -Pdocs-classic,spring -DskipTests=true -e
       - name: Upload to S3


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Update CI workflows to use Setup Java Action v4 (the latest). 
This action also supports building with Temurin Java distribution and has internal caching for maven files.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently used Setup Java Action v1 uses Node 12. That version of Node is deprecated, and produces warning in repository actions runs.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes
