### PR TITLE
Add SQSListener argument resolver to extract the subject of an SNS me…

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -639,6 +639,16 @@ public void listen(@SnsNotificationMessage List<Pojo> pojos) {
 }
 ----
 
+Since 3.3.0 you can also retrieve the subject of the SNS message through the `@SnsNotificationSubject` annotation.
+
+[source, java]
+----
+@SqsListener("my-queue")
+public void listen(@SnsNotificationSubject String subject) {
+	System.out.println(subject);
+}
+----
+
 ===== Specifying a MessageListenerContainerFactory
 A `MessageListenerContainerFactory` can be specified through the `factory` property.
 Such factory will then be used to create the container for the annotated method.

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -639,13 +639,13 @@ public void listen(@SnsNotificationMessage List<Pojo> pojos) {
 }
 ----
 
-Since 3.3.0 you can also retrieve the subject of the SNS message through the `@SnsNotificationSubject` annotation.
+Since 3.3.1 you can also retrieve the subject of the SNS message through the `@SnsNotificationSubject` annotation.
 
 [source, java]
 ----
 @SqsListener("my-queue")
-public void listen(@SnsNotificationSubject String subject) {
-	System.out.println(subject);
+public void listen(@SnsNotificationSubject String subject, @SnsNotificationMessage Pojo pojo) {
+	System.out.println("received message for subject %s: %s".formatted(subject, pojo));
 }
 ----
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/ConfigStoreRuntimeHints.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/ConfigStoreRuntimeHints.java
@@ -52,12 +52,12 @@ public class ConfigStoreRuntimeHints implements RuntimeHintsRegistrar {
 
 		if (ClassUtils.isPresent("io.awspring.cloud.s3.S3PropertySource", classLoader)) {
 			hints.reflection().registerType(TypeReference.of(S3PropertySources.class),
-				hint -> hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
-					MemberCategory.INTROSPECT_DECLARED_METHODS, MemberCategory.DECLARED_FIELDS));
+					hint -> hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+							MemberCategory.INTROSPECT_DECLARED_METHODS, MemberCategory.DECLARED_FIELDS));
 
 			hints.reflection().registerType(TypeReference.of(S3PropertySource.class),
-				hint -> hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
-					MemberCategory.INTROSPECT_DECLARED_METHODS, MemberCategory.DECLARED_FIELDS));
+					hint -> hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+							MemberCategory.INTROSPECT_DECLARED_METHODS, MemberCategory.DECLARED_FIELDS));
 		}
 	}
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SnsNotificationSubject.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SnsNotificationSubject.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
  * Controllers method for handling/receiving SQS notifications.
  *
  * @author Alexander Nebel
- * @since 3.3.0
+ * @since 3.3.1
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SnsNotificationSubject.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SnsNotificationSubject.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that is used to map SNS notification subject on an SQS Queue to a variable that is annotated. Used in
+ * Controllers method for handling/receiving SQS notifications.
+ *
+ * @author Alexander Nebel
+ * @since 3.3.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface SnsNotificationSubject {
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
@@ -22,6 +22,7 @@ import io.awspring.cloud.sqs.config.SqsEndpoint;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
 import io.awspring.cloud.sqs.support.resolver.BatchVisibilityHandlerMethodArgumentResolver;
 import io.awspring.cloud.sqs.support.resolver.NotificationMessageArgumentResolver;
+import io.awspring.cloud.sqs.support.resolver.NotificationSubjectArgumentResolver;
 import io.awspring.cloud.sqs.support.resolver.QueueAttributesMethodArgumentResolver;
 import io.awspring.cloud.sqs.support.resolver.SqsMessageMethodArgumentResolver;
 import io.awspring.cloud.sqs.support.resolver.VisibilityHandlerMethodArgumentResolver;
@@ -84,6 +85,7 @@ public class SqsListenerAnnotationBeanPostProcessor extends AbstractListenerAnno
 		List<HandlerMethodArgumentResolver> argumentResolvers = new ArrayList<>(createAdditionalArgumentResolvers());
 		if (objectMapper != null) {
 			argumentResolvers.add(new NotificationMessageArgumentResolver(messageConverter, objectMapper));
+			argumentResolvers.add(new NotificationSubjectArgumentResolver(objectMapper));
 		}
 		return argumentResolvers;
 	}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsJsonNode.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsJsonNode.java
