### PR TITLE
Add a constructor to S3ProtocolResolver allowing its usage outside of Spring context

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfiguration.java
@@ -34,7 +34,6 @@ import io.awspring.cloud.s3.S3Template;
 import java.util.Optional;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.*;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.PropertyMapper;
@@ -53,7 +52,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.encryption.s3.S3EncryptionClient;
 
 /**
- * {@link EnableAutoConfiguration} for {@link S3Client} and {@link S3ProtocolResolver}.
+ * {@link AutoConfiguration} for {@link S3Client} and {@link S3ProtocolResolver}.
  *
  * @author Maciej Walkowiak
  * @author Matej Nedic

--- a/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3ProtocolResolver.java
+++ b/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3ProtocolResolver.java
@@ -27,6 +27,7 @@ import org.springframework.core.io.ProtocolResolver;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 import software.amazon.awssdk.services.s3.S3Client;
 
 /**
@@ -52,6 +53,14 @@ public class S3ProtocolResolver implements ProtocolResolver, ResourceLoaderAware
 	private BeanFactory beanFactory;
 
 	public S3ProtocolResolver() {
+	}
+
+	// for direct usages outside of Spring context, when BeanFactory is not available
+	public S3ProtocolResolver(S3Client s3Client, S3OutputStreamProvider s3OutputStreamProvider) {
+		Assert.notNull(s3Client, "s3Client is required");
+		Assert.notNull(s3OutputStreamProvider, "s3OutputStreamProvider is required");
+		this.s3Client = s3Client;
+		this.s3OutputStreamProvider = s3OutputStreamProvider;
 	}
 
 	// only for testing

--- a/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ProtocolResolverTests.java
+++ b/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3ProtocolResolverTests.java
@@ -36,7 +36,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import software.amazon.awssdk.services.s3.S3Client;
 
 /**
- * Tests for {@link S3ProtocolResolverTests}.
+ * Tests for {@link S3ProtocolResolver}.
  *
  * @author Maciej Walkowiak
  */


### PR DESCRIPTION
Add a constructor to `S3ProtocolResolver` allowing its usage outside of Spring context

## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
A new constructor was added to `S3ProtocolResolver` allowing setting required fields directly rather than lazily later using `BeanFactory`. But the method with `BeanFactory` is still used by default by `S3AutoConfiguration` which creates `S3ProtocolResolver` through `@Import(S3ProtocolResolver.class)`, not through a method with `@Bean` annotation.


## :bulb: Motivation and Context
In our application we need to fetch some configuration files from S3 before Spring context fully starts, so that properties from S3 will be included in `@ConditionalOnProperty`, etc. We decided to do that in `EnvironmentPostProcessor`, we have working proof-of-concept with a copy of `S3ProtocolResolver` from Spring Cloud AWS but it would be best to use original `S3ProtocolResolver`, and a lack of proper constructor is blocking that.

We are aware of https://github.com/awspring/spring-cloud-aws/issues/161 but we need something lighter.

## :green_heart: How did you test it?
`S3ProtocolResolverTests` which use the same approach as in `S3AutoConfiguration`, i.e. `@Import(S3ProtocolResolver.class)` still pass, and the new constructor is not called automatically even if the no-arg one is removed (in such a case there is `BeanInstantiationException: Failed to instantiate [io.awspring.cloud.s3.S3ProtocolResolver]: No default constructor found`). That also means that the change is backward compatible and it neither affects the existing code nor change the flow.

## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing (plain Java tests are passing, I have problems running `@Testcontainers` on local machine)
- [x] No breaking changes


## :crystal_ball: Next steps
The new constructor could potentially be used to create a bean in the standard way through `@Bean` method but that would be a breaking change, assuming the no-arg constructor would be removed with that change.