### PR TITLE
Support `@ServiceConnection` endpoint attribute  for `S3Presigner`

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfiguration.java
@@ -110,12 +110,9 @@ public class S3AutoConfiguration {
 				.credentialsProvider(credentialsProvider).region(AwsClientBuilderConfigurer.resolveRegion(properties,
 						connectionDetails.getIfAvailable(), regionProvider));
 
-		if (properties.getEndpoint() != null) {
-			builder.endpointOverride(properties.getEndpoint());
-		}
-		else if (awsProperties.getEndpoint() != null) {
-			builder.endpointOverride(awsProperties.getEndpoint());
-		}
+		Optional.ofNullable(properties.getEndpoint()).ifPresent(builder::endpointOverride);
+		Optional.ofNullable(awsProperties.getEndpoint()).ifPresent(builder::endpointOverride);
+		Optional.ofNullable(connectionDetails.getIfAvailable()).map(AwsConnectionDetails::getEndpoint).ifPresent(builder::endpointOverride);
 		Optional.ofNullable(awsProperties.getFipsEnabled()).ifPresent(builder::fipsEnabled);
 		Optional.ofNullable(awsProperties.getDualstackEnabled()).ifPresent(builder::dualstackEnabled);
 		return builder.build();

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfiguration.java
@@ -56,6 +56,7 @@ import software.amazon.encryption.s3.S3EncryptionClient;
  *
  * @author Maciej Walkowiak
  * @author Matej Nedic
+ * @author Kunal Varpe
  */
 @AutoConfiguration
 @ConditionalOnClass({ S3Client.class, S3OutputStreamProvider.class })
@@ -110,9 +111,16 @@ public class S3AutoConfiguration {
 				.credentialsProvider(credentialsProvider).region(AwsClientBuilderConfigurer.resolveRegion(properties,
 						connectionDetails.getIfAvailable(), regionProvider));
 
-		Optional.ofNullable(properties.getEndpoint()).ifPresent(builder::endpointOverride);
-		Optional.ofNullable(awsProperties.getEndpoint()).ifPresent(builder::endpointOverride);
-		Optional.ofNullable(connectionDetails.getIfAvailable()).map(AwsConnectionDetails::getEndpoint).ifPresent(builder::endpointOverride);
+		if (properties.getEndpoint() != null) {
+			builder.endpointOverride(properties.getEndpoint());
+		}
+		else if (awsProperties.getEndpoint() != null) {
+			builder.endpointOverride(awsProperties.getEndpoint());
+		}
+		else if (connectionDetails.getIfAvailable() != null
+				&& connectionDetails.getIfAvailable().getEndpoint() != null) {
+			builder.endpointOverride(connectionDetails.getIfAvailable().getEndpoint());
+		}
 		Optional.ofNullable(awsProperties.getFipsEnabled()).ifPresent(builder::fipsEnabled);
 		Optional.ofNullable(awsProperties.getDualstackEnabled()).ifPresent(builder::dualstackEnabled);
 		return builder.build();

--- a/spring-cloud-aws-testcontainers/src/test/java/io/awspring/cloud/testcontainers/AwsContainerConnectionDetailsFactoryTest.java
+++ b/spring-cloud-aws-testcontainers/src/test/java/io/awspring/cloud/testcontainers/AwsContainerConnectionDetailsFactoryTest.java
@@ -28,6 +28,7 @@ import io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration;
 import io.awspring.cloud.autoconfigure.ses.SesAutoConfiguration;
 import io.awspring.cloud.autoconfigure.sns.SnsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
@@ -40,9 +41,13 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.ses.SesClient;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+import java.time.Duration;
 
 @SpringJUnitConfig
 @Testcontainers(disabledWithoutDocker = true)
@@ -86,6 +91,14 @@ class AwsContainerConnectionDetailsFactoryTest {
 	@Test
 	void configuresS3ClientWithServiceConnection(@Autowired S3Client client) {
 		assertThatCode(client::listBuckets).doesNotThrowAnyException();
+	}
+
+	@Test
+	@Disabled
+	void configuresS3PresignerWithServiceConnection(@Autowired S3Presigner s3Presigner) {
+		assertThatCode(() -> s3Presigner.presignGetObject(req1 -> req1.signatureDuration(Duration.ofSeconds(2))
+			.getObjectRequest(req2 -> req2.bucket("my-bucket").build())))
+			.doesNotThrowAnyException();
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-aws-testcontainers/src/test/java/io/awspring/cloud/testcontainers/AwsContainerConnectionDetailsFactoryTest.java
+++ b/spring-cloud-aws-testcontainers/src/test/java/io/awspring/cloud/testcontainers/AwsContainerConnectionDetailsFactoryTest.java
@@ -28,7 +28,7 @@ import io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration;
 import io.awspring.cloud.autoconfigure.ses.SesAutoConfiguration;
 import io.awspring.cloud.autoconfigure.sns.SnsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration;
-import org.junit.jupiter.api.Disabled;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
@@ -42,12 +42,9 @@ import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
-import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.ses.SesClient;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
-
-import java.time.Duration;
 
 @SpringJUnitConfig
 @Testcontainers(disabledWithoutDocker = true)
@@ -94,11 +91,9 @@ class AwsContainerConnectionDetailsFactoryTest {
 	}
 
 	@Test
-	@Disabled
 	void configuresS3PresignerWithServiceConnection(@Autowired S3Presigner s3Presigner) {
 		assertThatCode(() -> s3Presigner.presignGetObject(req1 -> req1.signatureDuration(Duration.ofSeconds(2))
-			.getObjectRequest(req2 -> req2.bucket("my-bucket").build())))
-			.doesNotThrowAnyException();
+				.getObjectRequest(req2 -> req2.bucket("my-bucket").key("test").build()))).doesNotThrowAnyException();
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
Fixes: gh-1289

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This change address the issue where endpoint property is not respected for S3Presigner bean auto configuration with `@ServiceConnection` .  

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It fixes #1289 which reports the issue.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
