### PR TITLE
SQS: Add autoconfiguration for maxDelayBetweenPolls

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -95,7 +95,8 @@
 |spring.cloud.aws.sqs.listener.max-concurrent-messages |  | The maximum concurrent messages that can be processed simultaneously for each queue. Note that if acknowledgement batching is being used, the actual maximum number of messages inflight might be higher.
 |spring.cloud.aws.sqs.listener.max-messages-per-poll |  | The maximum number of messages to be retrieved in a single poll to SQS.
 |spring.cloud.aws.sqs.listener.poll-timeout |  | The maximum amount of time for a poll to SQS.
-|spring.cloud.aws.sqs.queue-not-found-strategy |  | 
+|spring.cloud.aws.sqs.listener.max-delay-between-polls |  | The maximum amount of time to wait between consecutive polls to SQS.
+|spring.cloud.aws.sqs.queue-not-found-strategy |  |
 |spring.cloud.aws.sqs.region |  | Overrides the default region.
 
 |===

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -816,6 +816,7 @@ The Spring Boot Starter for SQS provides the following auto-configuration proper
 | <<maxConcurrentMessages, `spring.cloud.aws.sqs.listener.max-inflight-messages-per-queue`>> | Maximum number of inflight messages per queue. | No | 10
 | <<maxMessagesPerPoll, `spring.cloud.aws.sqs.listener.max-messages-per-poll`>> | Maximum number of messages to be received per poll. | No | 10
 | <<pollTimeout, `spring.cloud.aws.sqs.listener.poll-timeout`>> | Maximum amount of time to wait for messages in a poll. | No | 10 seconds
+| <<maxDelayBetweenPolls, `spring.cloud.aws.sqs.listener.max-delay-between-polls`>> | Maximum amount of time to wait between polls. | No | 10 seconds
 | `spring.cloud.aws.sqs.queue-not-found-strategy`  | The strategy to be used by SqsTemplate and SqsListeners when a queue does not exist. | No | CREATE
 |===
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -136,6 +136,7 @@ public class SqsAutoConfiguration {
 		mapper.from(this.sqsProperties.getListener().getMaxConcurrentMessages()).to(options::maxConcurrentMessages);
 		mapper.from(this.sqsProperties.getListener().getMaxMessagesPerPoll()).to(options::maxMessagesPerPoll);
 		mapper.from(this.sqsProperties.getListener().getPollTimeout()).to(options::pollTimeout);
+		mapper.from(this.sqsProperties.getListener().getMaxDelayBetweenPolls()).to(options::maxDelayBetweenPolls);
 	}
 
 	@Bean

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
@@ -88,7 +88,7 @@ public class SqsProperties extends AwsClientProperties {
 		private Duration pollTimeout;
 
 		/**
-		 *  The maximum amount of time to wait between consecutive polls to SQS.
+		 * The maximum amount of time to wait between consecutive polls to SQS.
 		 */
 		@Nullable
 		private Duration maxDelayBetweenPolls;

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
@@ -87,6 +87,12 @@ public class SqsProperties extends AwsClientProperties {
 		@Nullable
 		private Duration pollTimeout;
 
+		/**
+		 *  The maximum amount of time to wait between consecutive polls to SQS.
+		 */
+		@Nullable
+		private Duration maxDelayBetweenPolls;
+
 		@Nullable
 		public Integer getMaxConcurrentMessages() {
 			return this.maxConcurrentMessages;
@@ -112,6 +118,15 @@ public class SqsProperties extends AwsClientProperties {
 
 		public void setPollTimeout(Duration pollTimeout) {
 			this.pollTimeout = pollTimeout;
+		}
+
+		@Nullable
+		public Duration getMaxDelayBetweenPolls() {
+			return maxDelayBetweenPolls;
+		}
+
+		public void setMaxDelayBetweenPolls(Duration maxDelayBetweenPolls) {
+			this.maxDelayBetweenPolls = maxDelayBetweenPolls;
 		}
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
@@ -152,7 +152,8 @@ class SqsAutoConfigurationTest {
 				.withPropertyValues("spring.cloud.aws.sqs.enabled:true",
 						"spring.cloud.aws.sqs.listener.max-concurrent-messages:19",
 						"spring.cloud.aws.sqs.listener.max-messages-per-poll:8",
-						"spring.cloud.aws.sqs.listener.poll-timeout:6s")
+						"spring.cloud.aws.sqs.listener.poll-timeout:6s",
+						"spring.cloud.aws.sqs.listener.max-delay-between-polls:15s")
 				.withUserConfiguration(CustomComponentsConfiguration.class, ObjectMapperConfiguration.class).run(context -> {
 					assertThat(context).hasSingleBean(SqsMessageListenerContainerFactory.class);
 					SqsMessageListenerContainerFactory<?> factory = context
@@ -168,6 +169,7 @@ class SqsAutoConfigurationTest {
 						assertThat(options.getMaxConcurrentMessages()).isEqualTo(19);
 						assertThat(options.getMaxMessagesPerPoll()).isEqualTo(8);
 						assertThat(options.getPollTimeout()).isEqualTo(Duration.ofSeconds(6));
+						assertThat(options.getMaxDelayBetweenPolls()).isEqualTo(Duration.ofSeconds(15));
 					})
 					.extracting("messageConverter")
 					.asInstanceOf(type(SqsMessagingMessageConverter.class))

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
@@ -197,6 +197,7 @@ class SqsAutoConfigurationTest {
 					assertThat(options.getMaxConcurrentMessages()).isEqualTo(10);
 					assertThat(options.getMaxMessagesPerPoll()).isEqualTo(10);
 					assertThat(options.getPollTimeout()).isEqualTo(Duration.ofSeconds(10));
+					assertThat(options.getMaxDelayBetweenPolls()).isEqualTo(Duration.ofSeconds(10));
 				})
 				.extracting("messageConverter")
 				.asInstanceOf(type(SqsMessagingMessageConverter.class))


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This PR includes following changes:
- Added  `maxDelayBetweenPolls` configuration property to `SqsProperties`
- Added mapping for `SqsContainerOptions.maxDelayBetweenPolls` in `SqsAutoConfiguration` for configuring the property in `SqsMessageListenerContainerFactory`
- Included test case for the new property in `SqsAutoConfigurationTest`
- Added relevant docs for the new auto-configuration property `spring.cloud.aws.sqs.listener.max-delay-between-polls`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, there is no property available to configure the `maxDelayBetweenPolls` parameter for SQS Listener, making it difficult to configure it through the application properties. This change introduces the property `max-delay-between-polls` for SQS Listener.

Closes #1354

## :green_heart: How did you test it?
Built the project after making necessary changes and included the generated jar in a sample application. Ran this application in debug mode to verify whether the value mentioned in `application.properties` for `max-delay-between-polls` was being picked and correctly configured in `SqsContainerOptions` for the default `SqsListenerContainerFactory` bean.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
