### PR TITLE
Do not create S3 CRT client if aws-crt library is not on the classpath.

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.context.annotation.Bean;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.crt.s3.S3Client;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
 
@@ -44,7 +45,7 @@ import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
  * @since 3.0
  */
 @AutoConfiguration
-@ConditionalOnClass({ S3Client.class, S3AsyncClient.class })
+@ConditionalOnClass({ S3Client.class, S3AsyncClient.class, AwsCrtHttpClient.class})
 @EnableConfigurationProperties({ S3Properties.class })
 @ConditionalOnProperty(name = "spring.cloud.aws.s3.enabled", havingValue = "true", matchIfMissing = true)
 @AutoConfigureBefore(S3TransferManagerAutoConfiguration.class)

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfigurationTests.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfigurationTests.java
@@ -31,6 +31,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.endpoints.S3ClientContextParams;
 import software.amazon.awssdk.services.s3.internal.crt.S3NativeClientConfiguration;
@@ -112,6 +113,14 @@ class S3CrtAsyncClientAutoConfigurationTests {
 	@Test
 	void handlesMissingS3AsyncClient() {
 		contextRunner.withClassLoader(new FilteredClassLoader(S3AsyncClient.class)).run(context -> {
+			assertThat(context).hasNotFailed();
+			assertThat(context).doesNotHaveBean(S3AsyncClient.class);
+		});
+	}
+
+	@Test
+	void handlesMissingS3CrtLibrary() {
+		contextRunner.withClassLoader(new FilteredClassLoader(AwsCrtHttpClient.class)).run(context -> {
 			assertThat(context).hasNotFailed();
 			assertThat(context).doesNotHaveBean(S3AsyncClient.class);
 		});


### PR DESCRIPTION
Fixes #1358