### PR TITLE
Set S3AsyncClient endpoint from localstack if available in tests

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfiguration.java
@@ -67,6 +67,8 @@ public class S3CrtAsyncClientAutoConfiguration {
 			ObjectProvider<AwsConnectionDetails> connectionDetails) {
 		S3CrtAsyncClientBuilder builder = S3AsyncClient.crtBuilder().credentialsProvider(credentialsProvider).region(
 				this.awsClientBuilderConfigurer.resolveRegion(this.properties, connectionDetails.getIfAvailable()));
+		Optional.ofNullable(connectionDetails.getIfAvailable()).map(AwsConnectionDetails::getEndpoint)
+			.ifPresent(builder::endpointOverride);
 		Optional.ofNullable(this.awsProperties.getEndpoint()).ifPresent(builder::endpointOverride);
 		Optional.ofNullable(this.properties.getEndpoint()).ifPresent(builder::endpointOverride);
 		Optional.ofNullable(this.properties.getCrossRegionEnabled()).ifPresent(builder::crossRegionAccessEnabled);

--- a/spring-cloud-aws-testcontainers/pom.xml
+++ b/spring-cloud-aws-testcontainers/pom.xml
@@ -66,6 +66,11 @@
 			<artifactId>spring-cloud-aws-starter-s3</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>aws-crt-client</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-cloud-aws-testcontainers/src/test/java/io/awspring/cloud/testcontainers/AwsContainerConnectionDetailsFactoryTest.java
+++ b/spring-cloud-aws-testcontainers/src/test/java/io/awspring/cloud/testcontainers/AwsContainerConnectionDetailsFactoryTest.java
@@ -25,6 +25,7 @@ import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration
 import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
 import io.awspring.cloud.autoconfigure.dynamodb.DynamoDbAutoConfiguration;
 import io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration;
+import io.awspring.cloud.autoconfigure.s3.S3CrtAsyncClientAutoConfiguration;
 import io.awspring.cloud.autoconfigure.ses.SesAutoConfiguration;
 import io.awspring.cloud.autoconfigure.sns.SnsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration;
@@ -39,6 +40,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.ses.SesClient;
 import software.amazon.awssdk.services.sns.SnsClient;
@@ -88,10 +90,16 @@ class AwsContainerConnectionDetailsFactoryTest {
 		assertThatCode(client::listBuckets).doesNotThrowAnyException();
 	}
 
+	@Test
+	void configuresS3AsyncClientWithServiceConnection(@Autowired S3AsyncClient client) {
+		assertThatCode(client.listBuckets()::join).doesNotThrowAnyException();
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	@ImportAutoConfiguration({ AwsAutoConfiguration.class, CredentialsProviderAutoConfiguration.class,
 			RegionProviderAutoConfiguration.class, DynamoDbAutoConfiguration.class, SesAutoConfiguration.class,
-			SqsAutoConfiguration.class, SnsAutoConfiguration.class, S3AutoConfiguration.class })
+			SqsAutoConfiguration.class, SnsAutoConfiguration.class, S3AutoConfiguration.class,
+			S3CrtAsyncClientAutoConfiguration.class })
 	static class TestConfiguration {
 	}
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Changing `S3CrtAsyncClientAutoConfiguration#s3AsyncClient` to call `AwsConnectionDetails#getEndpoint` if available that should provide the `S3AsyncClient` with the endpoint to the localstack container if available.
I'm not sure if this was the right way to achieve this, hence a draft PR


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/awspring/spring-cloud-aws/issues/1329. It looks like the `S3AsyncClient` wasn't fetching the endpoint from localstack container

## :green_heart: How did you test it?
Added a test method `AwsContainerConnectionDetailsFactoryTest#configuresS3AsyncClientWithServiceConnection` that checks `@Autowired S3AsyncClient client` can list buckets while relying in `@ServiceConnection` localstack container

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
None?