### PR TITLE
Fix setting timeout in seconds in `SqsTemplate`

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
@@ -602,11 +602,11 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		ReceiveMessageRequest.Builder builder = ReceiveMessageRequest.builder().queueUrl(attributes.getQueueUrl())
 				.maxNumberOfMessages(maxNumberOfMessages).messageAttributeNames(this.messageAttributeNames)
 				.attributeNamesWithStrings(this.messageSystemAttributeNames)
-				.waitTimeSeconds(pollTimeout.toSeconds());
+				.waitTimeSeconds(toInt(pollTimeout.toSeconds()));
 		if (additionalHeaders.containsKey(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER)) {
 			builder.visibilityTimeout(
-					getValueAs(additionalHeaders, SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Duration.class)
-							.toSeconds());
+				toInt(getValueAs(additionalHeaders, SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Duration.class)
+							.toSeconds()));
 		}
 		if (additionalHeaders.containsKey(SqsHeaders.SQS_RECEIVE_REQUEST_ATTEMPT_ID_HEADER)) {
 			builder.receiveRequestAttemptId(
@@ -614,6 +614,15 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 							.toString());
 		}
 		return builder.build();
+	}
+
+	// Convert a long value to an int. Values larger than Integer.MAX_VALUE are set to Integer.MAX_VALUE
+	private int toInt(long longValue) {
+		if (longValue > Integer.MAX_VALUE) {
+			return Integer.MAX_VALUE;
+		}
+
+		return (int) longValue;
 	}
 
 	private <V> V getValueAs(Map<String, Object> headers, String headerName, Class<V> valueClass) {

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
@@ -602,11 +602,11 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		ReceiveMessageRequest.Builder builder = ReceiveMessageRequest.builder().queueUrl(attributes.getQueueUrl())
 				.maxNumberOfMessages(maxNumberOfMessages).messageAttributeNames(this.messageAttributeNames)
 				.attributeNamesWithStrings(this.messageSystemAttributeNames)
-				.waitTimeSeconds(pollTimeout.toSecondsPart());
+				.waitTimeSeconds(pollTimeout.toSeconds());
 		if (additionalHeaders.containsKey(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER)) {
 			builder.visibilityTimeout(
 					getValueAs(additionalHeaders, SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Duration.class)
-							.toSecondsPart());
+							.toSeconds());
 		}
 		if (additionalHeaders.containsKey(SqsHeaders.SQS_RECEIVE_REQUEST_ATTEMPT_ID_HEADER)) {
 			builder.receiveRequestAttemptId(

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -937,7 +937,7 @@ class SqsTemplateTests {
 				.willReturn(CompletableFuture.completedFuture(deleteResponse));
 		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
 		Optional<Message<String>> receivedMessage = template.receive(from -> from.queue(queue)
-				.pollTimeout(Duration.ofSeconds(1)).visibilityTimeout(Duration.ofSeconds(5))
+				.pollTimeout(Duration.ofSeconds(61)).visibilityTimeout(Duration.ofSeconds(65))
 				.additionalHeader(headerName1, headerValue1).additionalHeaders(Map.of(headerName2, headerValue2)),
 				String.class);
 		assertThat(receivedMessage).isPresent().hasValueSatisfying(message -> {
@@ -949,8 +949,8 @@ class SqsTemplateTests {
 		then(mockClient).should().receiveMessage(captor.capture());
 		ReceiveMessageRequest request = captor.getValue();
 		assertThat(request.maxNumberOfMessages()).isEqualTo(1);
-		assertThat(request.visibilityTimeout()).isEqualTo(5);
-		assertThat(request.waitTimeSeconds()).isEqualTo(1);
+		assertThat(request.visibilityTimeout()).isEqualTo(65);
+		assertThat(request.waitTimeSeconds()).isEqualTo(61);
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
* Timeouts in SqsTemplate were being set by calling Duration#getSecondsPart which is always a number between 0 and 59
* Update to use Duration#getSeconds to get the full timeout specified, in seconds


## :bulb: Motivation and Context
This supports using a visibility time and polling timeout that's greater than 60 seconds.

## :green_heart: How did you test it?
Updated one of the unit tests for SqsTemplate


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
