### PR TITLE
#595 migrate to sesv2

### DIFF
--- a/docs/src/main/asciidoc/ses.adoc
+++ b/docs/src/main/asciidoc/ses.adoc
@@ -135,8 +135,7 @@ The Spring Boot Starter for SES provides the following configuration options:
 | `spring.cloud.aws.ses.enabled` | Enables the SES integration. | No | `true`
 | `spring.cloud.aws.ses.endpoint` | Configures endpoint used by `SesClient`. | No |
 | `spring.cloud.aws.ses.region` | Configures region used by `SesClient`. | No |
-| `spring.cloud.aws.ses.source-arn` | Configures source ARN, used only for sending authorization. | No |
-| `spring.cloud.aws.ses.from-arn` | Configures from ARN, used only for sending authorization in the SendRawEmail operation. | No |
+| `spring.cloud.aws.ses.identity-arn` | Configures identity ARN, used only for sending authorization. | No |
 | `spring.cloud.aws.ses.configuration-set-name` | The configuration set name used for every message | No |
 |===
 
@@ -146,11 +145,8 @@ service will produce an error while using the mail service. Therefore, the regio
 sender configuration. The example below shows a typical combination of a region (`EU-CENTRAL-1`) that does not provide
 an SES service where the client is overridden to use a valid region (`EU-WEST-1`).
 
-`sourceArn` is the ARN of the identity that is associated with the sending authorization policy. For information about when to use this parameter, see the
-description see https://docs.aws.amazon.com/ses/latest/dg/sending-authorization-delegate-sender-tasks-email.html[Amazon SES Developer Guide].
-
-`fromArn` is the ARN of the identity that is associated with the sending authorization policy that permits you to specify a particular "From" address in the header of the raw email.
-For information about when to use this parameter, see the description see https://docs.aws.amazon.com/ses/latest/dg/sending-authorization-delegate-sender-tasks-email.html[Amazon SES Developer Guide].
+`identityArn` is the ARN of the identity that is associated with the sending authorization policy. For information about when to use this parameter, see the
+description see https://docs.aws.amazon.com/ses/latest/dg/sending-authorization-overview.html[https://docs.aws.amazon.com/ses/latest/dg/sending-authorization-delegate-sender-tasks-email.html][Amazon SES Developer Guide].
 
 `configurationSetName` sets the configuration set name on mail sender level and applies to every mail. For information about when to use this parameter, see the
 description https://docs.aws.amazon.com/ses/latest/dg/using-configuration-sets.html[Using configuration sets in Amazon SES].
@@ -158,8 +154,7 @@ description https://docs.aws.amazon.com/ses/latest/dg/using-configuration-sets.h
 [source,properties,indent=0]
 ----
 spring.cloud.aws.ses.region=eu-west-1
-spring.cloud.aws.ses.source-arn=arn:aws:ses:eu-west-1:123456789012:identity/example.com
-spring.cloud.aws.ses.from-arn=arn:aws:ses:eu-west-1:123456789012:identity/example.com
+spring.cloud.aws.ses.identity-arn=arn:aws:ses:eu-west-1:123456789012:identity/example.com
 spring.cloud.aws.ses.configuration-set-name=ConfigSet
 ----
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesClientCustomizer.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesClientCustomizer.java
@@ -16,14 +16,14 @@
 package io.awspring.cloud.autoconfigure.ses;
 
 import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
-import software.amazon.awssdk.services.ses.SesClientBuilder;
+import software.amazon.awssdk.services.sesv2.SesV2ClientBuilder;
 
 /**
- * Callback interface that can be used to customize a {@link SesClientBuilder}.
+ * Callback interface that can be used to customize a {@link SesV2ClientBuilder}.
  *
  * @author Maciej Walkowiak
  * @since 3.3.0
  */
 @FunctionalInterface
