### PR TITLE
Do not apply `ObjectMetadata#contentLength` for `UploadPartRequest`. …

### DIFF
--- a/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/ObjectMetadata.java
+++ b/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/ObjectMetadata.java
@@ -340,9 +340,6 @@ public class ObjectMetadata {
 	}
 
 	void apply(UploadPartRequest.Builder builder) {
-		if (contentLength != null) {
-			builder.contentLength(contentLength);
-		}
 		if (sseCustomerAlgorithm != null) {
 			builder.sseCustomerAlgorithm(sseCustomerAlgorithm);
 		}

--- a/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/ObjectMetadataTests.java
+++ b/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/ObjectMetadataTests.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.RequestPayer;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.model.StorageClass;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 
 /**
  * Unit tests for {@link ObjectMetadata}.
@@ -76,6 +77,19 @@ class ObjectMetadataTests {
 		assertThat(result.requestPayer()).isEqualTo(RequestPayer.REQUESTER);
 		assertThat(result.serverSideEncryption()).isEqualTo(ServerSideEncryption.AES256);
 		assertThat(result.checksumAlgorithm()).isEqualTo(ChecksumAlgorithm.CRC32);
+	}
+
+	@Test
+	void doesNotApplyContentLengthForPartUpload() {
+		long objectContentLength =  16L;
+		long partContentLength = 8L;
+		ObjectMetadata metadata = ObjectMetadata.builder().contentLength(objectContentLength).build();
+
+		UploadPartRequest.Builder builder = UploadPartRequest.builder().contentLength(partContentLength);
+		metadata.apply(builder);
+		UploadPartRequest result = builder.build();
+
+		assertThat(result.contentLength()).isEqualTo(partContentLength);
 	}
 
 }

--- a/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ResourceIntegrationTests.java
+++ b/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ResourceIntegrationTests.java
@@ -219,6 +219,28 @@ class S3ResourceIntegrationTests {
 	}
 
 	@TestAvailableOutputStreamProviders
+	void contentLengthCanBeSetForLargeFiles(S3OutputStreamProvider s3OutputStreamProvider) throws IOException {
+		int i = new Random().nextInt();
+		S3Resource resource = s3Resource("s3://first-bucket/new-file" + i + ".txt", s3OutputStreamProvider);
+		int fileSize = DEFAULT_PART_SIZE * 2;
+		resource.setObjectMetadata(ObjectMetadata.builder().contentLength((long) fileSize).build());
+
+		// create file larger than single part size in multipart upload to make sure that file can be successfully
+		// uploaded in parts
+		File file = File.createTempFile("s3resource", "test");
+		byte[] b = new byte[fileSize];
+		new Random().nextBytes(b);
+		Files.write(b, file);
+
+		try (OutputStream outputStream = resource.getOutputStream()) {
+			outputStream.write(Files.toByteArray(file));
+		}
+		GetObjectResponse result = client
+			.getObject(request -> request.bucket("first-bucket").key("new-file" + i + ".txt").build()).response();
+		assertThat(result.contentType()).isEqualTo("text/plain");
+	}
+
+	@TestAvailableOutputStreamProviders
 	void contentTypeCanBeResolvedForSmallFiles(S3OutputStreamProvider s3OutputStreamProvider) throws IOException {
 		S3Resource resource = s3Resource("s3://first-bucket/new-file.txt", s3OutputStreamProvider);
 


### PR DESCRIPTION
…(#1248)

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Fixes #1248 
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?

Created new integration and unit test.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
