### PR TITLE
Fixing issue 1262: AWSTraceHeader is now propagated

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
@@ -454,7 +454,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 	private Map<MessageSystemAttributeNameForSends, MessageSystemAttributeValue> mapMessageSystemAttributes(
 			Message message) {
 		return message.attributes().entrySet().stream().filter(Predicate.not(entry -> isSkipAttribute(entry.getKey())))
-				.collect(Collectors.toMap(entry -> MessageSystemAttributeNameForSends.fromValue(entry.getKey().name()),
+				.collect(Collectors.toMap(entry -> MessageSystemAttributeNameForSends.fromValue(entry.getKey().toString()),
 						entry -> MessageSystemAttributeValue.builder().dataType(MessageAttributeDataTypes.STRING)
 								.stringValue(entry.getValue()).build()));
 	}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsHeaderMapper.java
@@ -79,6 +79,10 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 			attributes.put(MessageSystemAttributeName.MESSAGE_DEDUPLICATION_ID,
 					headers.get(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, String.class));
 		}
+		if (headers.containsKey(SqsHeaders.MessageSystemAttributes.SQS_AWS_TRACE_HEADER)) {
+			attributes.put(MessageSystemAttributeName.AWS_TRACE_HEADER,
+				headers.get(SqsHeaders.MessageSystemAttributes.SQS_AWS_TRACE_HEADER, String.class));
+		}
 		Map<String, MessageAttributeValue> messageAttributes = headers.entrySet().stream()
 				.filter(entry -> !isSkipHeader(entry.getKey())).collect(Collectors.toMap(Map.Entry::getKey,
 						entry -> getMessageAttributeValue(entry.getKey(), entry.getValue())));
@@ -110,6 +114,7 @@ public class SqsHeaderMapper implements ContextAwareHeaderMapper<Message> {
 	private boolean isSkipHeader(String headerName) {
 		return SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER.equals(headerName)
 				|| SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER.equals(headerName)
+				|| SqsHeaders.MessageSystemAttributes.SQS_AWS_TRACE_HEADER.equals(headerName)
 				|| SqsHeaders.SQS_DELAY_HEADER.equals(headerName) || MessageHeaders.ID.equals(headerName)
 				|| MessageHeaders.TIMESTAMP.equals(headerName);
 	}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -20,8 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.sqs.QueueAttributesResolvingException;
@@ -47,23 +46,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
-import software.amazon.awssdk.services.sqs.model.CreateQueueResponse;
-import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
-import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResponse;
-import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest;
-import software.amazon.awssdk.services.sqs.model.GetQueueAttributesResponse;
-import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
-import software.amazon.awssdk.services.sqs.model.GetQueueUrlResponse;
-import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
-import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
-import software.amazon.awssdk.services.sqs.model.QueueDoesNotExistException;
-import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
-import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
-import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
-import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
-import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
-import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
-import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.services.sqs.model.*;
 
 /**
  * @author Tomaz Fernandes
@@ -1206,6 +1189,37 @@ class SqsTemplateTests {
 		assertThat(request.receiveRequestAttemptId()).isEqualTo(attemptId.toString());
 		assertThat(request.queueUrl()).isEqualTo(queue);
 
+	}
+
+	@Test
+	void shouldPropagateTracingAsMessageSystemAttribute() {
+		String queue = "test-queue";
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
+		SendMessageResponse response = SendMessageResponse.builder().messageId(UUID.randomUUID().toString())
+			.sequenceNumber("123").build();
+		given(mockClient.sendMessage(any(SendMessageRequest.class)))
+			.willReturn(CompletableFuture.completedFuture(response));
+
+		SqsOperations sqsOperations = SqsTemplate.newSyncTemplate(mockClient);
+		SendResult<Object> result = sqsOperations.send(options -> options
+			.queue(queue)
+			.header(SqsHeaders.MessageSystemAttributes.SQS_AWS_TRACE_HEADER, "abc")
+			.payload("test")
+		);
+
+		assertThat(result).isNotNull();
+
+		ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+		then(mockClient).should().sendMessage(captor.capture());
+		SendMessageRequest sendMessageRequest = captor.getValue();
+
+		assertThat(sendMessageRequest.messageSystemAttributes()).hasEntrySatisfying(
+			MessageSystemAttributeNameForSends.AWS_TRACE_HEADER,
+			value -> assertThat(value.stringValue()).isEqualTo("abc")
+		);
 	}
 
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
The fix propagates correctly the tracing header (AWSTraceHeader) as SQS message system attribute, when available among Spring Message headers


## :bulb: Motivation and Context
This PR is for fixing https://github.com/awspring/spring-cloud-aws/issues/1262

## :green_heart: How did you test it?
Added two tests: on `SqsTemplateTests` and `SqsHeaderMapperTests` involving the methods that have been changed

## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
