### PR TITLE
Introduce Analzyer for exceptions that happen during loading.

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/AwsParameterPropertySourceNotFoundException.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/AwsParameterPropertySourceNotFoundException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.config.parameterstore;
+
+public class AwsParameterPropertySourceNotFoundException extends RuntimeException {
+
+	AwsParameterPropertySourceNotFoundException(Exception source) {
+		super(source);
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoader.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreConfigDataLoader.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import org.springframework.boot.context.config.ConfigData;
 import org.springframework.boot.context.config.ConfigDataLoader;
 import org.springframework.boot.context.config.ConfigDataLoaderContext;
-import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
 import org.springframework.boot.logging.DeferredLogFactory;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.lang.Nullable;
@@ -47,28 +46,23 @@ public class ParameterStoreConfigDataLoader implements ConfigDataLoader<Paramete
 	@Override
 	@Nullable
 	public ConfigData load(ConfigDataLoaderContext context, ParameterStoreConfigDataResource resource) {
-		try {
-			// resource is disabled if parameter store integration is disabled via
-			// spring.cloud.aws.parameterstore.enabled=false
-			if (resource.isEnabled()) {
-				SsmClient ssm = context.getBootstrapContext().get(SsmClient.class);
-				ParameterStorePropertySource propertySource = resource.getPropertySources()
-						.createPropertySource(resource.getContext(), resource.isOptional(), ssm);
-				if (propertySource != null) {
-					return new ConfigData(Collections.singletonList(propertySource));
-				}
-				else {
-					return null;
-				}
+		// resource is disabled if parameter store integration is disabled via
+		// spring.cloud.aws.parameterstore.enabled=false
+		if (resource.isEnabled()) {
+			SsmClient ssm = context.getBootstrapContext().get(SsmClient.class);
+			ParameterStorePropertySource propertySource = resource.getPropertySources()
+					.createPropertySource(resource.getContext(), resource.isOptional(), ssm);
+			if (propertySource != null) {
+				return new ConfigData(Collections.singletonList(propertySource));
 			}
 			else {
-				// create dummy empty config data
-				return new ConfigData(
-						Collections.singletonList(new MapPropertySource("aws-parameterstore:" + context, Map.of())));
+				return null;
 			}
 		}
-		catch (Exception e) {
-			throw new ConfigDataResourceNotFoundException(resource, e);
+		else {
+			// create dummy empty config data
+			return new ConfigData(
+					Collections.singletonList(new MapPropertySource("aws-parameterstore:" + context, Map.of())));
 		}
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreExceptionHappenedAnalyzer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStoreExceptionHappenedAnalyzer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.config.parameterstore;
+
+import org.springframework.boot.diagnostics.AbstractFailureAnalyzer;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+
+public class ParameterStoreExceptionHappenedAnalyzer
+		extends AbstractFailureAnalyzer<AwsParameterPropertySourceNotFoundException> {
+
+	@Override
+	protected FailureAnalysis analyze(Throwable rootFailure, AwsParameterPropertySourceNotFoundException cause) {
+		return new FailureAnalysis("Could not import properties from AWS Parameter Store: " + cause.getMessage(),
+				"Depending on error message determine action course", cause);
+	}
+}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStorePropertySources.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/parameterstore/ParameterStorePropertySources.java
@@ -57,12 +57,4 @@ public class ParameterStorePropertySources {
 		return null;
 	}
 
-	static class AwsParameterPropertySourceNotFoundException extends RuntimeException {
-
-		AwsParameterPropertySourceNotFoundException(Exception source) {
-			super(source);
-		}
-
-	}
-
 }

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -13,5 +13,6 @@ io.awspring.cloud.autoconfigure.config.s3.S3ConfigDataLoader
 # Failure Analyzers
 org.springframework.boot.diagnostics.FailureAnalyzer=\
 io.awspring.cloud.autoconfigure.config.parameterstore.ParameterStoreMissingKeysFailureAnalyzer, \
+io.awspring.cloud.autoconfigure.config.parameterstore.ParameterStoreExceptionHappenedAnalyzer, \
 io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerMissingKeysFailureAnalyzer,\
 io.awspring.cloud.autoconfigure.config.s3.S3MissingKeysFailureAnalyzer


### PR DESCRIPTION
… happen during loading.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Since before we would wrap `AwsParameterPropertySourceNotFoundException` by re throwing it as `ConfigDataResourceNotFoundException`. This means that `ConfigDataNotFoundFailureAnalyzer` will pick it up and wrong message will be printed once error happens.

@maciejwalkowiak I am not happy with the naming (and I have not inspiration how to call it).  So please make a review before I change S3 and SecretsManager integration as well. :) 

## :bulb: Motivation and Context
closes #706

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
