### PR TITLE
Fix the capitalization of property for `S3EncryptionConditional.KmsKeyProperty`

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3EncryptionConditional.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3EncryptionConditional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2024 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
  * Conditional for creating {@link software.amazon.encryption.s3.S3EncryptionClient}. Will only create
  * S3EncryptionClient if one of following is true.
  * @author Matej Nedic
+ * @author Giacomo Baso
  * @since 3.3.0
  */
 public class S3EncryptionConditional extends AnyNestedCondition {
@@ -38,7 +39,7 @@ public class S3EncryptionConditional extends AnyNestedCondition {
 	static class AESProviderCondition {
 	}
 
-	@ConditionalOnProperty(name = "spring.cloud.aws.s3.encryption.keyId")
+	@ConditionalOnProperty(name = "spring.cloud.aws.s3.encryption.key-id")
 	static class KmsKeyProperty {
 	}
 }

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ import software.amazon.encryption.s3.S3EncryptionClient;
  *
  * @author Maciej Walkowiak
  * @author Matej Nedic
+ * @author Giacomo Baso
  */
 class S3AutoConfigurationTests {
 
@@ -166,6 +167,15 @@ class S3AutoConfigurationTests {
 				assertThat(context).hasSingleBean(S3EncryptionClient.class);
 				assertThat(context).hasSingleBean(S3AesProvider.class);
 			});
+		}
+
+		@Test
+		void createsEncryptionClientBackedByKms() {
+			contextRunnerEncryption
+					.withPropertyValues("spring.cloud.aws.s3.encryption.key-id:234abcd-12ab-34cd-56ef-1234567890ab")
+					.run(context -> {
+						assertThat(context).hasSingleBean(S3EncryptionClient.class);
+					});
 		}
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfigurationTests.java
@@ -139,7 +139,7 @@ class S3AutoConfigurationTests {
 		@Test
 		void s3ClientCanBeOverwritten() {
 			contextRunnerEncryption
-					.withPropertyValues("spring.cloud.aws.s3.encryption.keyId:234abcd-12ab-34cd-56ef-1234567890ab")
+					.withPropertyValues("spring.cloud.aws.s3.encryption.key-id:234abcd-12ab-34cd-56ef-1234567890ab")
 					.withUserConfiguration(CustomS3ClientConfiguration.class).run(context -> {
 						assertThat(context).hasSingleBean(S3Client.class);
 					});


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Changes the capitalization of the property for `S3EncryptionConditional.KmsKeyProperty` from `spring.cloud.aws.s3.encryption.keyId` to `spring.cloud.aws.s3.encryption.key-id`. Adds a test that verifies the creation of an `S3EncryptionClient` when setting that property.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes gh-1333


## :green_heart: How did you test it?
Unit tests, manual tests with a sample application.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