@@ -22,7 +22,7 @@ import org.springframework.messaging.converter.MessageConversionException;
 /**
  * @author Michael Sosa
  * @author Alexander Nebel
- * @since 3.3.0
+ * @since 3.3.1
  */
 public class SnsJsonNode {
 	private final String jsonString;

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsJsonNode.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsJsonNode.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.support.converter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.messaging.converter.MessageConversionException;
+
+/**
+ * @author Michael Sosa
+ * @author Alexander Nebel
+ * @since 3.3.0
+ */
+public class SnsJsonNode {
+	private final String jsonString;
+	private final JsonNode jsonNode;
+
+	public SnsJsonNode(ObjectMapper jsonMapper, String jsonString) {
+		try {
+			this.jsonString = jsonString;
+			jsonNode = jsonMapper.readTree(jsonString);
+		}
+		catch (Exception e) {
+			throw new MessageConversionException("Could not read JSON", e);
+		}
+		validate();
+	}
+
+	void validate() throws MessageConversionException {
+		if (!jsonNode.has("Type")) {
+			throw new MessageConversionException("Payload: '" + jsonString + "' does not contain a Type attribute",
+					null);
+		}
+
+		if (!"Notification".equals(jsonNode.get("Type").asText())) {
+			throw new MessageConversionException("Payload: '" + jsonString + "' is not a valid notification", null);
+		}
+
+		if (!jsonNode.has("Message")) {
+			throw new MessageConversionException("Payload: '" + jsonString + "' does not contain a message", null);
+		}
+	}
+
+	public String getMessageAsString() {
+		return jsonNode.get("Message").asText();
+	}
+
+	public String getSubjectAsString() {
+		if (!jsonNode.has("Subject")) {
+			throw new MessageConversionException("Payload: '" + jsonString + "' does not contain a subject", null);
+		}
+		return jsonNode.get("Subject").asText();
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsSubjectConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsSubjectConverter.java
@@ -30,11 +30,11 @@ import org.springframework.util.ClassUtils;
  */
 public class SnsSubjectConverter implements MessageConverter {
 
-	private final ObjectMapper jsonMapper;
+	private final ObjectMapper objectMapper;
 
-	public SnsSubjectConverter(ObjectMapper jsonMapper) {
-		Assert.notNull(jsonMapper, "jsonMapper must not be null");
-		this.jsonMapper = jsonMapper;
+	public SnsSubjectConverter(ObjectMapper objectMapper) {
+		Assert.notNull(objectMapper, "jsonMapper must not be null");
+		this.objectMapper = objectMapper;
 	}
 
 	@Override
@@ -51,7 +51,7 @@ public class SnsSubjectConverter implements MessageConverter {
 			throw new MessageConversionException("Conversion of List is not supported", null);
 		}
 
-		var snsJsonNode = new SnsJsonNode(jsonMapper, message.getPayload().toString());
+		var snsJsonNode = new SnsJsonNode(objectMapper, message.getPayload().toString());
 		return snsJsonNode.getSubjectAsString();
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsSubjectConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsSubjectConverter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.support.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+/**
+ * @author Alexander Nebel
+ * @since 3.3.0
+ */
+public class SnsSubjectConverter implements MessageConverter {
+
+	private final ObjectMapper jsonMapper;
+
+	public SnsSubjectConverter(ObjectMapper jsonMapper) {
+		Assert.notNull(jsonMapper, "jsonMapper must not be null");
+		this.jsonMapper = jsonMapper;
+	}
+
+	@Override
+	public Object fromMessage(Message<?> message, Class<?> targetClass) {
+		Assert.notNull(message, "message must not be null");
+		Assert.notNull(targetClass, "target class must not be null");
+
+		Object payload = message.getPayload();
+
+		if (!ClassUtils.isAssignable(targetClass, String.class)) {
+			throw new MessageConversionException("Subject can only be injected into String assignable Types", null);
+		}
+		if (payload instanceof List) {
+			throw new MessageConversionException("Conversion of List is not supported", null);
+		}
+
+		var snsJsonNode = new SnsJsonNode(jsonMapper, message.getPayload().toString());
+		return snsJsonNode.getSubjectAsString();
+	}
+
+	@Override
+	public Message<?> toMessage(Object payload, MessageHeaders headers) {
+		throw new UnsupportedOperationException(
+				"This converter only supports reading a SNS notification and not writing them");
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsSubjectConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SnsSubjectConverter.java
@@ -26,7 +26,7 @@ import org.springframework.util.ClassUtils;
 
 /**
  * @author Alexander Nebel
- * @since 3.3.0
+ * @since 3.3.1
  */
 public class SnsSubjectConverter implements MessageConverter {
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/NotificationSubjectArgumentResolver.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/NotificationSubjectArgumentResolver.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.support.resolver;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.annotation.SnsNotificationSubject;
+import io.awspring.cloud.sqs.support.converter.SnsSubjectConverter;
+import java.lang.reflect.Executable;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.util.ClassUtils;
+
+/**
+ * @author Alexander Nebel
+ * @since 3.3.0
+ */
+public class NotificationSubjectArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private static final Logger logger = LoggerFactory.getLogger(NotificationSubjectArgumentResolver.class);
+
+	private final MessageConverter converter;
+
+	public NotificationSubjectArgumentResolver(ObjectMapper jsonMapper) {
+		this.converter = new SnsSubjectConverter(jsonMapper);
+	}
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		if (parameter.hasParameterAnnotation(SnsNotificationSubject.class)) {
+			if (ClassUtils.isAssignable(parameter.getParameterType(), String.class)) {
+				return true;
+			}
+			if (logger.isWarnEnabled()) {
+				logger.warn(
+						"Notification subject can only be injected into String assignable Types - No injection happening for {}#{}",
+						parameter.getDeclaringClass().getName(), getMethodName(parameter));
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter par, Message<?> msg) {
+		return converter.fromMessage(msg, par.getParameterType());
+	}
+
+	private String getMethodName(MethodParameter parameter) {
+		var method = parameter.getMethod();
+		var constructor = parameter.getConstructor();
+		return Optional.ofNullable(method != null ? method : constructor).map(Executable::getName)
+				.orElse("<Method name not resolvable>");
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/NotificationSubjectArgumentResolver.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/resolver/NotificationSubjectArgumentResolver.java
@@ -30,7 +30,7 @@ import org.springframework.util.ClassUtils;
 
 /**
  * @author Alexander Nebel
- * @since 3.3.0
+ * @since 3.3.1
  */
 public class NotificationSubjectArgumentResolver implements HandlerMethodArgumentResolver {
 

--- a/spring-cloud-aws-sqs/src/test/resources/notificationMessage.json
+++ b/spring-cloud-aws-sqs/src/test/resources/notificationMessage.json
@@ -1,5 +1,6 @@
 {
 	"Type": "Notification",
+	"Subject": "IntegrationTestSubject",
 	"MessageId": "f2c15fec-c617-5b08-b54d-13c4099fec60",
 	"TopicArn": "arn:aws:sns:eu-west-1:111111111111:mySampleTopic",
 	"Message": "{\"specversion\": \"1.0.2\", \"data\": {\"firstField\":\"pojoNotificationMessage\",\"secondField\":\"secondValue\"}}",


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Support extracting of SNS subjects in SQS listeners using an annotation on a String parameter

I looked at the following PR and made the change accordingly to the current state of the code added there:
https://github.com/awspring/spring-cloud-aws/pull/898

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This functionality was there in the old spring-cloud-aws library (2.x) and is making transitioning to the new library easier.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