-public interface SesClientCustomizer extends AwsClientCustomizer<SesClientBuilder> {
+public interface SesClientCustomizer extends AwsClientCustomizer<SesV2ClientBuilder> {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/ses/SesProperties.java
@@ -24,6 +24,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Eddú Meléndez
  * @author Arun Patra
+ * @author Dominik Kovács
  */
 @ConfigurationProperties(prefix = SesProperties.PREFIX)
 public class SesProperties extends AwsClientProperties {
@@ -34,10 +35,10 @@ public class SesProperties extends AwsClientProperties {
 	public static final String PREFIX = "spring.cloud.aws.ses";
 
 	/**
-	 * Configures source ARN. Used only for sending authorization.
+	 * Configures identity ARN. Used only for sending authorization.
 	 */
 	@Nullable
-	private String sourceArn;
+	private String identityArn;
 
 	/**
 	 * Configures configuration set name.
@@ -45,15 +46,9 @@ public class SesProperties extends AwsClientProperties {
 	@Nullable
 	private String configurationSetName;
 
-	/**
-	 * Configures from ARN. Only applies to SendRawEmail operation.
-	 */
 	@Nullable
-	private String fromArn;
-
-	@Nullable
-	public String getSourceArn() {
-		return sourceArn;
+	public String getIdentityArn() {
+		return identityArn;
 	}
 
 	@Nullable
@@ -61,21 +56,12 @@ public class SesProperties extends AwsClientProperties {
 		return configurationSetName;
 	}
 
-	@Nullable
-	public String getFromArn() {
-		return fromArn;
-	}
-
-	public void setSourceArn(@Nullable String sourceArn) {
-		this.sourceArn = sourceArn;
+	public void setIdentityArn(@Nullable String identityArn) {
+		this.identityArn = identityArn;
 	}
 
 	public void setConfigurationSetName(@Nullable String configurationSetName) {
 		this.configurationSetName = configurationSetName;
-	}
-
-	public void setFromArn(@Nullable String fromArn) {
-		this.fromArn = fromArn;
 	}
 
 }

--- a/spring-cloud-aws-ses/pom.xml
+++ b/spring-cloud-aws-ses/pom.xml
@@ -23,7 +23,7 @@
 		</dependency>
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
-			<artifactId>ses</artifactId>
+			<artifactId>sesv2</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.mail</groupId>

--- a/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/SimpleEmailServiceJavaMailSender.java
+++ b/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/SimpleEmailServiceJavaMailSender.java
@@ -42,10 +42,10 @@ import org.springframework.mail.javamail.MimeMessagePreparator;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.services.ses.SesClient;
-import software.amazon.awssdk.services.ses.model.RawMessage;
-import software.amazon.awssdk.services.ses.model.SendRawEmailRequest;
-import software.amazon.awssdk.services.ses.model.SendRawEmailResponse;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.RawMessage;
+import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
+import software.amazon.awssdk.services.sesv2.model.SendEmailResponse;
 
 /**
  * {@link JavaMailSender} implementation that allows to send {@link MimeMessage} using the Simple E-Mail Service. In
@@ -55,6 +55,7 @@ import software.amazon.awssdk.services.ses.model.SendRawEmailResponse;
  * @author Agim Emruli
  * @author Eddú Meléndez
  * @author Arun Patra
+ * @author Dominik Kovács
  * @since 1.0
  */
 public class SimpleEmailServiceJavaMailSender extends SimpleEmailServiceMailSender implements JavaMailSender {
@@ -74,26 +75,17 @@ public class SimpleEmailServiceJavaMailSender extends SimpleEmailServiceMailSend
 	@Nullable
 	private FileTypeMap defaultFileTypeMap;
 
-	@Nullable
-	private String fromArn;
-
-	public SimpleEmailServiceJavaMailSender(SesClient sesClient) {
+	public SimpleEmailServiceJavaMailSender(SesV2Client sesClient) {
 		this(sesClient, null);
 	}
 
-	public SimpleEmailServiceJavaMailSender(SesClient sesClient, @Nullable String sourceArn) {
-		this(sesClient, sourceArn, null);
+	public SimpleEmailServiceJavaMailSender(SesV2Client sesClient, @Nullable String identityArn) {
+		this(sesClient, identityArn, null);
 	}
 
-	public SimpleEmailServiceJavaMailSender(SesClient sesClient, @Nullable String sourceArn,
+	public SimpleEmailServiceJavaMailSender(SesV2Client sesClient, @Nullable String identityArn,
 			@Nullable String configurationSetName) {
-		super(sesClient, sourceArn, configurationSetName);
-	}
-
-	public SimpleEmailServiceJavaMailSender(SesClient sesClient, @Nullable String sourceArn,
-			@Nullable String configurationSetName, @Nullable String fromArn) {
-		super(sesClient, sourceArn, configurationSetName);
-		this.fromArn = fromArn;
+		super(sesClient, identityArn, configurationSetName);
 	}
 
 	/**
@@ -215,19 +207,20 @@ public class SimpleEmailServiceJavaMailSender extends SimpleEmailServiceMailSend
 	public void send(MimeMessage... mimeMessages) throws MailException {
 		Assert.notNull(mimeMessages, "mimeMessages are required");
 		Map<Object, Exception> failedMessages = new HashMap<>();
-
 		for (MimeMessage mimeMessage : mimeMessages) {
 			try {
-				RawMessage rawMessage = createRawMessage(mimeMessage);
+				SendEmailRequest request = SendEmailRequest.builder()
+					.fromEmailAddressIdentityArn(getIdentityArn())
+					.configurationSetName(getConfigurationSetName())
+					.content(content -> content.raw(createRawMessage(mimeMessage)))
+					.build();
 
-				SendRawEmailResponse sendRawEmailResponse = getEmailService()
-						.sendRawEmail(SendRawEmailRequest.builder().sourceArn(getSourceArn()).fromArn(this.fromArn)
-								.configurationSetName(getConfigurationSetName()).rawMessage(rawMessage).build());
+				SendEmailResponse sendEmailResponse = getEmailService().sendEmail(request);
 
 				if (LOGGER.isDebugEnabled()) {
-					LOGGER.debug("Message with id: {} successfully sent", sendRawEmailResponse.messageId());
+					LOGGER.debug("Message with id: {} successfully sent", sendEmailResponse.messageId());
 				}
-				mimeMessage.setHeader("Message-ID", sendRawEmailResponse.messageId());
+				mimeMessage.setHeader("Message-ID", sendEmailResponse.messageId());
 			}
 			catch (Exception e) {
 				// Ignore Exception because we are collecting and throwing all if any

--- a/spring-cloud-aws-ses/src/test/java/io/awspring/cloud/ses/SimpleEmailServiceMailSenderTest.java
+++ b/spring-cloud-aws-ses/src/test/java/io/awspring/cloud/ses/SimpleEmailServiceMailSenderTest.java
@@ -28,10 +28,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.SimpleMailMessage;
-import software.amazon.awssdk.services.ses.SesClient;
-import software.amazon.awssdk.services.ses.model.SendEmailRequest;
-import software.amazon.awssdk.services.ses.model.SendEmailResponse;
-import software.amazon.awssdk.services.ses.model.SesException;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
+import software.amazon.awssdk.services.sesv2.model.SendEmailResponse;
+import software.amazon.awssdk.services.sesv2.model.SesV2Exception;
 
 /**
  * Tests for {@link SimpleEmailServiceMailSender}.
@@ -39,12 +39,13 @@ import software.amazon.awssdk.services.ses.model.SesException;
  * @author Eddú Meléndez
  * @author Maciej Walkowiak
  * @author Arun Patra
+ * @author Dominik Kovács
  */
 class SimpleEmailServiceMailSenderTest {
 
 	@Test
 	void testSendSimpleMailWithMinimalProperties() {
-		SesClient emailService = mock(SesClient.class);
+		SesV2Client emailService = mock(SesV2Client.class);
 		SimpleEmailServiceMailSender mailSender = new SimpleEmailServiceMailSender(emailService,
 				"arn:aws:ses:us-east-1:00000000:identity/domain.com");
 
@@ -57,19 +58,19 @@ class SimpleEmailServiceMailSenderTest {
 		mailSender.send(simpleMailMessage);
 
 		SendEmailRequest sendEmailRequest = request.getValue();
-		assertThat(sendEmailRequest.source()).isEqualTo(simpleMailMessage.getFrom());
+		assertThat(sendEmailRequest.fromEmailAddress()).isEqualTo(simpleMailMessage.getFrom());
 		assertThat(sendEmailRequest.destination().toAddresses().get(0))
 				.isEqualTo(Objects.requireNonNull(simpleMailMessage.getTo())[0]);
-		assertThat(sendEmailRequest.message().subject().data()).isEqualTo(simpleMailMessage.getSubject());
-		assertThat(sendEmailRequest.message().body().text().data()).isEqualTo(simpleMailMessage.getText());
-		assertThat(sendEmailRequest.destination().ccAddresses().size()).isEqualTo(0);
-		assertThat(sendEmailRequest.destination().bccAddresses().size()).isEqualTo(0);
-		assertThat(sendEmailRequest.sourceArn()).isEqualTo("arn:aws:ses:us-east-1:00000000:identity/domain.com");
+		assertThat(sendEmailRequest.content().simple().subject().data()).isEqualTo(simpleMailMessage.getSubject());
+		assertThat(sendEmailRequest.content().simple().body().text().data()).isEqualTo(simpleMailMessage.getText());
+		assertThat(sendEmailRequest.destination().ccAddresses()).isEmpty();
+		assertThat(sendEmailRequest.destination().bccAddresses()).isEmpty();
+		assertThat(sendEmailRequest.fromEmailAddressIdentityArn()).isEqualTo("arn:aws:ses:us-east-1:00000000:identity/domain.com");
 	}
 
 	@Test
 	void testSendSimpleMailWithConfigurationSetNameSet() {
-		SesClient emailService = mock(SesClient.class);
+		SesV2Client emailService = mock(SesV2Client.class);
 		SimpleEmailServiceMailSender mailSender = new SimpleEmailServiceMailSender(emailService, null,
 				"Configuration Set");
 		SimpleMailMessage simpleMailMessage = createSimpleMailMessage();
@@ -85,7 +86,7 @@ class SimpleEmailServiceMailSenderTest {
 
 	@Test
 	void testSendSimpleMailWithCCandBCC() {
-		SesClient emailService = mock(SesClient.class);
+		SesV2Client emailService = mock(SesV2Client.class);
 		SimpleEmailServiceMailSender mailSender = new SimpleEmailServiceMailSender(emailService);
 
 		SimpleMailMessage simpleMailMessage = createSimpleMailMessage();
@@ -99,11 +100,11 @@ class SimpleEmailServiceMailSenderTest {
 		mailSender.send(simpleMailMessage);
 
 		SendEmailRequest sendEmailRequest = request.getValue();
-		assertThat(sendEmailRequest.source()).isEqualTo(simpleMailMessage.getFrom());
+		assertThat(sendEmailRequest.fromEmailAddress()).isEqualTo(simpleMailMessage.getFrom());
 		assertThat(sendEmailRequest.destination().toAddresses().get(0))
 				.isEqualTo(Objects.requireNonNull(simpleMailMessage.getTo())[0]);
-		assertThat(sendEmailRequest.message().subject().data()).isEqualTo(simpleMailMessage.getSubject());
-		assertThat(sendEmailRequest.message().body().text().data()).isEqualTo(simpleMailMessage.getText());
+		assertThat(sendEmailRequest.content().simple().subject().data()).isEqualTo(simpleMailMessage.getSubject());
+		assertThat(sendEmailRequest.content().simple().body().text().data()).isEqualTo(simpleMailMessage.getText());
 		assertThat(sendEmailRequest.destination().ccAddresses().get(0))
 				.isEqualTo(Objects.requireNonNull(simpleMailMessage.getCc())[0]);
 		assertThat(sendEmailRequest.destination().bccAddresses().get(0))
@@ -112,7 +113,7 @@ class SimpleEmailServiceMailSenderTest {
 
 	@Test
 	void testSendSimpleMailWithNoTo() {
-		SesClient emailService = mock(SesClient.class);
+		SesV2Client emailService = mock(SesV2Client.class);
 		SimpleEmailServiceMailSender mailSender = new SimpleEmailServiceMailSender(emailService);
 
 		// Not using createSimpleMailMessage as we don't want the to address set.
@@ -130,15 +131,15 @@ class SimpleEmailServiceMailSenderTest {
 		mailSender.send(simpleMailMessage);
 
 		SendEmailRequest sendEmailRequest = request.getValue();
-		assertThat(sendEmailRequest.message().subject().data()).isEqualTo(simpleMailMessage.getSubject());
-		assertThat(sendEmailRequest.message().body().text().data()).isEqualTo(simpleMailMessage.getText());
+		assertThat(sendEmailRequest.content().simple().subject().data()).isEqualTo(simpleMailMessage.getSubject());
+		assertThat(sendEmailRequest.content().simple().body().text().data()).isEqualTo(simpleMailMessage.getText());
 		assertThat(sendEmailRequest.destination().bccAddresses().get(0))
 				.isEqualTo(Objects.requireNonNull(simpleMailMessage.getBcc())[0]);
 	}
 
 	@Test
 	void testSendMultipleMails() {
-		SesClient emailService = mock(SesClient.class);
+		SesV2Client emailService = mock(SesV2Client.class);
 		SimpleEmailServiceMailSender mailSender = new SimpleEmailServiceMailSender(emailService);
 
 		ArgumentCaptor<SendEmailRequest> request = ArgumentCaptor.forClass(SendEmailRequest.class);
@@ -151,7 +152,7 @@ class SimpleEmailServiceMailSenderTest {
 
 	@Test
 	void testSendMultipleMailsWithExceptionWhileSending() {
-		SesClient emailService = mock(SesClient.class);
+		SesV2Client emailService = mock(SesV2Client.class);
 		SimpleEmailServiceMailSender mailSender = new SimpleEmailServiceMailSender(emailService);
 
 		SimpleMailMessage firstMessage = createSimpleMailMessage();
@@ -160,7 +161,7 @@ class SimpleEmailServiceMailSenderTest {
 		SimpleMailMessage failureMail = createSimpleMailMessage();
 		when(emailService.sendEmail(ArgumentMatchers.isA(SendEmailRequest.class)))
 				.thenReturn(SendEmailResponse.builder().build())
-				.thenThrow(SesException.builder().message("error").build())
+				.thenThrow(SesV2Exception.builder().message("error").build())
 				.thenReturn(SendEmailResponse.builder().build());
 
 		SimpleMailMessage thirdMessage = createSimpleMailMessage();
@@ -170,14 +171,14 @@ class SimpleEmailServiceMailSenderTest {
 			fail("Exception expected due to error while sending mail");
 		}
 		catch (MailSendException e) {
-			assertThat(e.getFailedMessages().size()).isEqualTo(1);
-			assertThat(e.getFailedMessages().containsKey(failureMail)).isTrue();
+			assertThat(e.getFailedMessages()).hasSize(1);
+			assertThat(e.getFailedMessages()).containsKey(failureMail);
 		}
 	}
 
 	@Test
 	void testShutDownOfResources() {
-		SesClient emailService = mock(SesClient.class);
+		SesV2Client emailService = mock(SesV2Client.class);
 		SimpleEmailServiceMailSender mailSender = new SimpleEmailServiceMailSender(emailService);
 
 		mailSender.destroy();


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Migration of AWS SES from v1 to v2


## :bulb: Motivation and Context
Amazon SES v2 API and SMTP accepts email messages up to 40MB in size including any images and attachments that are part of the message. Messages larger than 10MB are subject to bandwidth throttling, and depending on your sending rate, you may be throttled to as low as 40MB/s. For example, you could send a 40MB message at the rate of 1 message per second, or two 20MB messages per second.

Amazon SES API v1 accepts messages up to 10MB in size including any images and attachments that are part of the message.

Issue #595


## :green_heart: How did you test it?
Unit tests
I don't have localstack pro, so no integration tests


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
