### PR TITLE
remove s3-transfer-manager from spring-cloud-aws-dependencies

### DIFF
--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -83,12 +83,6 @@
 				<version>${amazon.s3.accessgrants}</version>
 				<optional>true</optional>
 			</dependency>
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>s3-transfer-manager</artifactId>
-				<version>${awssdk-v2.version}</version>
-				<optional>true</optional>
-			</dependency>
 
 			<dependency>
 				<groupId>io.awspring.cloud</groupId>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Removed `s3-transfer-manager` from `spring-cloud-aws-dependencies`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
addresses #1271 

`s3-transfer-manager` dependency is already managed in [aws-sdk-java-v2:bom](https://github.com/aws/aws-sdk-java-v2/blob/master/bom/pom.xml#L217)

## :green_heart: How did you test it?

run the test suite and added the `s3-transfer-manager` dependency to a test project using locally build `3.3.0-SNAPSHOT`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
