### PR TITLE
Observability Support for SQS

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -1869,7 +1869,9 @@ SqsTemplate sqsTemplateWithCustomConvention(SqsAsyncClient sqsAsyncClient,
 
 ==== Context Propagation
 
-For regular blocking components such as message listeners, interceptors, and error handlers, observation scopes are automatically managed, so no further action is required.
+For regular blocking components such as message listeners, interceptors, and error handlers, observation scopes are automatically managed, and no further action is required.
+
+Remote baggage propagation is supported through the "baggage" message header.
 
 For asynchronous variants of these components, the observation context is not automatically propagated between threads.
 However, the Observation object is injected in the message headers under the key `ObservationThreadLocalAccessor.KEY`.

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -219,6 +219,18 @@ Such attributes are available as `MessageHeaders` in received messages.
 #AUTO
 |Set the ContentBasedDeduplication queue attribute value of the queues the template is sending messages to.
 With `ContentBasedDeduplication#AUTO`, the queue attribute value will be resolved automatically.
+
+|`observationRegistry`
+|ObservationRegistry
+|ObservationRegistry.NOOP
+|Set the `ObservationRegistry` to be used for recording observations during message sending and receiving operations.
+See <<Observability Support>> for more information.
+
+|`observationConvention`
+|ObservationConvention
+|null
+|Sets a custom `ObservationConvention` to be used for customizing observation key-value pairs.
+See <<Observability Support>> for more information.
 |===
 
 [[sqs-send-message]]
@@ -817,6 +829,7 @@ The Spring Boot Starter for SQS provides the following auto-configuration proper
 | <<maxMessagesPerPoll, `spring.cloud.aws.sqs.listener.max-messages-per-poll`>> | Maximum number of messages to be received per poll. | No | 10
 | <<pollTimeout, `spring.cloud.aws.sqs.listener.poll-timeout`>> | Maximum amount of time to wait for messages in a poll. | No | 10 seconds
 | `spring.cloud.aws.sqs.queue-not-found-strategy`  | The strategy to be used by SqsTemplate and SqsListeners when a queue does not exist. | No | CREATE
+| `spring.cloud.aws.sqs.observation-enabled` | Enables observability support for SQS operations. | No | false
 |===
 
 
@@ -973,6 +986,18 @@ See <<Providing a TaskExecutor>>.
 For `FIFO` queues, visibility is extended for all messages in a message group before each message is processed.
 See <<FIFO Support>>.
 Otherwise, visibility is specified once when polling SQS.
+
+|`observationRegistry`
+|`ObservationRegistry`
+|`ObservationRegistry.NOOP`
+|Sets the `ObservationRegistry` to be used for recording observations during message processing.
+See <<Observability Support>>.
+
+|`observationConvention`
+|`ObservationConvention`
+|`null`
+|Sets a custom `ObservationConvention` to be used for customizing observation key-value pairs.
+See <<Observability Support>>.
 
 |`queueNotFoundStrategy`
 |`FAIL`, `CREATE`
@@ -1723,6 +1748,150 @@ There can be multiple `SqsAsyncClientCustomizer` beans present in single applica
 
 Note that `SqsAsyncClientCustomizer` beans are applied **after** `AwsAsyncClientCustomizer` beans and therefore can overwrite previously set configurations.
 
+
+=== Observability Support
+
+Spring Cloud AWS SQS supports observability through Micrometer's Observation API. This integration provides the ability to monitor and trace SQS operations throughout your application.
+
+==== Enabling Observability
+
+Observability can be enabled in a Spring Boot application by:
+
+1. Setting the `spring.cloud.aws.sqs.observation-enabled` property to `true`
+2. Having a `ObservationRegistry` bean in your application context
+
+When using direct SQS component configuration, observability can be enabled by:
+
+1. Setting an `ObservationRegistry` in the container options or template options
+2. Optionally providing a custom `ObservationConvention` to customize the key-value pairs
+
+```java
+@Bean
+SqsTemplate sqsTemplate(SqsAsyncClient sqsAsyncClient, ObservationRegistry observationRegistry) {
+    return SqsTemplate.builder()
+            .sqsAsyncClient(sqsAsyncClient)
+            .configure(options -> options.observationRegistry(observationRegistry))
+            .build();
+}
+
+@Bean
+SqsMessageListenerContainerFactory<Object> sqsListenerContainerFactory(SqsAsyncClient sqsAsyncClient, ObservationRegistry observationRegistry) {
+    return SqsMessageListenerContainerFactory.builder()
+            .sqsAsyncClient(sqsAsyncClient)
+            .configure(options -> options.observationRegistry(observationRegistry))
+            .build();
+}
+```
+
+==== Available Observations
+
+Spring Cloud AWS SQS provides the following observations:
+
+1. `spring.aws.sqs.template` - Records SQS operations performed through the `SqsTemplate`
+2. `spring.aws.sqs.listener` - Records message processing through the `SqsMessageListenerContainer`
+
+Both observations include the following common tags:
+
+Low cardinality tags:
+- `messaging.system`: "sqs"
+- `messaging.operation`: "publish" (template) or "receive" (listener)
+- `messaging.destination.name` or `messaging.source.name`: The queue name
+- `messaging.destination.kind` or `messaging.source.kind`: "queue"
+
+High cardinality tags:
+- `messaging.message.id`: The SQS message ID from AWS.
+
+For FIFO queues, the following additional high cardinality tags are included:
+- `messaging.message.message-group.id`: The message group ID
+- `messaging.message.message-deduplication.id`: The message deduplication ID
+
+==== Customizing Observations
+
+Custom observation conventions can be provided to add custom tags or replace the default ones with custom ones.
+
+===== Adding Custom Tags
+
+To add custom tags while preserving all default tags, the `DefaultConvention` classes can be extended and the `getCustomLowCardinalityKeyValues` and / or getCustomHighCardinalityKeyValues method overridden:
+
+```java
+@Bean
+SqsTemplateObservation.Convention sqsTemplateObservationConvention() {
+    return new SqsTemplateObservation.DefaultConvention() {
+        @Override
+        protected KeyValues getCustomHighCardinalityKeyValues(SqsTemplateObservation.Context context) {
+            String paymentId = MessageHeaderUtils.getHeaderAsString(context.getMessage(), "payment-id-header-name");
+            return KeyValues.of("payment.id", paymentId);
+        }
+    };
+}
+```
+
+===== Replacing Default Tags
+
+For complete control over the observation tags, the `Convention` interfaces can be implemented directly:
+
+```java
+@Bean
+SqsListenerObservation.Convention sqsListenerObservationConvention() {
+    return new SqsListenerObservation.Convention() {
+
+        @Override
+        public KeyValues getLowCardinalityKeyValues(SqsListenerObservation.Context context) {
+            return KeyValues.of("messaging.system", "sqs")
+                   .and("messaging.operation", "receive")
+                   .and("custom.tag", "custom-value");
+        }
+        
+        @Override
+        public KeyValues getHighCardinalityKeyValues(SqsListenerObservation.Context context) {
+            String paymentId = MessageHeaderUtils.getHeaderAsString(context.getMessage(), "payment-id-header-name");
+            return KeyValues.of("payment.id", paymentId);
+        }
+    };
+}
+```
+
+Custom convention beans defined in the application context will be automatically wired by Spring Boot auto-configuration. For manual configuration:
+
+```java
+@Bean
+SqsTemplate sqsTemplateWithCustomConvention(SqsAsyncClient sqsAsyncClient, 
+                                          ObservationRegistry observationRegistry,
+                                          SqsTemplateObservation.Convention convention) {
+    return SqsTemplate.builder()
+            .sqsAsyncClient(sqsAsyncClient)
+            .configure(options -> options
+                .observationRegistry(observationRegistry)
+                .observationConvention(convention))
+            .build();
+}
+```
+
+==== Context Propagation
+
+For regular blocking components such as message listeners, interceptors, and error handlers, observation scopes are automatically managed, so no further action is required.
+
+For asynchronous variants of these components, the observation context is not automatically propagated between threads.
+However, the Observation object is injected in the message headers under the key `ObservationThreadLocalAccessor.KEY`.
+A scope can be manually opened in the new thread with the following approach:
+
+```java
+// Set up the context registry with the appropriate accessors
+ContextRegistry registry = new ContextRegistry();
+registry.registerContextAccessor(new MessageHeaderContextAccessor());
+registry.registerThreadLocalAccessor(new ObservationThreadLocalAccessor());
+
+// Create a scope and ensure it's closed when done
+try (Scope scope = ContextSnapshotFactory.builder()
+        .contextRegistry(registry)
+        .build()
+        .captureFrom(message.getHeaders())
+        .setThreadLocals()) {
+    // Your logic here - the observation context is now available in this thread
+}
+```
+
+IMPORTANT: The scope should be closed in the same thread where it was opened to prevent thread local leakage.
 
 === IAM Permissions
 Following IAM permissions are required by Spring Cloud AWS SQS:

--- a/spring-cloud-aws-autoconfigure/pom.xml
+++ b/spring-cloud-aws-autoconfigure/pom.xml
@@ -176,5 +176,10 @@
 			<artifactId>amazon-s3-encryption-client-java</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-observation-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
@@ -49,6 +49,8 @@ public class SqsProperties extends AwsClientProperties {
 	@Nullable
 	private QueueNotFoundStrategy queueNotFoundStrategy;
 
+	private Boolean observationEnabled = false;
+
 	/**
 	 * Return the strategy to use if the queue is not found.
 	 * @return the {@link QueueNotFoundStrategy}
@@ -64,6 +66,14 @@ public class SqsProperties extends AwsClientProperties {
 	 */
 	public void setQueueNotFoundStrategy(QueueNotFoundStrategy queueNotFoundStrategy) {
 		this.queueNotFoundStrategy = queueNotFoundStrategy;
+	}
+
+	public Boolean isObservationEnabled() {
+		return this.observationEnabled;
+	}
+
+	public void setObservationEnabled(Boolean observationEnabled) {
+		this.observationEnabled = observationEnabled;
 	}
 
 	public static class Listener {

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
@@ -38,6 +38,11 @@ import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import io.awspring.cloud.sqs.support.converter.MessagingMessageConverter;
 import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
+import io.awspring.cloud.sqs.support.observation.SqsListenerObservation;
+import io.awspring.cloud.sqs.support.observation.SqsTemplateObservation;
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
@@ -124,6 +129,85 @@ class SqsAutoConfigurationTest {
 			assertThat(context).hasSingleBean(SqsTemplate.class);
 			assertThat(context).hasSingleBean(SqsMessageListenerContainerFactory.class);
 			assertThat(sqsProperties.getQueueNotFoundStrategy()).isEqualTo(QueueNotFoundStrategy.FAIL);
+		});
+	}
+
+	@Test
+	void withObservationEnabled() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.observation-enabled=true")
+				.withUserConfiguration(TestObservationRegistryConfiguration.class).run(context -> {
+					assertThat(context).hasSingleBean(SqsProperties.class);
+					SqsProperties sqsProperties = context.getBean(SqsProperties.class);
+					assertThat(context).hasSingleBean(SqsAsyncClient.class);
+					assertThat(context).hasSingleBean(SqsTemplate.class);
+					assertThat(context).hasSingleBean(SqsMessageListenerContainerFactory.class);
+					assertThat(context).hasSingleBean(TestObservationRegistry.class);
+					assertThat(sqsProperties.isObservationEnabled()).isTrue();
+
+					// Verify SqsTemplate has the observation registry configured
+					SqsTemplate sqsTemplate = context.getBean(SqsTemplate.class);
+					assertThat(sqsTemplate).extracting("observationRegistry")
+							.isEqualTo(context.getBean(ObservationRegistry.class));
+
+					// Verify SqsMessageListenerContainerFactory has the observation registry configured
+					SqsMessageListenerContainerFactory<?> factory = context
+							.getBean(SqsMessageListenerContainerFactory.class);
+					assertThat(factory).extracting("containerOptionsBuilder")
+							.asInstanceOf(type(ContainerOptionsBuilder.class))
+							.extracting(ContainerOptionsBuilder::build).extracting("observationRegistry")
+							.isEqualTo(context.getBean(ObservationRegistry.class));
+				});
+	}
+
+	@Test
+	void withCustomObservationConventions() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.observation-enabled=true")
+				.withUserConfiguration(TestObservationRegistryConfiguration.class,
+						CustomObservationConventionConfiguration.class)
+				.run(context -> {
+					assertThat(context).hasSingleBean(SqsProperties.class);
+					assertThat(context).hasSingleBean(SqsTemplate.class);
+					assertThat(context).hasSingleBean(SqsMessageListenerContainerFactory.class);
+					assertThat(context).hasSingleBean(TestObservationRegistry.class);
+					assertThat(context).hasSingleBean(SqsTemplateObservation.Convention.class);
+					assertThat(context).hasSingleBean(SqsListenerObservation.Convention.class);
+
+					// Verify SqsTemplate has the custom observation convention configured
+					SqsTemplate sqsTemplate = context.getBean(SqsTemplate.class);
+					assertThat(sqsTemplate).extracting("customObservationConvention")
+							.isEqualTo(context.getBean(SqsTemplateObservation.Convention.class));
+
+					// Verify SqsMessageListenerContainerFactory has the custom observation convention configured
+					SqsMessageListenerContainerFactory<?> factory = context
+							.getBean(SqsMessageListenerContainerFactory.class);
+					assertThat(factory).extracting("containerOptionsBuilder")
+							.asInstanceOf(type(ContainerOptionsBuilder.class))
+							.extracting(ContainerOptionsBuilder::build).extracting("observationConvention")
+							.isEqualTo(context.getBean(SqsListenerObservation.Convention.class));
+				});
+	}
+
+	@Test
+	void withObservationDisabled() {
+		this.contextRunner.withUserConfiguration(TestObservationRegistryConfiguration.class).run(context -> {
+			assertThat(context).hasSingleBean(SqsProperties.class);
+			SqsProperties sqsProperties = context.getBean(SqsProperties.class);
+			assertThat(sqsProperties.isObservationEnabled()).isFalse();
+
+			// Verify SqsTemplate has the default NOOP observation registry
+			SqsTemplate sqsTemplate = context.getBean(SqsTemplate.class);
+			assertThat(sqsTemplate).extracting("observationRegistry")
+					.isNotEqualTo(context.getBean(ObservationRegistry.class))
+					.asInstanceOf(type(ObservationRegistry.class)).extracting(ObservationRegistry::isNoop)
+					.isEqualTo(true);
+
+			// Verify SqsMessageListenerContainerFactory has the default NOOP observation registry
+			SqsMessageListenerContainerFactory<?> factory = context.getBean(SqsMessageListenerContainerFactory.class);
+			assertThat(factory).extracting("containerOptionsBuilder").asInstanceOf(type(ContainerOptionsBuilder.class))
+					.extracting(ContainerOptionsBuilder::build).extracting("observationRegistry")
+					.isNotEqualTo(context.getBean(ObservationRegistry.class))
+					.asInstanceOf(type(ObservationRegistry.class)).extracting(ObservationRegistry::isNoop)
+					.isEqualTo(true);
 		});
 	}
 
@@ -257,6 +341,40 @@ class SqsAutoConfigurationTest {
 			};
 		}
 
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class TestObservationRegistryConfiguration {
+
+		@Bean
+		TestObservationRegistry observationRegistry() {
+			return TestObservationRegistry.create();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomObservationConventionConfiguration {
+
+		@Bean
+		SqsTemplateObservation.Convention customSqsTemplateObservationConvention() {
+			return new SqsTemplateObservation.DefaultConvention() {
+				@Override
+				protected KeyValues getCustomHighCardinalityKeyValues(SqsTemplateObservation.Context context) {
+					return KeyValues.of("payment.id", "test-payment-id");
+				}
+			};
+		}
+
+		@Bean
+		SqsListenerObservation.Convention customSqsListenerObservationConvention() {
+			return new SqsListenerObservation.DefaultConvention() {
+				@Override
+				protected KeyValues getCustomHighCardinalityKeyValues(SqsListenerObservation.Context context) {
+					return KeyValues.of("order.id", "test-order-id");
+				}
+			};
+		}
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-aws-sqs/pom.xml
+++ b/spring-cloud-aws-sqs/pom.xml
@@ -43,6 +43,34 @@
 			<artifactId>spring-cloud-aws-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-observation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>context-propagation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-observation-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/ExceptionUtils.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/ExceptionUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Utilities to handle exceptions.
+ *
+ * @author Tomaz Fernandes
+ * @since 3.4
+ */
+public class ExceptionUtils {
+
+	/**
+	 * Unwraps the original exception until an exception not in the provided exceptions is found.
+	 *
+	 * @param original the exception to unwrap.
+	 * @param exceptionsToUnwrap the exceptions from which the original exception should be unwrapped from.
+	 * @return the unwrapped exception.
+	 */
+	@SafeVarargs
+	public static Throwable unwrapException(Throwable original, Class<? extends Throwable>... exceptionsToUnwrap) {
+		Set<Class<? extends Throwable>> exceptions = Arrays.stream(exceptionsToUnwrap).collect(Collectors.toSet());
+		Throwable unwrapped = original;
+		while (exceptions.contains(unwrapped.getClass()) && unwrapped.getCause() != null) {
+			unwrapped = unwrapped.getCause();
+		}
+		return unwrapped;
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/MessageHeaderUtils.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/MessageHeaderUtils.java
@@ -128,4 +128,26 @@ public class MessageHeaderUtils {
 		return new MessagingMessageHeaders(accessor.toMessageHeaders(), headers.getId(), headers.getTimestamp());
 	}
 
+	/**
+	 * Remove the provided header key from the {@link Message} if present. Note that a new {@link Message} instance will
+	 * be returned.
+	 *
+	 * @param message the message from which the header should be removed.
+	 * @param key the header key to be removed.
+	 * @return a new {@link Message} instance with the header removed.
+	 * @param <T> the message type.
+	 */
+	public static <T> Message<T> removeHeaderIfPresent(Message<T> message, String key) {
+		if (!message.getHeaders().containsKey(key)) {
+			return message;
+		}
+		MessageHeaderAccessor accessor = new MessageHeaderAccessor();
+		MessageHeaders headers = message.getHeaders();
+		accessor.copyHeaders(headers);
+		accessor.removeHeader(key);
+		MessagingMessageHeaders newHeaders = new MessagingMessageHeaders(accessor.toMessageHeaders(), headers.getId(),
+				headers.getTimestamp());
+		return new GenericMessage<>(message.getPayload(), newHeaders);
+	}
+
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractPipelineMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractPipelineMessageListenerContainer.java
@@ -35,6 +35,7 @@ import io.awspring.cloud.sqs.listener.sink.MessageSink;
 import io.awspring.cloud.sqs.listener.source.AcknowledgementProcessingMessageSource;
 import io.awspring.cloud.sqs.listener.source.MessageSource;
 import io.awspring.cloud.sqs.listener.source.PollingMessageSource;
+import io.awspring.cloud.sqs.support.observation.AbstractListenerObservation;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -174,9 +175,13 @@ public abstract class AbstractPipelineMessageListenerContainer<T, O extends Cont
 				.acceptIfInstance(this.messageSink, TaskExecutorAware.class,
 						teac -> teac.setTaskExecutor(getComponentsTaskExecutor()))
 				.acceptIfInstance(this.messageSink, MessageProcessingPipelineSink.class,
-						mls -> mls.setMessagePipeline(messageProcessingPipeline));
+						mls -> mls.setMessagePipeline(messageProcessingPipeline))
+				.acceptIfInstance(this.messageSink, ObservableComponent.class,
+						oc -> oc.setObservationSpecifics(createMessagingObservationSpecifics()));
 		doConfigureMessageSink(this.messageSink);
 	}
+
+	protected abstract AbstractListenerObservation.Specifics<?> createMessagingObservationSpecifics();
 
 	protected void doConfigureMessageSink(MessageSink<T> messageSink) {
 	}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptions.java
@@ -18,6 +18,8 @@ package io.awspring.cloud.sqs.listener;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementOrdering;
 import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementMode;
 import io.awspring.cloud.sqs.support.converter.MessagingMessageConverter;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.ObservationRegistry;
 import java.time.Duration;
 import java.util.Collection;
 import org.springframework.core.task.TaskExecutor;
@@ -165,6 +167,18 @@ public interface ContainerOptions<O extends ContainerOptions<O, B>, B extends Co
 	 */
 	@Nullable
 	AcknowledgementOrdering getAcknowledgementOrdering();
+
+	/**
+	 * Return the {@link ObservationRegistry} to use in this container.
+	 * @return the observation Registry.
+	 */
+	ObservationRegistry getObservationRegistry();
+
+	/**
+	 * Return a custom {@link ObservationConvention} to use with this container.
+	 * @return the observation convention.
+	 */
+	ObservationConvention<?> getObservationConvention();
 
 	/**
 	 * Configure a {@link ConfigurableContainerComponent} with this options. Internal use mostly.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptionsBuilder.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ContainerOptionsBuilder.java
@@ -18,6 +18,7 @@ package io.awspring.cloud.sqs.listener;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementOrdering;
 import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementMode;
 import io.awspring.cloud.sqs.support.converter.MessagingMessageConverter;
+import io.micrometer.observation.ObservationRegistry;
 import java.time.Duration;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.retry.backoff.BackOffPolicy;
@@ -186,6 +187,14 @@ public interface ContainerOptionsBuilder<B extends ContainerOptionsBuilder<B, O>
 	 * @return this instance.
 	 */
 	B messageConverter(MessagingMessageConverter<?> messageConverter);
+
+	/**
+	 * Set the {@link ObservationRegistry} for this container.
+	 *
+	 * @param observationRegistry the observation registry.
+	 * @return this instance.
+	 */
+	B observationRegistry(ObservationRegistry observationRegistry);
 
 	/**
 	 * Create the {@link ContainerOptions} instance.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ObservableComponent.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ObservableComponent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener;
+
+import io.awspring.cloud.sqs.support.observation.AbstractListenerObservation;
+
+/**
+ * Represents a {@link AbstractPipelineMessageListenerContainer} component that can be observed.
+ *
+ * @author Tomaz Fernandes
+ * @since 3.4
+ */
+public interface ObservableComponent {
+
+	/**
+	 * Set the Observation-related instances that are specific to a messaging system.
+	 * @param observationSpecifics the observation-related instances.
+	 */
+	void setObservationSpecifics(AbstractListenerObservation.Specifics<?> observationSpecifics);
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsContainerOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsContainerOptions.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.sqs.listener;
 
+import io.awspring.cloud.sqs.support.observation.SqsListenerObservation;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -52,7 +53,7 @@ public class SqsContainerOptions extends AbstractContainerOptions<SqsContainerOp
 	 * Create a {@link ContainerOptions} instance from the builder.
 	 * @param builder the builder.
 	 */
-	protected SqsContainerOptions(BuilderImpl builder) {
+	private SqsContainerOptions(BuilderImpl builder) {
 		super(builder);
 		this.queueAttributeNames = builder.queueAttributeNames;
 		this.messageAttributeNames = builder.messageAttributeNames;
@@ -125,7 +126,7 @@ public class SqsContainerOptions extends AbstractContainerOptions<SqsContainerOp
 		return new BuilderImpl(this);
 	}
 
-	private static class BuilderImpl
+	protected static class BuilderImpl
 			extends AbstractContainerOptions.Builder<SqsContainerOptionsBuilder, SqsContainerOptions>
 			implements SqsContainerOptionsBuilder {
 
@@ -208,6 +209,14 @@ public class SqsContainerOptions extends AbstractContainerOptions<SqsContainerOp
 		public SqsContainerOptionsBuilder queueNotFoundStrategy(QueueNotFoundStrategy queueNotFoundStrategy) {
 			Assert.notNull(queueNotFoundStrategy, "queueNotFoundStrategy cannot be null");
 			this.queueNotFoundStrategy = queueNotFoundStrategy;
+			return this;
+		}
+
+		@Override
+		public SqsContainerOptionsBuilder observationConvention(
+				SqsListenerObservation.Convention observationConvention) {
+			Assert.notNull(observationConvention, "observationConvention cannot be null");
+			super.observationConvention(observationConvention);
 			return this;
 		}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsContainerOptionsBuilder.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsContainerOptionsBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.sqs.listener;
 
+import io.awspring.cloud.sqs.support.observation.SqsListenerObservation;
 import java.time.Duration;
 import java.util.Collection;
 import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
@@ -73,5 +74,12 @@ public interface SqsContainerOptionsBuilder
 	 * @return this instance.
 	 */
 	SqsContainerOptionsBuilder queueNotFoundStrategy(QueueNotFoundStrategy queueNotFoundStrategy);
+
+	/**
+	 * Set a custom SqsListenerObservation.Convention to be used in this container.
+	 * @param observationConvention the custom observation convention.
+	 * @return this instance.
+	 */
+	SqsContainerOptionsBuilder observationConvention(SqsListenerObservation.Convention observationConvention);
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainer.java
@@ -25,6 +25,7 @@ import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor;
 import io.awspring.cloud.sqs.listener.sink.MessageSink;
 import io.awspring.cloud.sqs.listener.source.MessageSource;
+import io.awspring.cloud.sqs.support.observation.SqsListenerObservation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -108,6 +109,8 @@ public class SqsMessageListenerContainer<T>
 
 	private static final Logger logger = LoggerFactory.getLogger(SqsMessageListenerContainer.class);
 
+	private static final SqsListenerObservation.SqsSpecifics OBSERVATION_SPECIFIC_INSTANCES = new SqsListenerObservation.SqsSpecifics();
+
 	private final SqsAsyncClient sqsAsyncClient;
 
 	public SqsMessageListenerContainer(SqsAsyncClient sqsAsyncClient, SqsContainerOptions options) {
@@ -141,6 +144,11 @@ public class SqsMessageListenerContainer<T>
 	protected void doConfigureMessageSources(Collection<MessageSource<T>> messageSources) {
 		ConfigUtils.INSTANCE.acceptManyIfInstance(messageSources, SqsAsyncClientAware.class,
 				asca -> asca.setSqsAsyncClient(this.sqsAsyncClient));
+	}
+
+	@Override
+	protected SqsListenerObservation.SqsSpecifics createMessagingObservationSpecifics() {
+		return OBSERVATION_SPECIFIC_INSTANCES;
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/sink/adapter/AbstractDelegatingMessageListeningSinkAdapter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/sink/adapter/AbstractDelegatingMessageListeningSinkAdapter.java
@@ -18,11 +18,13 @@ package io.awspring.cloud.sqs.listener.sink.adapter;
 import io.awspring.cloud.sqs.ConfigUtils;
 import io.awspring.cloud.sqs.LifecycleHandler;
 import io.awspring.cloud.sqs.listener.ContainerOptions;
+import io.awspring.cloud.sqs.listener.ObservableComponent;
 import io.awspring.cloud.sqs.listener.SqsAsyncClientAware;
 import io.awspring.cloud.sqs.listener.TaskExecutorAware;
 import io.awspring.cloud.sqs.listener.pipeline.MessageProcessingPipeline;
 import io.awspring.cloud.sqs.listener.sink.MessageProcessingPipelineSink;
 import io.awspring.cloud.sqs.listener.sink.MessageSink;
+import io.awspring.cloud.sqs.support.observation.AbstractListenerObservation;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.util.Assert;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
@@ -34,7 +36,7 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClient;
  * @since 3.0
  */
 public abstract class AbstractDelegatingMessageListeningSinkAdapter<T>
-		implements MessageProcessingPipelineSink<T>, TaskExecutorAware, SqsAsyncClientAware {
+		implements MessageProcessingPipelineSink<T>, TaskExecutorAware, SqsAsyncClientAware, ObservableComponent {
 
 	private final MessageSink<T> delegate;
 
@@ -64,6 +66,12 @@ public abstract class AbstractDelegatingMessageListeningSinkAdapter<T>
 	public void setSqsAsyncClient(SqsAsyncClient sqsAsyncClient) {
 		ConfigUtils.INSTANCE.acceptIfInstance(this.delegate, SqsAsyncClientAware.class,
 				saca -> saca.setSqsAsyncClient(sqsAsyncClient));
+	}
+
+	@Override
+	public void setObservationSpecifics(AbstractListenerObservation.Specifics<?> observationSpecifics) {
+		ConfigUtils.INSTANCE.acceptIfInstance(this.delegate, ObservableComponent.class,
+				saca -> saca.setObservationSpecifics(observationSpecifics));
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingTemplateOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/MessagingTemplateOptions.java
@@ -15,6 +15,7 @@
  */
 package io.awspring.cloud.sqs.operations;
 
+import io.micrometer.observation.ObservationRegistry;
 import java.time.Duration;
 import java.util.Map;
 
@@ -84,4 +85,11 @@ public interface MessagingTemplateOptions<O extends MessagingTemplateOptions<O>>
 	 */
 	O additionalHeadersForReceive(Map<String, Object> defaultAdditionalHeaders);
 
+	/**
+	 * Set the {@link ObservationRegistry} to be used with this template.
+	 *
+	 * @param observationRegistry the observation registry.
+	 * @return the options instance.
+	 */
+	O observationRegistry(ObservationRegistry observationRegistry);
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
@@ -29,6 +29,7 @@ import io.awspring.cloud.sqs.support.converter.MessageConversionContext;
 import io.awspring.cloud.sqs.support.converter.MessagingMessageConverter;
 import io.awspring.cloud.sqs.support.converter.SqsMessageConversionContext;
 import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
+import io.awspring.cloud.sqs.support.observation.SqsTemplateObservation;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
@@ -79,6 +80,8 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 
 	private static final Logger logger = LoggerFactory.getLogger(SqsTemplate.class);
 
+	private static final SqsTemplateObservation.SqsSpecifics SQS_OBSERVATION_SPECIFICS = new SqsTemplateObservation.SqsSpecifics();
+
 	private final Map<String, CompletableFuture<QueueAttributes>> queueAttributesCache = new ConcurrentHashMap<>();
 
 	private final Map<String, SqsMessageConversionContext> conversionContextCache = new ConcurrentHashMap<>();
@@ -96,7 +99,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 	private final TemplateContentBasedDeduplication contentBasedDeduplication;
 
 	private SqsTemplate(SqsTemplateBuilderImpl builder) {
-		super(builder.messageConverter, builder.options);
+		super(builder.messageConverter, builder.options, SQS_OBSERVATION_SPECIFICS);
 		SqsTemplateOptionsImpl options = builder.options;
 		this.sqsAsyncClient = builder.sqsAsyncClient;
 		this.messageAttributeNames = options.messageAttributeNames;
@@ -686,6 +689,13 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 		public SqsTemplateOptions contentBasedDeduplication(
 				TemplateContentBasedDeduplication contentBasedDeduplication) {
 			this.contentBasedDeduplication = contentBasedDeduplication;
+			return this;
+		}
+
+		@Override
+		public SqsTemplateOptions observationConvention(SqsTemplateObservation.Convention observationConvention) {
+			Assert.notNull(observationConvention, "observationConvention cannot be null");
+			super.observationConvention(observationConvention);
 			return this;
 		}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplateOptions.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.sqs.operations;
 
 import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
+import io.awspring.cloud.sqs.support.observation.SqsTemplateObservation;
 import java.util.Collection;
 import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
@@ -78,4 +79,11 @@ public interface SqsTemplateOptions extends MessagingTemplateOptions<SqsTemplate
 	 * @return the options instance.
 	 */
 	SqsTemplateOptions contentBasedDeduplication(TemplateContentBasedDeduplication contentBasedDeduplication);
+
+	/**
+	 * Set a custom {@link io.micrometer.observation.ObservationConvention} to be used by this template.
+	 * @param observationConvention the custom observation convention.
+	 * @return the options instance.
+	 */
+	SqsTemplateOptions observationConvention(SqsTemplateObservation.Convention observationConvention);
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/observation/AbstractListenerObservation.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/observation/AbstractListenerObservation.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.support.observation;
+
+import io.awspring.cloud.sqs.MessageHeaderUtils;
+import io.micrometer.common.KeyValues;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.docs.ObservationDocumentation;
+import io.micrometer.observation.transport.ReceiverContext;
+import org.springframework.lang.NonNull;
+import org.springframework.messaging.Message;
+
+/**
+ * Observation for Message Listener Containers.
+ *
+ * @author Tomaz Fernandes
+ * @since 3.4
+ */
+public abstract class AbstractListenerObservation {
+
+	/**
+	 * {@link ObservationConvention} for message listener key values.
+	 */
+	public static abstract class Convention<ContextType extends Context> implements ObservationConvention<ContextType> {
+
+		@Override
+		@NonNull
+		public KeyValues getLowCardinalityKeyValues(ContextType context) {
+			return KeyValues
+					.of(AbstractListenerObservation.Documentation.LowCardinalityTags.MESSAGING_SYSTEM
+							.withValue(getMessagingSystem()),
+							AbstractListenerObservation.Documentation.LowCardinalityTags.MESSAGING_OPERATION
+									.withValue("receive"),
+							AbstractListenerObservation.Documentation.LowCardinalityTags.MESSAGING_SOURCE_NAME
+									.withValue(context.getSourceName()),
+							AbstractListenerObservation.Documentation.LowCardinalityTags.MESSAGING_SOURCE_KIND
+									.withValue(getSourceKind()))
+					.and(getSpecificLowCardinalityKeyValues(context))
+					.and(getCustomLowCardinalityKeyValues(context));
+		}
+
+		protected KeyValues getSpecificLowCardinalityKeyValues(ContextType context) {
+			return KeyValues.empty();
+		}
+
+		/**
+		 * Return custom low cardinality key values for the observation. This method is intended to 
+		 * be overridden by subclasses to add custom low cardinality tags to the observation.
+		 * 
+		 * @param context the context for which to get key values.
+		 * @return key values to add to the observation, empty by default.
+		 */
+		protected KeyValues getCustomLowCardinalityKeyValues(ContextType context) {
+			return KeyValues.empty();
+		}
+
+		@Override
+		@NonNull
+		public KeyValues getHighCardinalityKeyValues(ContextType context) {
+			return KeyValues.of(Documentation.HighCardinalityTags.MESSAGE_ID.withValue(context.getMessageId()))
+					.and(getSpecificHighCardinalityKeyValues(context)).and(getCustomHighCardinalityKeyValues(context));
+		}
+
+		protected KeyValues getSpecificHighCardinalityKeyValues(ContextType context) {
+			return KeyValues.empty();
+		}
+
+		/**
+		 * Return custom high cardinality key values for the observation. This method is intended to 
+		 * be overridden by subclasses to add custom high cardinality tags to the observation.
+		 * 
+		 * @param context the context for which to get key values.
+		 * @return key values to add to the observation, empty by default.
+		 */
+		protected KeyValues getCustomHighCardinalityKeyValues(ContextType context) {
+			return KeyValues.empty();
+		}
+
+		@Override
+		public String getContextualName(ContextType context) {
+			return context.getSourceName() + " receive";
+		}
+
+		@Override
+		public String getName() {
+			return "spring.aws." + getMessagingSystem() + ".listener";
+		}
+
+		protected abstract String getSourceKind();
+
+		protected abstract String getMessagingSystem();
+
+	}
+
+	/**
+	 * {@link ObservationDocumentation} for message listener keys.
+	 */
+	public static abstract class Documentation implements ObservationDocumentation {
+
+		KeyName[] EMPTY = new KeyName[0];
+
+		@Override
+		public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+			return getSpecificDefaultConvention();
+		}
+
+		protected abstract Class<? extends ObservationConvention<? extends Observation.Context>> getSpecificDefaultConvention();
+
+		@Override
+		@NonNull
+		public KeyName[] getLowCardinalityKeyNames() {
+			return KeyName.merge(AbstractListenerObservation.Documentation.LowCardinalityTags.values(),
+					getSpecificLowCardinalityKeyNames());
+		}
+
+		protected KeyName[] getSpecificLowCardinalityKeyNames() {
+			return EMPTY;
+		}
+
+		@Override
+		@NonNull
+		public KeyName[] getHighCardinalityKeyNames() {
+			return KeyName.merge(HighCardinalityTags.values(), getSpecificHighCardinalityKeyNames());
+		}
+
+		protected KeyName[] getSpecificHighCardinalityKeyNames() {
+			return EMPTY;
+		}
+
+		/**
+		 * Low cardinality tags.
+		 */
+		public enum LowCardinalityTags implements KeyName {
+
+			/**
+			 * Messaging system.
+			 */
+			MESSAGING_SYSTEM {
+				@Override
+				@NonNull
+				public String asString() {
+					return "messaging.system";
+				}
+
+			},
+
+			/**
+			 * Messaging operation.
+			 */
+			MESSAGING_OPERATION {
+				@Override
+				@NonNull
+				public String asString() {
+					return "messaging.operation";
+				}
+
+			},
+
+			/**
+			 * Messaging source name.
+			 */
+			MESSAGING_SOURCE_NAME {
+				@Override
+				@NonNull
+				public String asString() {
+					return "messaging.source.name";
+				}
+
+			},
+
+			/**
+			 * Messaging source kind.
+			 */
+			MESSAGING_SOURCE_KIND {
+				@Override
+				@NonNull
+				public String asString() {
+					return "messaging.source.kind";
+				}
+
+			},
+
+		}
+
+		/**
+		 * High cardinality tags.
+		 */
+		public enum HighCardinalityTags implements KeyName {
+
+			/**
+			 * Message id.
+			 */
+			MESSAGE_ID {
+				@Override
+				@NonNull
+				public String asString() {
+					return "messaging.message.id";
+				}
+			},
+
+		}
+
+	}
+
+	/**
+	 * {@link ReceiverContext} for message listeners.
+	 */
+	public static abstract class Context extends ReceiverContext<Message<?>> {
+
+		private final Message<?> message;
+		private final String messageId;
+		private final String sourceName;
+
+		/**
+		 * Build a messaging receiver context.
+		 * @param message the message.
+		 * @param sourceName the source name.
+		 */
+		protected Context(Message<?> message, String sourceName) {
+			super((carrier, key) -> carrier.getHeaders().get(key, String.class));
+			setCarrier(message);
+			this.message = message;
+			this.messageId = MessageHeaderUtils.getId(message);
+			this.sourceName = sourceName;
+		}
+
+		/**
+		 * Return the message id.
+		 * @return the message id.
+		 */
+		public String getMessageId() {
+			return this.messageId;
+		}
+
+		/**
+		 * Return the message.
+		 * @return the message.
+		 */
+		public Message<?> getMessage() {
+			return this.message;
+		}
+
+		/**
+		 * Return the source name.
+		 * @return the source name.
+		 */
+		public String getSourceName() {
+			return this.sourceName;
+		}
+	}
+
+	/**
+	 * Observation-related instances that are specific to a messaging system.
+	 * @param <ContextType>
+	 */
+	public interface Specifics<ContextType extends Context> {
+
+		/**
+		 * Construct an specific {@link Context} instance with the provided message.
+		 * @param message the message from which the context should be constructed.
+		 * @return the context instance.
+		 */
+		ContextType createContext(Message<?> message);
+
+		/**
+		 * Return the default {@link ObservationConvention} for the specific messaging system.
+		 * @return the convention.
+		 */
+		ObservationConvention<ContextType> getDefaultConvention();
+
+		/**
+		 * Return the {@link ObservationDocumentation} for the specific messaging system.
+		 * @return the documentation.
+		 */
+		ObservationDocumentation getDocumentation();
+
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/observation/AbstractTemplateObservation.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/observation/AbstractTemplateObservation.java
@@ -237,6 +237,7 @@ public abstract class AbstractTemplateObservation {
 		private static final String BAGGAGE_KEY = "baggage";
 		private static final String TRACEPARENT_KEY = "traceparent";
 		private static final String TRACESTATE_KEY = "tracestate";
+		private static final String B3_KEY = "b3";
 
 		private final Message<?> message;
 		private final String destinationName;
@@ -262,7 +263,7 @@ public abstract class AbstractTemplateObservation {
 		}
 
 		private static boolean isAllowedKey(String key) {
-			return BAGGAGE_KEY.equals(key) || TRACEPARENT_KEY.equals(key) || TRACESTATE_KEY.equals(key);
+			return BAGGAGE_KEY.equals(key) || TRACEPARENT_KEY.equals(key) || TRACESTATE_KEY.equals(key) || B3_KEY.equals(key);
 		}
 
 		/**

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/observation/AbstractTemplateObservation.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/observation/AbstractTemplateObservation.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.support.observation;
+
+import io.awspring.cloud.sqs.operations.SendResult;
+import io.micrometer.common.KeyValues;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.docs.ObservationDocumentation;
+import io.micrometer.observation.transport.SenderContext;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.lang.NonNull;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+
+/**
+ * Observation for {@link io.awspring.cloud.sqs.operations.MessagingOperations}.
+ *
+ * @author Tomaz Fernandes
+ * @since 3.4
+ */
+public abstract class AbstractTemplateObservation {
+
+	/**
+	 * {@link AbstractTemplateObservation.Convention} for template key values.
+	 */
+	public static abstract class Convention<ContextType extends Context> implements ObservationConvention<ContextType> {
+
+		@Override
+		@NonNull
+		public KeyValues getLowCardinalityKeyValues(ContextType context) {
+			return KeyValues
+					.of(AbstractTemplateObservation.Documentation.LowCardinalityTags.MESSAGING_SYSTEM
+							.withValue(getMessagingSystem()),
+							AbstractTemplateObservation.Documentation.LowCardinalityTags.MESSAGING_OPERATION
+									.withValue("publish"),
+							AbstractTemplateObservation.Documentation.LowCardinalityTags.MESSAGING_DESTINATION_NAME
+									.withValue(context.getDestinationName()),
+							AbstractTemplateObservation.Documentation.LowCardinalityTags.MESSAGING_DESTINATION_KIND
+									.withValue(getSourceKind()))
+					.and(getSpecificLowCardinalityKeyValues(context)).and(getCustomLowCardinalityKeyValues(context));
+		}
+
+		protected KeyValues getSpecificLowCardinalityKeyValues(ContextType context) {
+			return KeyValues.empty();
+		}
+
+		/**
+		 * Return custom low cardinality key values for the observation. This method is intended to 
+		 * be overridden by subclasses to add custom low cardinality tags to the observation.
+		 * 
+		 * @param context the context for which to get key values.
+		 * @return key values to add to the observation, empty by default.
+		 */
+		protected KeyValues getCustomLowCardinalityKeyValues(ContextType context) {
+			return KeyValues.empty();
+		}
+
+		@Override
+		@NonNull
+		public KeyValues getHighCardinalityKeyValues(@NonNull ContextType context) {
+			return getMessageIdKeyValue(context)
+				.and(getSpecificHighCardinalityKeyValues(context))
+				.and(getCustomHighCardinalityKeyValues(context));
+		}
+
+		private KeyValues getMessageIdKeyValue(ContextType context) {
+			String messageId = context.getMessageId();
+			return messageId != null ? KeyValues
+				.of(Documentation.HighCardinalityTags.MESSAGE_ID
+					.withValue(messageId)) : KeyValues.empty();
+		}
+
+		protected KeyValues getSpecificHighCardinalityKeyValues(ContextType context) {
+			return KeyValues.empty();
+		}
+
+		/**
+		 * Return custom high cardinality key values for the observation. This method is intended to 
+		 * be overridden by subclasses to add custom high cardinality tags to the observation.
+		 * 
+		 * @param context the context for which to get key values.
+		 * @return key values to add to the observation, empty by default.
+		 */
+		protected KeyValues getCustomHighCardinalityKeyValues(ContextType context) {
+			return KeyValues.empty();
+		}
+
+		@Override
+		public String getContextualName(ContextType context) {
+			return context.getDestinationName() + " send";
+		}
+
+		@Override
+		public String getName() {
+			return "spring.aws." + getMessagingSystem() + ".template";
+		}
+
+		protected abstract String getSourceKind();
+
+		protected abstract String getMessagingSystem();
+
+	}
+
+	/**
+	 * {@link ObservationDocumentation} for template keys.
+	 */
+	public static abstract class Documentation implements ObservationDocumentation {
+
+		KeyName[] EMPTY = new KeyName[0];
+
+		@Override
+		public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+			return getSpecificDefaultConvention();
+		}
+
+		protected abstract Class<? extends ObservationConvention<? extends Observation.Context>> getSpecificDefaultConvention();
+
+		@Override
+		@NonNull
+		public KeyName[] getLowCardinalityKeyNames() {
+			return KeyName.merge(AbstractTemplateObservation.Documentation.LowCardinalityTags.values(),
+					getSpecificLowCardinalityKeyNames());
+		}
+
+		protected KeyName[] getSpecificLowCardinalityKeyNames() {
+			return EMPTY;
+		}
+
+		@Override
+		@NonNull
+		public KeyName[] getHighCardinalityKeyNames() {
+			return KeyName.merge(AbstractTemplateObservation.Documentation.LowCardinalityTags.values(),
+					getSpecificHighCardinalityKeyNames());
+		}
+
+		protected KeyName[] getSpecificHighCardinalityKeyNames() {
+			return EMPTY;
+		}
+
+		/**
+		 * Low cardinality tags.
+		 */
+		public enum LowCardinalityTags implements KeyName {
+
+			/**
+			 * Messaging system.
+			 */
+			MESSAGING_SYSTEM {
+				@Override
+				@NonNull
+				public String asString() {
+					return "messaging.system";
+				}
+
+			},
+
+			/**
+			 * Messaging operation.
+			 */
+			MESSAGING_OPERATION {
+				@Override
+				@NonNull
+				public String asString() {
+					return "messaging.operation";
+				}
+
+			},
+
+			/**
+			 * Messaging destination name.
+			 */
+			MESSAGING_DESTINATION_NAME {
+				@Override
+				@NonNull
+				public String asString() {
+					return "messaging.destination.name";
+				}
+
+			},
+
+			/**
+			 * Messaging destination kind.
+			 */
+			MESSAGING_DESTINATION_KIND {
+				@Override
+				@NonNull
+				public String asString() {
+					return "messaging.destination.kind";
+				}
+
+			},
+
+		}
+
+		/**
+		 * High cardinality tags.
+		 */
+		public enum HighCardinalityTags implements KeyName {
+
+			/**
+			 * Message id.
+			 */
+			MESSAGE_ID {
+				@Override
+				@NonNull
+				public String asString() {
+					return "messaging.message.id";
+				}
+			},
+
+		}
+
+	}
+
+	/**
+	 * {@link SenderContext} for message listeners.
+	 */
+	public static abstract class Context extends SenderContext<Map<String, Object>> {
+
+		private final Message<?> message;
+		private final String destinationName;
+		private SendResult<?> sendResult;
+
+		/**
+		 * Build a messaging sender context.
+		 *
+		 * @param message the message.
+		 * @param destinationName the destination name.
+		 */
+		protected Context(Message<?> message, String destinationName) {
+			super((carrier, key, value) -> {
+				if (carrier != null) {
+					carrier.put(key, value);
+				}
+			});
+			setCarrier(new HashMap<>());
+			Assert.notNull(message, "Message must not be null");
+			Assert.notNull(destinationName, "destinationName must not be null");
+			this.message = message;
+			this.destinationName = destinationName;
+		}
+
+		/**
+		 * Set the send result for this context.
+		 * 
+		 * @param sendResult the send result from message sending operation.
+		 */
+		public void setSendResult(SendResult<?> sendResult) {
+			Assert.notNull(sendResult, "sendResult must not be null");
+			this.sendResult = sendResult;
+		}
+
+		/**
+		 * Return the message id.
+		 *
+		 * @return the message id.
+		 */
+		public String getMessageId() {
+			return this.sendResult != null ? sendResult.messageId().toString() : null;
+		}
+
+		/**
+		 * Return the send result.
+		 * 
+		 * @return the send result.
+		 */
+		public SendResult<?> getSendResult() {
+			return this.sendResult;
+		}
+
+		/**
+		 * Return the message.
+		 *
+		 * @return the message.
+		 */
+		public Message<?> getMessage() {
+			return this.message;
+		}
+
+		/**
+		 * Return the destination name.
+		 *
+		 * @return the destination name.
+		 */
+		public String getDestinationName() {
+			return this.destinationName;
+		}
+
+	}
+
+	/**
+	 * Contains observation-related instances that are specific to a messaging system.
+	 *
+	 * @param <ContextType>
+	 */
+	public interface Specifics<ContextType extends Context> {
+
+		/**
+		 * Construct an specific {@link AbstractListenerObservation.Context} instance with the provided message.
+		 *
+		 * @param message the message from which the context should be constructed.
+		 * @return the context instance.
+		 */
+		ContextType createContext(Message<?> message, String destinationName);
+
+		/**
+		 * Return the default {@link ObservationConvention} for the specific messaging system.
+		 *
+		 * @return the convention.
+		 */
+		ObservationConvention<ContextType> getDefaultConvention();
+
+		/**
+		 * Return the {@link ObservationDocumentation} for the specific messaging system.
+		 *
+		 * @return the documentation.
+		 */
+		ObservationDocumentation getDocumentation();
+
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/observation/AbstractTemplateObservation.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/observation/AbstractTemplateObservation.java
@@ -234,6 +234,10 @@ public abstract class AbstractTemplateObservation {
 	 */
 	public static abstract class Context extends SenderContext<Map<String, Object>> {
 
+		private static final String BAGGAGE_KEY = "baggage";
+		private static final String TRACEPARENT_KEY = "traceparent";
+		private static final String TRACESTATE_KEY = "tracestate";
+
 		private final Message<?> message;
 		private final String destinationName;
 		private SendResult<?> sendResult;
@@ -246,7 +250,7 @@ public abstract class AbstractTemplateObservation {
 		 */
 		protected Context(Message<?> message, String destinationName) {
 			super((carrier, key, value) -> {
-				if (carrier != null) {
+				if (carrier != null && isAllowedKey(key)) {
 					carrier.put(key, value);
 				}
 			});
@@ -255,6 +259,10 @@ public abstract class AbstractTemplateObservation {
 			Assert.notNull(destinationName, "destinationName must not be null");
 			this.message = message;
 			this.destinationName = destinationName;
+		}
+
+		private static boolean isAllowedKey(String key) {
+			return BAGGAGE_KEY.equals(key) || TRACEPARENT_KEY.equals(key) || TRACESTATE_KEY.equals(key);
 		}
 
 		/**

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/observation/MessageHeaderContextAccessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/observation/MessageHeaderContextAccessor.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.support.observation;
+
+import io.micrometer.context.ContextAccessor;
+import java.util.Map;
+import java.util.function.Predicate;
+import org.springframework.lang.NonNull;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * {@link ContextAccessor} that use {@link MessageHeaders} to hold the Observation context. Intended for read-only
+ * operations.
+ *
+ * @author Tomaz Fernandes
+ * @since 3.4
+ */
+public class MessageHeaderContextAccessor implements ContextAccessor<MessageHeaders, MessageHeaders> {
+
+	@Override
+	@NonNull
+	public Class<? extends MessageHeaders> readableType() {
+		return MessageHeaders.class;
+	}
+
+	@Override
+	public void readValues(MessageHeaders sourceContext, @NonNull Predicate<Object> keyPredicate,
+			@NonNull Map<Object, Object> target) {
+		sourceContext.forEach((k, v) -> {
+			if (keyPredicate.test(k)) {
+				target.put(k, v);
+			}
+		});
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> T readValue(MessageHeaders sourceContext, Object key) {
+		return (T) sourceContext.get(key.toString());
+	}
+
+	@Override
+	@NonNull
+	public Class<? extends MessageHeaders> writeableType() {
+		return MessageHeaders.class;
+	}
+
+	@Override
+	@NonNull
+	public MessageHeaders writeValues(@NonNull Map<Object, Object> valuesToWrite,
+			@NonNull MessageHeaders targetContext) {
+		throw new UnsupportedOperationException("Should not write values to the MessageHeaders");
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/observation/SqsListenerObservation.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/observation/SqsListenerObservation.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.support.observation;
+
+import io.awspring.cloud.sqs.MessageHeaderUtils;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.micrometer.common.KeyValues;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.docs.ObservationDocumentation;
+import org.springframework.lang.NonNull;
+import org.springframework.messaging.Message;
+import org.springframework.util.StringUtils;
+
+/**
+ *
+ * SQS-specific Observation for {@link io.awspring.cloud.sqs.listener.SqsMessageListenerContainer}.
+ *
+ * @author Tomaz Fernandes
+ * @since 3.4
+ */
+public class SqsListenerObservation {
+
+	/**
+	 * {@link ObservationDocumentation} for SQS message listener keys.
+	 */
+	public static class Documentation extends AbstractListenerObservation.Documentation {
+
+		@Override
+		protected Class<? extends ObservationConvention<? extends Observation.Context>> getSpecificDefaultConvention() {
+			return DefaultConvention.class;
+		}
+
+		protected KeyName[] getSpecificHighCardinalityKeyNames() {
+			return SqsListenerObservation.Documentation.HighCardinalityTags.values();
+		}
+
+		/**
+		 * SQS-specific high cardinality tags.
+		 */
+		public enum HighCardinalityTags implements KeyName {
+
+			/**
+			 * Message group id for messages from FIFO queues.
+			 */
+			MESSAGE_GROUP_ID {
+				@Override
+				@NonNull
+				public String asString() {
+					return "messaging.message.message-group.id";
+				}
+			},
+
+			/**
+			 * Message deduplication id for messages from FIFO queues.
+			 */
+			MESSAGE_DEDUPLICATION_ID {
+				@Override
+				@NonNull
+				public String asString() {
+					return "messaging.message.message-deduplication.id";
+				}
+			},
+
+		}
+
+	}
+
+	/**
+	 * {@link ObservationConvention} for SQS message listener key values.
+	 */
+	public interface Convention extends ObservationConvention<Context> {
+
+		@Override
+		default boolean supportsContext(@NonNull Observation.Context context) {
+			return context instanceof Context;
+		}
+
+		/**
+		 * Return the name of this observation.
+		 * 
+		 * @return the name of the observation.
+		 */
+		@Override
+		default String getName() {
+			return "spring.cloud.aws.sqs.listener";
+		}
+
+	}
+
+	/**
+	 * {@link Context} for SQS message listeners.
+	 */
+	public static class Context extends AbstractListenerObservation.Context {
+
+		private final String messageGroupId;
+
+		private final String messageDeduplicationId;
+
+		/**
+		 * Construct an SQS message receiver context.
+		 *
+		 * @param message the message.
+		 */
+		public Context(Message<?> message) {
+			super(message, getQueueName(message));
+			this.messageGroupId = message.getHeaders()
+					.containsKey(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER)
+							? MessageHeaderUtils.getHeaderAsString(message,
+									SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER)
+							: "";
+			this.messageDeduplicationId = message.getHeaders()
+					.containsKey(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER)
+							? MessageHeaderUtils.getHeaderAsString(message,
+									SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER)
+							: "";
+			setRemoteServiceName("AWS SQS");
+		}
+
+		private static String getQueueName(Message<?> message) {
+			return MessageHeaderUtils.getHeaderAsString(message, SqsHeaders.SQS_QUEUE_NAME_HEADER);
+		}
+
+		/**
+		 * Return the message group id.
+		 *
+		 * @return the message group id.
+		 */
+		public String getMessageGroupId() {
+			return this.messageGroupId;
+		}
+
+		/**
+		 * Return the message deduplication id.
+		 *
+		 * @return the message deduplication id.
+		 */
+		public String getMessageDeduplicationId() {
+			return this.messageDeduplicationId;
+		}
+	}
+
+	/**
+	 * {@link ObservationConvention} for SQS listener key values.
+	 *
+	 * @author Tomaz Fernandes
+	 * @since 3.4
+	 */
+	public static class DefaultConvention extends AbstractListenerObservation.Convention<Context>
+			implements Convention {
+
+		@Override
+		protected String getSourceKind() {
+			return "queue";
+		}
+
+		@Override
+		protected String getMessagingSystem() {
+			return "sqs";
+		}
+
+		@Override
+		protected KeyValues getSpecificHighCardinalityKeyValues(Context context) {
+			// FIFO-specific keys
+			String messageDeduplicationId = context.getMessageDeduplicationId();
+			String messageGroupId = context.getMessageGroupId();
+			return StringUtils.hasText(messageGroupId) && StringUtils.hasText(messageDeduplicationId) ? KeyValues.of(
+					Documentation.HighCardinalityTags.MESSAGE_GROUP_ID.withValue(messageGroupId),
+					Documentation.HighCardinalityTags.MESSAGE_DEDUPLICATION_ID.withValue(messageDeduplicationId))
+					: KeyValues.empty();
+		}
+
+	}
+
+	/**
+	 * Observation-related instances that are specific to SQS.
+	 */
+	public static class SqsSpecifics implements AbstractListenerObservation.Specifics<Context> {
+
+		private static final SqsListenerObservation.DefaultConvention LISTENER_CONVENTION_INSTANCE = new SqsListenerObservation.DefaultConvention();
+
+		private static final SqsListenerObservation.Documentation LISTENER_DOCUMENTATION_INSTANCE = new SqsListenerObservation.Documentation();
+
+		@Override
+		public Context createContext(Message<?> message) {
+			return new Context(message);
+		}
+
+		@Override
+		public ObservationConvention<Context> getDefaultConvention() {
+			return LISTENER_CONVENTION_INSTANCE;
+		}
+
+		@Override
+		public ObservationDocumentation getDocumentation() {
+			return LISTENER_DOCUMENTATION_INSTANCE;
+		}
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/observation/SqsTemplateObservation.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/observation/SqsTemplateObservation.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.support.observation;
+
+import io.awspring.cloud.sqs.MessageHeaderUtils;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import io.micrometer.common.KeyValues;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.docs.ObservationDocumentation;
+import org.springframework.lang.NonNull;
+import org.springframework.messaging.Message;
+import org.springframework.util.StringUtils;
+
+/**
+ * Observation for {@link io.awspring.cloud.sqs.operations.SqsTemplate}.
+ *
+ * @author Tomaz Fernandes
+ * @since 3.4
+ */
+public class SqsTemplateObservation {
+
+	/**
+	 * {@link ObservationDocumentation} for SqsTemplate keys.
+	 */
+	public static class Documentation extends AbstractTemplateObservation.Documentation {
+
+		@Override
+		protected Class<? extends ObservationConvention<? extends Observation.Context>> getSpecificDefaultConvention() {
+			return DefaultConvention.class;
+		}
+
+		protected KeyName[] getSpecificHighCardinalityKeyNames() {
+			return SqsTemplateObservation.Documentation.HighCardinalityTags.values();
+		}
+
+		/**
+		 * High cardinality tags.
+		 */
+		public enum HighCardinalityTags implements KeyName {
+
+			/**
+			 * Message group id for messages sent to FIFO queues.
+			 */
+			MESSAGE_GROUP_ID {
+				@Override
+				@NonNull
+				public String asString() {
+					return "messaging.message.message-group.id";
+				}
+			},
+
+			/**
+			 * Message deduplication id for messages sent to FIFO queues.
+			 */
+			MESSAGE_DEDUPLICATION_ID {
+				@Override
+				@NonNull
+				public String asString() {
+					return "messaging.message.message-deduplication.id";
+				}
+			},
+
+		}
+
+	}
+
+	/**
+	 * {@link ObservationConvention} for {@link SqsTemplate} key values.
+	 */
+	public interface Convention extends ObservationConvention<Context> {
+
+		@Override
+		default boolean supportsContext(@NonNull Observation.Context context) {
+			return context instanceof Context;
+		}
+
+		/**
+		 * Return the name of this observation.
+		 *
+		 * @return the name of the observation.
+		 */
+		@Override
+		default String getName() {
+			return "spring.cloud.aws.sqs.template";
+		}
+
+	}
+
+	/**
+	 * {@link SqsListenerObservation.Context} for {@link SqsTemplate}.
+	 */
+	public static class Context extends AbstractTemplateObservation.Context {
+
+		private final String messageGroupId;
+
+		private final String messageDeduplicationId;
+
+		/**
+		 * Construct an SQS message sender context.
+		 *
+		 * @param message the message.
+		 */
+		public Context(Message<?> message, String destinationName) {
+			super(message, destinationName);
+			this.messageGroupId = message.getHeaders()
+					.containsKey(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER)
+							? MessageHeaderUtils.getHeaderAsString(message,
+									SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER)
+							: "";
+			this.messageDeduplicationId = message.getHeaders()
+					.containsKey(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER)
+							? MessageHeaderUtils.getHeaderAsString(message,
+									SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER)
+							: "";
+			setRemoteServiceName("AWS SQS");
+		}
+
+		/**
+		 * Return the message group id.
+		 *
+		 * @return the message group id.
+		 */
+		public String getMessageGroupId() {
+			return this.messageGroupId;
+		}
+
+		/**
+		 * Return the message deduplication id.
+		 *
+		 * @return the message deduplication id.
+		 */
+		public String getMessageDeduplicationId() {
+			return this.messageDeduplicationId;
+		}
+	}
+
+	/**
+	 * {@link ObservationConvention} for SQS template key values.
+	 *
+	 * @author Tomaz Fernandes
+	 * @since 3.4
+	 */
+	public static class DefaultConvention extends AbstractTemplateObservation.Convention<Context>
+			implements Convention {
+
+		@Override
+		protected String getSourceKind() {
+			return "queue";
+		}
+
+		@Override
+		protected String getMessagingSystem() {
+			return "sqs";
+		}
+
+		@Override
+		protected KeyValues getSpecificHighCardinalityKeyValues(Context context) {
+			// FIFO-specific keys
+			String messageDeduplicationId = context.getMessageDeduplicationId();
+			String messageGroupId = context.getMessageGroupId();
+			return StringUtils.hasText(messageGroupId) && StringUtils.hasText(messageDeduplicationId) ? KeyValues.of(
+					SqsTemplateObservation.Documentation.HighCardinalityTags.MESSAGE_GROUP_ID.withValue(messageGroupId),
+					SqsTemplateObservation.Documentation.HighCardinalityTags.MESSAGE_DEDUPLICATION_ID
+							.withValue(messageDeduplicationId))
+					: KeyValues.empty();
+		}
+
+	}
+
+	/**
+	 * Observation-related instances that are specific to SQS.
+	 */
+	public static class SqsSpecifics implements AbstractTemplateObservation.Specifics<Context> {
+
+		private static final DefaultConvention CONVENTION_INSTANCE = new DefaultConvention();
+
+		private static final Documentation DOCUMENTATION_INSTANCE = new Documentation();
+
+		@Override
+		public Context createContext(Message<?> message, String destinationName) {
+			return new Context(message, destinationName);
+		}
+
+		@Override
+		public ObservationConvention<Context> getDefaultConvention() {
+			return CONVENTION_INSTANCE;
+		}
+
+		@Override
+		public ObservationDocumentation getDocumentation() {
+			return DOCUMENTATION_INSTANCE;
+		}
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/ExceptionUtilsTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/ExceptionUtilsTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ExceptionUtils}.
+ *
+ * @author Tomaz Fernandes
+ */
+class ExceptionUtilsTest {
+
+	@Test
+	void shouldReturnOriginalExceptionWhenNoExceptionsToUnwrap() {
+		// given
+		RuntimeException original = new RuntimeException("Original exception");
+
+		// when
+		Throwable unwrapped = ExceptionUtils.unwrapException(original);
+
+		// then
+		assertThat(unwrapped).isSameAs(original);
+	}
+
+	@Test
+	void shouldReturnOriginalExceptionWhenNotInExceptionsToUnwrap() {
+		// given
+		RuntimeException original = new RuntimeException("Original exception");
+
+		// when
+		Throwable unwrapped = ExceptionUtils.unwrapException(original, IOException.class);
+
+		// then
+		assertThat(unwrapped).isSameAs(original);
+	}
+
+	@Test
+	void shouldUnwrapSingleLevelException() {
+		// given
+		IOException cause = new IOException("Root cause");
+		CompletionException original = new CompletionException(cause);
+
+		// when
+		Throwable unwrapped = ExceptionUtils.unwrapException(original, CompletionException.class);
+
+		// then
+		assertThat(unwrapped).isSameAs(cause);
+	}
+
+	@Test
+	void shouldUnwrapMultipleLevelExceptions() {
+		// given
+		IllegalArgumentException rootCause = new IllegalArgumentException("Root cause");
+		IOException midCause = new IOException("Mid cause", rootCause);
+		CompletionException executionException = new CompletionException(midCause);
+		RuntimeException topException = new RuntimeException("Top exception", executionException);
+
+		// when
+		Throwable unwrapped = ExceptionUtils.unwrapException(topException, RuntimeException.class,
+				CompletionException.class);
+
+		// then
+		assertThat(unwrapped).isSameAs(midCause);
+	}
+
+	@Test
+	void shouldUnwrapAllSpecifiedExceptionTypes() {
+		// given
+		IllegalArgumentException rootCause = new IllegalArgumentException("Root cause");
+		ExecutionException midCause1 = new ExecutionException("Mid cause 1", rootCause);
+		CompletionException midCause2 = new CompletionException(midCause1);
+		RuntimeException topException = new RuntimeException("Top exception", midCause2);
+
+		// when
+		Throwable unwrapped = ExceptionUtils.unwrapException(topException, RuntimeException.class,
+				CompletionException.class, ExecutionException.class);
+
+		// then
+		assertThat(unwrapped).isSameAs(rootCause);
+	}
+
+	@Test
+	void shouldHandleNullCause() {
+		// given
+		CompletionException exceptionWithNullCause = new CompletionException(null);
+
+		// when/then
+		Throwable unwrapped = ExceptionUtils.unwrapException(exceptionWithNullCause, CompletionException.class);
+
+		// then
+		assertThat(unwrapped).isEqualTo(exceptionWithNullCause);
+	}
+
+	@Test
+	void shouldWorkWithCustomExceptions() {
+		// given
+		class Level1Exception extends RuntimeException {
+			Level1Exception(Throwable cause) {
+				super(cause);
+			}
+		}
+
+		class Level2Exception extends RuntimeException {
+			Level2Exception(Throwable cause) {
+				super(cause);
+			}
+		}
+
+		IOException rootCause = new IOException("Root cause");
+		Level2Exception level2 = new Level2Exception(rootCause);
+		Level1Exception level1 = new Level1Exception(level2);
+
+		// when
+		Throwable unwrapped = ExceptionUtils.unwrapException(level1, Level1Exception.class, Level2Exception.class);
+
+		// then
+		assertThat(unwrapped).isSameAs(rootCause);
+	}
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/MessageHeaderUtilsTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/MessageHeaderUtilsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * Tests for {@link MessageHeaderUtils}.
+ *
+ * @author Tomaz Fernandes
+ */
+class MessageHeaderUtilsTest {
+
+	@Test
+	void shouldRemoveHeaderWhenPresent() {
+		// given
+		String headerKey = "test-header";
+		String headerValue = "test-value";
+		Message<String> message = MessageBuilder.withPayload("test-payload").setHeader(headerKey, headerValue).build();
+
+		// when
+		Message<String> result = MessageHeaderUtils.removeHeaderIfPresent(message, headerKey);
+
+		// then
+		assertThat(result.getPayload()).isEqualTo(message.getPayload());
+		assertThat(result.getHeaders().containsKey(headerKey)).isFalse();
+
+		// Original message should remain unchanged
+		assertThat(message.getHeaders().containsKey(headerKey)).isTrue();
+		assertThat(message.getHeaders().get(headerKey)).isEqualTo(headerValue);
+	}
+
+	@Test
+	void shouldReturnOriginalMessageWhenHeaderNotPresent() {
+		// given
+		String headerKey = "non-existent-header";
+		Message<String> message = MessageBuilder.withPayload("test-payload").build();
+
+		// when
+		Message<String> result = MessageHeaderUtils.removeHeaderIfPresent(message, headerKey);
+
+		// then
+		assertThat(result).isSameAs(message);
+	}
+
+	@Test
+	void shouldPreserveMessageIdAndTimestamp() {
+		// given
+		String headerKey = "test-header";
+		String headerValue = "test-value";
+		Message<String> message = MessageBuilder.withPayload("test-payload").setHeader(headerKey, headerValue).build();
+
+		// when
+		Message<String> result = MessageHeaderUtils.removeHeaderIfPresent(message, headerKey);
+
+		// then
+		assertThat(result.getHeaders().getId()).isEqualTo(message.getHeaders().getId());
+		assertThat(result.getHeaders().getTimestamp()).isEqualTo(message.getHeaders().getTimestamp());
+		assertThat(MessageHeaderUtils.getId(result)).isEqualTo(message.getHeaders().getId().toString());
+	}
+
+	@Test
+	void shouldPreserveOtherHeaders() {
+		// given
+		String headerToRemove = "header-to-remove";
+		String headerToKeep = "header-to-keep";
+		Message<String> message = MessageBuilder.withPayload("test-payload").setHeader(headerToRemove, "remove-value")
+				.setHeader(headerToKeep, "keep-value").setHeader("another-header", "another-value").build();
+
+		// when
+		Message<String> result = MessageHeaderUtils.removeHeaderIfPresent(message, headerToRemove);
+
+		// then
+		assertThat(result.getHeaders().containsKey(headerToRemove)).isFalse();
+		assertThat(result.getHeaders().get(headerToKeep)).isEqualTo("keep-value");
+		assertThat(result.getHeaders().get("another-header")).isEqualTo("another-value");
+		assertThat(result.getHeaders().size()).isEqualTo(message.getHeaders().size() - 1);
+	}
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
@@ -48,7 +48,17 @@ import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import io.awspring.cloud.sqs.listener.sink.MessageSink;
 import io.awspring.cloud.sqs.listener.source.AbstractSqsMessageSource;
 import io.awspring.cloud.sqs.listener.source.MessageSource;
+import io.awspring.cloud.sqs.operations.SendResult;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
+import io.awspring.cloud.sqs.support.observation.AbstractListenerObservation;
+import io.awspring.cloud.sqs.support.observation.AbstractTemplateObservation;
+import io.awspring.cloud.sqs.support.observation.SqsListenerObservation;
+import io.awspring.cloud.sqs.support.observation.SqsTemplateObservation;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.ObservationContextAssert;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -64,6 +74,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -138,6 +150,10 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 
 	static final String ACK_AFTER_SECOND_ERROR_FACTORY = "ackAfterSecondErrorFactory";
 
+	static final String OBSERVES_MESSAGE_QUEUE_NAME = "observes_message_test_queue";
+
+	static final String OBSERVES_ERROR_QUEUE_NAME = "observes_error_test_queue";
+
 	@BeforeAll
 	static void beforeTests() {
 		SqsAsyncClient client = createAsyncClient();
@@ -158,6 +174,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 				createQueue(client, MANUALLY_CREATE_INACTIVE_CONTAINER_QUEUE_NAME),
 				createQueue(client, MANUALLY_CREATE_FACTORY_QUEUE_NAME),
 				createQueue(client, CONSUMES_ONE_MESSAGE_AT_A_TIME_QUEUE_NAME),
+				createQueue(client, OBSERVES_MESSAGE_QUEUE_NAME), createQueue(client, OBSERVES_ERROR_QUEUE_NAME),
 				createQueue(client, MAX_CONCURRENT_MESSAGES_QUEUE_NAME)).join();
 	}
 
@@ -168,7 +185,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 	SqsTemplate sqsTemplate;
 
 	@Autowired
-	ObjectMapper objectMapper;
+	TestObservationRegistry observationRegistry;
 
 	@Autowired
 	@Qualifier("inactiveContainer")
@@ -182,6 +199,110 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		assertThat(latchContainer.receivesMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.invocableHandlerMethodLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.acknowledgementCallbackSuccessLatch.await(10, TimeUnit.SECONDS)).isTrue();
+	}
+
+	@Test
+	void observesMessage() throws Exception {
+		String messageBody = "observesMessage-payload";
+		SendResult<Object> sendResult = sqsTemplate
+			.send(to -> to.queue(OBSERVES_MESSAGE_QUEUE_NAME).payload(messageBody));
+		logger.debug("Sent message to queue {} with messageBody {}", OBSERVES_MESSAGE_QUEUE_NAME, messageBody);
+		assertThat(latchContainer.observesMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		await()
+			.atMost(10, TimeUnit.SECONDS)
+			.untilAsserted(() ->
+				TestObservationRegistryAssert.then(observationRegistry)
+					.hasHandledContextsThatSatisfy(contexts -> {
+						ObservationContextAssert.then(getContextWithContextualNameEqualTo(contexts, "observes_message_test_queue send"))
+							.hasNameEqualTo("spring.aws.sqs.template")
+							.isInstanceOf(SqsTemplateObservation.Context.class)
+							.hasLowCardinalityKeyValue(
+								AbstractTemplateObservation.Documentation.LowCardinalityTags.MESSAGING_OPERATION
+									.asString(),
+								"publish")
+							.hasLowCardinalityKeyValue(
+								AbstractTemplateObservation.Documentation.LowCardinalityTags.MESSAGING_DESTINATION_NAME
+									.asString(),
+								OBSERVES_MESSAGE_QUEUE_NAME)
+							.hasLowCardinalityKeyValue(
+								AbstractTemplateObservation.Documentation.LowCardinalityTags.MESSAGING_DESTINATION_KIND
+									.asString(),
+								"queue")
+							.hasLowCardinalityKeyValue(
+								AbstractTemplateObservation.Documentation.LowCardinalityTags.MESSAGING_SYSTEM
+									.asString(),
+								"sqs")
+							.hasHighCardinalityKeyValue(
+								AbstractTemplateObservation.Documentation.HighCardinalityTags.MESSAGE_ID.asString(),
+								sendResult.messageId().toString())
+							.doesNotHaveParentObservation();
+						ObservationContextAssert.then(getContextWithContextualNameEqualTo(contexts, "observes_message_test_queue receive"))
+							.hasNameEqualTo("spring.aws.sqs.listener")
+							.isInstanceOf(SqsListenerObservation.Context.class)
+							.hasLowCardinalityKeyValue(
+								AbstractListenerObservation.Documentation.LowCardinalityTags.MESSAGING_OPERATION
+									.asString(),
+								"receive")
+							.hasLowCardinalityKeyValue(
+								AbstractListenerObservation.Documentation.LowCardinalityTags.MESSAGING_SOURCE_NAME
+									.asString(),
+								"observes_message_test_queue")
+							.hasLowCardinalityKeyValue(
+								AbstractListenerObservation.Documentation.LowCardinalityTags.MESSAGING_SOURCE_KIND
+									.asString(),
+								"queue")
+							.hasLowCardinalityKeyValue(
+								AbstractListenerObservation.Documentation.LowCardinalityTags.MESSAGING_SYSTEM
+									.asString(),
+								"sqs")
+							.hasHighCardinalityKeyValue(
+								AbstractListenerObservation.Documentation.HighCardinalityTags.MESSAGE_ID.asString(),
+								sendResult.messageId().toString())
+							.doesNotHaveHighCardinalityKeyValueWithKey(
+								SqsListenerObservation.Documentation.HighCardinalityTags.MESSAGE_GROUP_ID
+									.asString())
+							.doesNotHaveParentObservation();
+						ObservationContextAssert.then(getContextWithName(contexts, "listener.process"))
+							.hasParentObservationContextMatching(
+								contextView -> contextView.getName().equals("spring.aws.sqs.listener"));
+					}));
+	}
+
+	private Observation.@NotNull Context getContextWithName(List<Observation.Context> contexts, String name) {
+		return contexts.stream().filter(context -> context.getName().equals(name)).findFirst().orElseThrow(() -> new AssertionError("Could not find context with name " + name));
+	}
+
+	private Observation.@NotNull Context getContextWithContextualNameEqualTo(List<Observation.Context> contexts, String contextualName) {
+		return contexts.stream().filter(context -> context.getContextualName() != null && context.getContextualName().equals(contextualName)).findFirst().orElseThrow(() -> new AssertionError("Could not find context with contextual name " + contextualName));
+	}
+
+	@Test
+	void observesError() throws Exception {
+		String messageBody = "observesMessage-payload";
+		sqsTemplate.send(to -> to.queue(OBSERVES_ERROR_QUEUE_NAME).payload(messageBody));
+		logger.debug("Sent message to queue {} with messageBody {}", OBSERVES_ERROR_QUEUE_NAME, messageBody);
+		assertThat(latchContainer.observesErrorLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		await()
+			.atMost(10, TimeUnit.SECONDS)
+			.untilAsserted(() ->
+				TestObservationRegistryAssert.then(observationRegistry)
+					.hasHandledContextsThatSatisfy(contexts -> {
+						ObservationContextAssert.then(getContextWithContextualNameEqualTo(contexts, "observes_error_test_queue send")).hasNameEqualTo("spring.aws.sqs.template")
+							.isInstanceOf(AbstractTemplateObservation.Context.class)
+							.doesNotHaveParentObservation();
+						List<Observation.Context> receivingContexts = contexts.stream()
+							.filter(context -> context.getContextualName() != null && context.getContextualName().equals("observes_error_test_queue receive"))
+							.toList();
+						ObservationContextAssert.then(receivingContexts.get(0)).hasNameEqualTo("spring.aws.sqs.listener")
+							.isInstanceOf(AbstractListenerObservation.Context.class)
+							.doesNotHaveParentObservation().assertThatError().isInstanceOf(RuntimeException.class)
+							.hasMessage("Expected exception from observes-error");
+						ObservationContextAssert.then(receivingContexts.get(1)).hasNameEqualTo("spring.aws.sqs.listener")
+							.isInstanceOf(AbstractListenerObservation.Context.class)
+							.hasContextualNameEqualTo("observes_error_test_queue receive")
+							.doesNotHaveParentObservation().doesNotHaveError();
+					})
+			);
 	}
 
 	@Test
@@ -497,6 +618,42 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		}
 	}
 
+	static class ObservesMessageListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		ObservationRegistry observationRegistry;
+
+		@SqsListener(queueNames = OBSERVES_MESSAGE_QUEUE_NAME, id = "observesMessageContainer")
+		void listen(String message) {
+			Observation.createNotStarted("listener.process", observationRegistry).observe(() -> {
+				logger.debug("Observed message in Listener Method: {}", message);
+				latchContainer.observesMessageLatch.countDown();
+			});
+
+			logger.debug("Received observed message in Listener Method: " + message);
+		}
+	}
+
+	static class ObservesErrorListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		AtomicBoolean hasThrown = new AtomicBoolean(false);
+
+		@SqsListener(queueNames = OBSERVES_ERROR_QUEUE_NAME, id = "observes-error", messageVisibilitySeconds = "1")
+		void listen(String message, @Header(SqsHeaders.SQS_QUEUE_NAME_HEADER) String queueName) {
+			logger.debug("Received message {} from queue {}", message, queueName);
+			if (hasThrown.compareAndSet(false, true)) {
+				throw new RuntimeException("Expected exception from observes-error");
+			}
+			latchContainer.observesErrorLatch.countDown();
+		}
+	}
+
 	static class LatchContainer {
 
 		final CountDownLatch receivesMessageLatch = new CountDownLatch(1);
@@ -520,6 +677,8 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		final CountDownLatch acknowledgementCallbackBatchLatch = new CountDownLatch(1);
 		final CountDownLatch acknowledgementCallbackErrorLatch = new CountDownLatch(1);
 		final CountDownLatch manuallyInactiveCreatedContainerLatch = new CountDownLatch(1);
+		final CountDownLatch observesMessageLatch = new CountDownLatch(1);
+		final CountDownLatch observesErrorLatch = new CountDownLatch(1);
 		final CyclicBarrier maxConcurrentMessagesBarrier = new CyclicBarrier(21);
 
 	}
@@ -530,7 +689,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 
 		// @formatter:off
 		@Bean
-		public SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFactory() {
+		public SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFactory(ObservationRegistry observationRegistry) {
 			return SqsMessageListenerContainerFactory
 				.builder()
 				.sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
@@ -538,6 +697,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 				.configure(options -> options
 					.maxDelayBetweenPolls(Duration.ofSeconds(5))
 					.queueAttributeNames(Collections.singletonList(QueueAttributeName.QUEUE_ARN))
+					.observationRegistry(observationRegistry)
 					.pollTimeout(Duration.ofSeconds(5)))
 				.build();
 		}
@@ -759,6 +919,16 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		}
 
 		@Bean
+		ObservesMessageListener observesMessageListener() {
+			return new ObservesMessageListener();
+		}
+
+		@Bean
+		ObservesErrorListener observesErrorListener() {
+			return new ObservesErrorListener();
+		}
+
+		@Bean
 		SqsListenerConfigurer customizer() {
 			return registrar -> {
 				registrar.setMessageHandlerMethodFactory(new DefaultMessageHandlerMethodFactory() {
@@ -782,12 +952,18 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		}
 
 		@Bean
-		SqsTemplate sqsTemplate() {
-			return SqsTemplate.builder().sqsAsyncClient(BaseSqsIntegrationTest.createAsyncClient()).build();
+		SqsTemplate sqsTemplate(ObservationRegistry observationRegistry) {
+			return SqsTemplate.builder().configure(options -> options.observationRegistry(observationRegistry))
+					.sqsAsyncClient(BaseSqsIntegrationTest.createAsyncClient()).build();
+		}
+
+		@Bean
+		ObservationRegistry observationRegistry() {
+			return TestObservationRegistry.create();
 		}
 
 		private AsyncMessageInterceptor<Object> testInterceptor() {
-			return new AsyncMessageInterceptor<Object>() {
+			return new AsyncMessageInterceptor<>() {
 				@Override
 				public CompletableFuture<Message<Object>> intercept(Message<Object> message) {
 					latchContainer.interceptorLatch.countDown();

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsObservationIntegrationTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsObservationIntegrationTest.java
@@ -1,0 +1,466 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.integration;
+
+import io.awspring.cloud.sqs.MessageHeaderUtils;
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration;
+import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementMode;
+import io.awspring.cloud.sqs.listener.errorhandler.ErrorHandler;
+import io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor;
+import io.awspring.cloud.sqs.operations.SendResult;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import io.awspring.cloud.sqs.support.converter.MessagingMessageHeaders;
+import io.awspring.cloud.sqs.support.observation.MessageHeaderContextAccessor;
+import io.micrometer.context.ContextRegistry;
+import io.micrometer.context.ContextSnapshot;
+import io.micrometer.context.ContextSnapshotFactory;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
+import io.micrometer.observation.tck.ObservationContextAssert;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.support.MessageBuilder;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Integration tests for the SQS Observation API.
+ *
+ * @author Mariusz Sondecki
+ * @author Tomaz Fernandes
+ *
+ */
+@SpringBootTest
+class SqsObservationIntegrationTests extends BaseSqsIntegrationTest {
+
+	private static final Logger logger = LoggerFactory.getLogger(SqsObservationIntegrationTests.class);
+
+	static final String RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME = "observability_on_components_test_queue";
+
+	static final String SYNC_CONTEXT_PROPAGATION_QUEUE_NAME = "sync_context_propagation_test_queue";
+
+	static final String ASYNC_CONTEXT_PROPAGATION_QUEUE_NAME = "async_context_propagation_test_queue";
+
+	static final String SHOULD_CHANGE_PAYLOAD = "should-change-payload";
+
+	private static final String CHANGED_PAYLOAD = "Changed payload";
+
+	private static final UUID CHANGED_ID = UUID.fromString("0009f2c8-1dc4-e211-cc99-9f9c62b5e66b");
+
+	@Autowired
+	LatchContainer latchContainer;
+
+	@Autowired
+	SqsTemplate sqsTemplate;
+
+	@Autowired(required = false)
+	ReceivesChangedPayloadOnErrorListener receivesChangedPayloadOnErrorListener;
+	
+	@Autowired
+	TestObservationRegistry observationRegistry;
+
+	@BeforeAll
+	static void beforeTests() {
+		SqsAsyncClient client = createAsyncClient();
+		CompletableFuture.allOf(createQueue(client, RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME),
+				createQueue(client, SYNC_CONTEXT_PROPAGATION_QUEUE_NAME),
+				createQueue(client, ASYNC_CONTEXT_PROPAGATION_QUEUE_NAME)).join();
+	}
+
+	@Test
+	@DisplayName("Should correctly instrument and propagate observations across multiple components")
+	void shouldInstrumentObservationsAcrossThreads() throws Exception {
+		sqsTemplate.send(SYNC_CONTEXT_PROPAGATION_QUEUE_NAME, SHOULD_CHANGE_PAYLOAD);
+		assertThat(latchContainer.receivesChangedMessageOnErrorLatch.await(20, TimeUnit.SECONDS)).isTrue();
+		assertThat(receivesChangedPayloadOnErrorListener.receivedMessages).containsExactly(CHANGED_PAYLOAD);
+		assertThat(latchContainer.receivesChangedMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		await()
+			.atMost(10, TimeUnit.SECONDS)
+			.untilAsserted(() ->
+				TestObservationRegistryAssert.then(observationRegistry)
+				.hasHandledContextsThatSatisfy(contexts -> {
+
+					assertThat(contexts).hasSizeGreaterThanOrEqualTo(8);
+					
+					Optional<Observation.Context> templateWithoutParent = contexts.stream()
+						.filter(ctx -> ctx.getName().equals("spring.aws.sqs.template") && ctx.getParentObservation() == null)
+						.findFirst();
+					assertThat(templateWithoutParent).isPresent();
+					ObservationContextAssert.then(templateWithoutParent.get())
+						.hasNameEqualTo("spring.aws.sqs.template")
+						.doesNotHaveParentObservation();
+					
+					Observation.Context listenerContext = getContextWithNameAndQueueName(contexts,
+							"spring.aws.sqs.listener",
+						SYNC_CONTEXT_PROPAGATION_QUEUE_NAME);
+					
+					ObservationContextAssert.then(listenerContext)
+						.hasNameEqualTo("spring.aws.sqs.listener")
+						.doesNotHaveParentObservation();
+					
+					List<String> childObservationNames = contexts.stream()
+						.filter(ctx -> ctx.getParentObservation() != null &&
+								ctx.getParentObservation().getContextView().getName().equals("spring.aws.sqs.listener"))
+						.peek(childCtx -> ObservationContextAssert.then(childCtx)
+								.hasParentObservationContextMatching(
+										parentCtx -> parentCtx.getName().equals("spring.aws.sqs.listener")))
+						.map(Observation.Context::getName)
+						.collect(Collectors.toList());
+					
+					List<String> expectedChildObservations = Arrays.asList(
+						"blockingInterceptor.intercept",
+						"listener.listen", 
+						"spring.aws.sqs.template", 
+						"errorHandler.handle", 
+						"interceptor1.afterProcessing", 
+						"interceptor2.afterProcessing"
+					);
+					
+					assertThat(childObservationNames).containsAll(expectedChildObservations);
+				})
+			);
+	}
+	
+	@Test
+	@DisplayName("Should propagate context in asynchronous listener with scope")
+	void shouldPropagateContextInAsyncListener() throws Exception {
+		// When
+		String payload = "test-async-context-propagation";
+		sqsTemplate.send(ASYNC_CONTEXT_PROPAGATION_QUEUE_NAME, payload);
+		
+		// Then
+		assertThat(latchContainer.asyncContextPropagationLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		
+		await()
+			.atMost(10, TimeUnit.SECONDS)
+			.untilAsserted(() ->
+				TestObservationRegistryAssert.then(observationRegistry)
+					.hasHandledContextsThatSatisfy(contexts -> {
+
+						assertThat(getContextWithNameAndQueueName(contexts,
+								"spring.aws.sqs.listener", 
+								ASYNC_CONTEXT_PROPAGATION_QUEUE_NAME)).isNotNull();
+
+						Optional<Observation.Context> childContext = contexts.stream()
+							.filter(ctx -> ctx.getName().equals("async.child.operation"))
+							.findFirst();
+
+						assertThat(childContext).isPresent();
+						
+						// Verify the child has the correct parent
+						ObservationContextAssert.then(childContext.get())
+							.hasNameEqualTo("async.child.operation")
+							.hasParentObservationContextMatching(
+								parentCtx -> parentCtx.getName().equals("spring.aws.sqs.listener") &&
+								parentCtx.getContextualName() != null &&
+								parentCtx.getContextualName().contains(ASYNC_CONTEXT_PROPAGATION_QUEUE_NAME));
+					})
+			);
+	}
+
+	static class ReceivesChangedPayloadOnErrorListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		SqsTemplate sqsTemplate;
+
+		@Autowired
+		ObservationRegistry observationRegistry;
+
+		Collection<String> receivedMessages = Collections.synchronizedList(new ArrayList<>());
+
+		@SqsListener(queueNames = SYNC_CONTEXT_PROPAGATION_QUEUE_NAME, id = "receives-changed-payload-on-error")
+		void listen(Message<String> message, @Header(SqsHeaders.SQS_QUEUE_NAME_HEADER) String queueName) {
+			Observation.createNotStarted("listener.listen", observationRegistry).observe(() -> {
+				logger.debug("Received message {} with id {} from queue {}", message.getPayload(),
+						MessageHeaderUtils.getId(message), queueName);
+				if (isChangedPayload(message)) {
+					receivedMessages.add(message.getPayload());
+					latchContainer.receivesChangedMessageOnErrorLatch.countDown();
+				}
+			});
+			SendResult<String> sendResult = sqsTemplate.send(RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME,
+					message.getPayload());
+			logger.debug("Sent message by SqsTemplate#sendAsync: {}", sendResult.messageId());
+			throw new RuntimeException("Expected exception from receives-changed-payload-on-error");
+		}
+	}
+
+	static class BlockingErrorHandler implements ErrorHandler<String> {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		ObservationRegistry observationRegistry;
+
+		@Override
+		public void handle(Message<String> message, Throwable t) {
+			Observation.createNotStarted("errorHandler.handle", observationRegistry).observe(() -> {
+				logger.debug("BlockingErrorHandler - handle: {}", MessageHeaderUtils.getId(message));
+				if (isChangedPayload(message)) {
+					latchContainer.receivesChangedMessageOnErrorLatch.countDown();
+				}
+			});
+		}
+	}
+
+	static class ReceivesChangedMessageInterceptor implements MessageInterceptor<String> {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		SqsTemplate sqsTemplate;
+
+		@Autowired
+		ObservationRegistry observationRegistry;
+
+		@Override
+		public void afterProcessing(Message<String> message, Throwable t) {
+			Observation.createNotStarted("interceptor1.afterProcessing", observationRegistry).observe(() -> {
+				logger.debug("ReceivesChangedMessageInterceptor - afterProcessing: {}",
+						MessageHeaderUtils.getId(message));
+				Optional<Message<String>> result = sqsTemplate
+						.receive(RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME, String.class);
+				logger.debug("Received message with SqsTemplate#receive: {}",
+						result.map(MessageHeaderUtils::getId).orElse("empty"));
+				result.ifPresent(msg -> latchContainer.receivesChangedMessageLatch.countDown());
+			});
+		}
+	}
+
+	static class ReceivesChangedPayloadOnErrorInterceptor implements MessageInterceptor<String> {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		ObservationRegistry observationRegistry;
+
+		@Override
+		public void afterProcessing(Message<String> message, Throwable t) {
+			Observation.createNotStarted("interceptor2.afterProcessing", observationRegistry).observe(() -> {
+				logger.debug("ReceivesChangedPayloadOnErrorInterceptor - afterProcessing: {}",
+						MessageHeaderUtils.getId(message));
+				if (isChangedPayload(message)) {
+					latchContainer.receivesChangedMessageOnErrorLatch.countDown();
+				}
+			});
+		}
+	}
+	
+	static class AsyncContextPropagationListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		ObservationRegistry observationRegistry;
+
+		private final ContextSnapshotFactory snapshotFactory;
+
+		AsyncContextPropagationListener() {
+			ContextRegistry contextRegistry = new ContextRegistry();
+			contextRegistry.registerContextAccessor(new MessageHeaderContextAccessor());
+			contextRegistry.registerThreadLocalAccessor(new ObservationThreadLocalAccessor());
+			this.snapshotFactory = ContextSnapshotFactory.builder()
+				.contextRegistry(contextRegistry)
+				.build();
+		}
+
+		@SqsListener(queueNames = ASYNC_CONTEXT_PROPAGATION_QUEUE_NAME, id = "async-context-propagation", factory = "asyncSqsListenerContainerFactory")
+		CompletableFuture<Void> listen(Message<String> message) {
+			logger.debug("Received message in async listener: {}", message.getPayload());
+
+			try (ContextSnapshot.Scope scope = snapshotFactory
+					.captureFrom(message.getHeaders())
+					.setThreadLocals()) {
+				
+				Observation childObservation = Observation.createNotStarted("async.child.operation", observationRegistry);
+				childObservation.observe(() -> logger.debug("Executing task in child observation with propagated context"));
+				latchContainer.asyncContextPropagationLatch.countDown();
+			}
+			
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+	static class BlockingInterceptor implements MessageInterceptor<String> {
+
+		@Autowired
+		ObservationRegistry observationRegistry;
+
+		@Override
+		public Message<String> intercept(Message<String> message) {
+			return Observation.createNotStarted("blockingInterceptor.intercept", observationRegistry).observe(() -> {
+				logger.debug("BlockingInterceptor - intercept: {}", MessageHeaderUtils.getId(message));
+				if (message.getPayload().equals(SHOULD_CHANGE_PAYLOAD)) {
+					MessagingMessageHeaders headers = new MessagingMessageHeaders(message.getHeaders(), CHANGED_ID);
+					return MessageBuilder.createMessage(CHANGED_PAYLOAD, headers);
+				}
+				return message;
+			});
+		}
+	}
+
+	static class LatchContainer {
+
+		final CountDownLatch receivesChangedMessageLatch = new CountDownLatch(1);
+
+		final CountDownLatch receivesChangedMessageOnErrorLatch = new CountDownLatch(3);
+		
+		final CountDownLatch asyncContextPropagationLatch = new CountDownLatch(1);
+
+	}
+
+	@Import(SqsBootstrapConfiguration.class)
+	@Configuration
+	static class SQSConfiguration {
+
+		LatchContainer latchContainer = new LatchContainer();
+
+		// @formatter:off
+		@Bean
+		SqsMessageListenerContainerFactory<String> defaultSqsListenerContainerFactory() {
+			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
+			factory.configure(options -> options
+				.maxDelayBetweenPolls(Duration.ofSeconds(1))
+				.queueAttributeNames(Collections.singletonList(QueueAttributeName.QUEUE_ARN))
+				.acknowledgementMode(AcknowledgementMode.ALWAYS)
+				.pollTimeout(Duration.ofSeconds(3)));
+			factory.setSqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient);
+			factory.configure(options -> options.observationRegistry(observationRegistry()));
+			factory.addMessageInterceptor(interceptor1());
+			factory.addMessageInterceptor(interceptor2());
+			factory.addMessageInterceptor(blockingInterceptor());
+			factory.setErrorHandler(blockErrorHandler());
+			return factory;
+		}
+		
+		// @formatter:on
+
+		// @formatter:off
+		@Bean
+		SqsMessageListenerContainerFactory<String> asyncSqsListenerContainerFactory() {
+			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
+			factory.configure(options -> options
+				.maxDelayBetweenPolls(Duration.ofSeconds(1))
+				.pollTimeout(Duration.ofSeconds(3)));
+			factory.setSqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient);
+			factory.configure(options -> options.observationRegistry(observationRegistry()));
+			return factory;
+		}
+
+		// @formatter:on
+
+		@Bean
+		BlockingErrorHandler blockErrorHandler() {
+			return new BlockingErrorHandler();
+		}
+
+		@Bean
+		ReceivesChangedPayloadOnErrorListener receivesChangedPayloadOnErrorListener() {
+			return new ReceivesChangedPayloadOnErrorListener();
+		}
+
+		@Bean
+		LatchContainer latchContainer() {
+			return this.latchContainer;
+		}
+
+		@Bean
+		TestObservationRegistry observationRegistry() {
+			return TestObservationRegistry.create();
+		}
+
+		@Bean
+		SqsTemplate sqsTemplate() {
+			return SqsTemplate.builder().configure(options -> options.observationRegistry(observationRegistry()))
+					.sqsAsyncClient(BaseSqsIntegrationTest.createAsyncClient()).build();
+		}
+
+		@Bean
+		ReceivesChangedMessageInterceptor interceptor1() {
+			return new ReceivesChangedMessageInterceptor();
+		}
+
+		@Bean
+		ReceivesChangedPayloadOnErrorInterceptor interceptor2() {
+			return new ReceivesChangedPayloadOnErrorInterceptor();
+		}
+
+		@Bean
+		BlockingInterceptor blockingInterceptor() {
+			return new BlockingInterceptor();
+		}
+		
+		@Bean
+		AsyncContextPropagationListener asyncContextPropagationListener() {
+			return new AsyncContextPropagationListener();
+		}
+
+	}
+
+	private static boolean isChangedPayload(Message<?> message) {
+		return message != null && message.getPayload().equals(CHANGED_PAYLOAD)
+				&& MessageHeaderUtils.getId(message).equals(CHANGED_ID.toString());
+	}
+	
+	private Observation.Context getContextWithNameAndQueueName(List<Observation.Context> contexts, String name, String queueName) {
+		return contexts.stream()
+				.filter(ctx -> ctx.getName().equals(name) && 
+					ctx.getContextualName() != null && 
+					ctx.getContextualName().contains(queueName))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("Could not find context with name " + name + " and queue " + queueName));
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/AsyncComponentAdaptersTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/AsyncComponentAdaptersTests.java
@@ -15,16 +15,6 @@
  */
 package io.awspring.cloud.sqs.listener;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-
 import io.awspring.cloud.sqs.MessageExecutionThreadFactory;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementResultCallback;
 import io.awspring.cloud.sqs.listener.acknowledgement.AsyncAcknowledgementResultCallback;
@@ -32,18 +22,41 @@ import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
 import io.awspring.cloud.sqs.listener.errorhandler.ErrorHandler;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
-import java.util.function.Supplier;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
+import io.micrometer.observation.tck.TestObservationRegistry;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.core.task.TaskRejectedException;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link AsyncComponentAdapters}.
@@ -261,6 +274,8 @@ class AsyncComponentAdaptersTests {
 		SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor();
 		MessageListener<Object> listener = mock(MessageListener.class);
 		Message<Object> message = mock(Message.class);
+		MessageHeaders headers = mock(MessageHeaders.class);
+		given(message.getHeaders()).willReturn(headers);
 		AsyncMessageListener<Object> asyncListener = AsyncComponentAdapters.adapt(listener);
 		((TaskExecutorAware) asyncListener).setTaskExecutor(executor);
 		asyncListener.onMessage(message).join();
@@ -288,6 +303,8 @@ class AsyncComponentAdaptersTests {
 		SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor();
 		MessageInterceptor<Object> interceptor = mock(MessageInterceptor.class);
 		Message<Object> message = mock(Message.class);
+		MessageHeaders headers = mock(MessageHeaders.class);
+		given(message.getHeaders()).willReturn(headers);
 		AsyncMessageInterceptor<Object> asyncInterceptor = AsyncComponentAdapters.adapt(interceptor);
 		((TaskExecutorAware) asyncInterceptor).setTaskExecutor(executor);
 		asyncInterceptor.intercept(message).join();
@@ -315,6 +332,8 @@ class AsyncComponentAdaptersTests {
 		SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor();
 		ErrorHandler<Object> errorHandler = mock(ErrorHandler.class);
 		Message<Object> message = mock(Message.class);
+		MessageHeaders headers = mock(MessageHeaders.class);
+		given(message.getHeaders()).willReturn(headers);
 		AsyncErrorHandler<Object> asyncErrorHandler = AsyncComponentAdapters.adapt(errorHandler);
 		((TaskExecutorAware) asyncErrorHandler).setTaskExecutor(executor);
 		Throwable t = mock(Throwable.class);
@@ -384,5 +403,131 @@ class AsyncComponentAdaptersTests {
 		then(errorHandler).should().handle(messagesCaptor.capture(), eq(throwable));
 		assertThat(messagesCaptor.getValue()).isEqualTo(messages);
 	}
+	
+	@Test
+	void shouldPropagateObservationContext() {
 
+		SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor();
+		final Object[] capturedThreadLocalContext = new Object[1];
+
+		ObservationThreadLocalAccessor accessor = new ObservationThreadLocalAccessor();
+
+		// Create a listener that will verify the thread local during execution
+		MessageListener<String> listener = new MessageListener<String>() {
+			@Override
+			public void onMessage(Message<String> message) {
+				// Capture the observation from thread local
+				capturedThreadLocalContext[0] = accessor.getValue();
+			}
+		};
+
+		ObservationRegistry observationRegistry = TestObservationRegistry.create();
+		Observation observation = Observation.start("test-observation", observationRegistry);
+		
+		Map<String, Object> headers = new HashMap<>();
+		headers.put(ObservationThreadLocalAccessor.KEY, observation);
+		Message<String> message = MessageBuilder.createMessage("payload", new MessageHeaders(headers));
+		
+		MessageListener<String> spyListener = spy(listener);
+		
+		AsyncMessageListener<String> asyncListener = AsyncComponentAdapters.adapt(spyListener);
+		((TaskExecutorAware) asyncListener).setTaskExecutor(executor);
+		
+		try {
+			asyncListener.onMessage(message).join();
+			
+			ArgumentCaptor<Message<String>> messageCaptor = ArgumentCaptor.forClass(Message.class);
+			then(spyListener).should().onMessage(messageCaptor.capture());
+			Message<String> passedMessage = messageCaptor.getValue();
+			assertThat(passedMessage.getHeaders().containsKey(ObservationThreadLocalAccessor.KEY)).isFalse();
+			
+			assertThat(capturedThreadLocalContext[0]).isEqualTo(observation);
+		}
+		finally {
+			observation.stop();
+		}
+	}
+	
+	@Test
+	void shouldHandleMessageWithoutObservationContext() {
+
+		SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor();
+		final boolean[] executionSucceeded = new boolean[1];
+		
+		MessageListener<String> listener = new MessageListener<String>() {
+			@Override
+			public void onMessage(Message<String> message) {
+				// Set flag indicating successful execution
+				executionSucceeded[0] = true;
+			}
+		};
+		
+		// Create message without observation context in headers
+		Message<String> message = MessageBuilder.createMessage("payload", new MessageHeaders(new HashMap<>()));
+		
+		AsyncMessageListener<String> asyncListener = AsyncComponentAdapters.adapt(listener);
+		((TaskExecutorAware) asyncListener).setTaskExecutor(executor);
+		
+		// Execute
+		asyncListener.onMessage(message).join();
+		
+		// Verify the listener was executed successfully without errors
+		assertThat(executionSucceeded[0]).isTrue();
+	}
+	
+	@Test
+	void shouldRestoreObservationContextAfterExecution() {
+
+		SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor();
+		MessageInterceptor<String> interceptor = mock(MessageInterceptor.class);
+		
+		Observation observationContext = mock(Observation.class);
+		
+		Map<String, Object> headers = new HashMap<>();
+		headers.put(ObservationThreadLocalAccessor.KEY, observationContext);
+		Message<String> message = MessageBuilder.createMessage("payload", new MessageHeaders(headers));
+		
+		Message<String> modifiedMessage = MessageBuilder.createMessage("modified", new MessageHeaders(new HashMap<>()));
+		when(interceptor.intercept(any(Message.class))).thenReturn(modifiedMessage);
+		
+		AsyncMessageInterceptor<String> asyncInterceptor = AsyncComponentAdapters.adapt(interceptor);
+		((TaskExecutorAware) asyncInterceptor).setTaskExecutor(executor);
+		
+		Message<String> result = asyncInterceptor.intercept(message).join();
+		
+		assertThat(result.getHeaders().get(ObservationThreadLocalAccessor.KEY)).isEqualTo(observationContext);
+	}
+	
+	@Test
+	void shouldHandleErrorsWithObservationContext() {
+
+		SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor();
+		MessageListener<String> listener = mock(MessageListener.class);
+		
+		Observation observationContext = mock(Observation.class);
+		
+		Map<String, Object> headers = new HashMap<>();
+		headers.put(ObservationThreadLocalAccessor.KEY, observationContext);
+		Message<String> message = MessageBuilder.createMessage("payload", new MessageHeaders(headers));
+		
+		ListenerExecutionFailedException exception = new ListenerExecutionFailedException("Test exception", new RuntimeException(), message);
+		doThrow(exception).when(listener).onMessage(any(Message.class));
+		
+		AsyncMessageListener<String> asyncListener = AsyncComponentAdapters.adapt(listener);
+		((TaskExecutorAware) asyncListener).setTaskExecutor(executor);
+		
+		CompletableFuture<Void> future = asyncListener.onMessage(message);
+		
+		assertThatThrownBy(future::join)
+			.isInstanceOf(CompletionException.class)
+			.extracting(Throwable::getCause)
+			.isInstanceOf(AsyncAdapterBlockingExecutionFailedException.class)
+			.extracting(Throwable::getCause)
+			.isInstanceOf(ListenerExecutionFailedException.class)
+			.satisfies(ex -> {
+				ListenerExecutionFailedException lefe = (ListenerExecutionFailedException) ex;
+				Message<?> errorMessage = lefe.getFailedMessage();
+				assertThat(errorMessage.getHeaders().get(ObservationThreadLocalAccessor.KEY)).isEqualTo(observationContext);
+			});
+	}
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/sink/AbstractMessageProcessingPipelineSinkObservationTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/sink/AbstractMessageProcessingPipelineSinkObservationTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.sink;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.awspring.cloud.sqs.listener.MessageProcessingContext;
+import io.awspring.cloud.sqs.listener.SqsContainerOptions;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.listener.pipeline.MessageProcessingPipeline;
+import io.awspring.cloud.sqs.support.observation.SqsListenerObservation;
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * Tests for Observation support in {@link AbstractMessageProcessingPipelineSink}.
+ *
+ * @author Tomaz Fernandes
+ */
+@SuppressWarnings({ "unchecked", "rawtypes" })
+class AbstractMessageProcessingPipelineSinkObservationTest {
+
+	private TestMessageProcessingPipelineSink sink;
+
+	private TestObservationRegistry observationRegistry;
+
+	private MessageProcessingPipeline<String> messagePipeline;
+
+	@BeforeEach
+	void setUp() {
+		observationRegistry = TestObservationRegistry.create();
+		messagePipeline = mock(MessageProcessingPipeline.class);
+
+		sink = new TestMessageProcessingPipelineSink();
+		sink.setMessagePipeline(messagePipeline);
+		sink.setObservationSpecifics(new SqsListenerObservation.SqsSpecifics());
+
+		SqsContainerOptions options = SqsContainerOptions.builder().observationRegistry(observationRegistry).build();
+
+		sink.configure(options);
+		sink.setTaskExecutor(new SimpleAsyncTaskExecutor());
+	}
+
+	@Test
+	void shouldCreateAndCompleteObservation() throws Exception {
+		// given
+		Message<String> message = MessageBuilder.withPayload("test-payload")
+				.setHeader("test-header", "test-header-value").setHeader(SqsHeaders.SQS_QUEUE_NAME_HEADER, "test-queue")
+				.build();
+
+		MessageProcessingContext<String> context = MessageProcessingContext.create();
+
+		when(messagePipeline.process(any(Message.class), eq(context)))
+				.thenReturn(CompletableFuture.completedFuture(null));
+
+		// when
+		CompletableFuture<Void> result = sink.emit(Collections.singleton(message), context);
+
+		// then
+		result.get(); // wait for completion
+
+		then(messagePipeline).should().process(any(Message.class), any());
+
+		TestObservationRegistryAssert.then(observationRegistry).hasNumberOfObservationsEqualTo(1)
+				.hasSingleObservationThat().hasNameEqualTo("spring.aws.sqs.listener")
+				.hasLowCardinalityKeyValue("messaging.system", "sqs")
+				.hasLowCardinalityKeyValue("messaging.operation", "receive")
+				.hasLowCardinalityKeyValue("messaging.source.name", "test-queue")
+				.hasLowCardinalityKeyValue("messaging.source.kind", "queue");
+
+		// Verify the message was modified to include the observation context
+		then(messagePipeline).should().process(org.mockito.ArgumentMatchers
+				.<Message> argThat(msg -> msg.getHeaders().containsKey(ObservationThreadLocalAccessor.KEY)), any());
+	}
+
+	@Test
+	void shouldHandleExceptionAndCompleteObservation() {
+		// given
+		Message<String> message = MessageBuilder.withPayload("test-payload")
+				.setHeader(SqsHeaders.SQS_QUEUE_NAME_HEADER, "test-queue").build();
+		MessageProcessingContext<String> context = MessageProcessingContext.create();
+
+		RuntimeException testException = new RuntimeException("Test exception");
+		when(messagePipeline.process(any(Message.class), any()))
+				.thenReturn(CompletableFuture.failedFuture(testException));
+
+		// when
+		CompletableFuture<Void> result = sink.emit(Collections.singleton(message), context);
+
+		// then
+		try {
+			result.join(); // should fail
+		}
+		catch (Exception ignored) {
+			// Expected
+		}
+		TestObservationRegistryAssert.then(observationRegistry).hasNumberOfObservationsEqualTo(1)
+				.hasSingleObservationThat().hasNameEqualTo(("spring.aws.sqs.listener")).hasError();
+	}
+
+	@Test
+	void shouldIncludeFifoSpecificAttributesInObservation() throws Exception {
+		// given
+		Message<String> message = MessageBuilder.withPayload("test-payload")
+				.setHeader(SqsHeaders.SQS_QUEUE_NAME_HEADER, "test-queue.fifo")
+				.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, "test-group")
+				.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, "test-dedup-id")
+				.build();
+
+		MessageProcessingContext<String> context = MessageProcessingContext.create();
+
+		when(messagePipeline.process(any(Message.class), eq(context)))
+				.thenReturn(CompletableFuture.completedFuture(null));
+
+		// when
+		CompletableFuture<Void> result = sink.emit(Collections.singleton(message), context);
+
+		// then
+		result.get(); // wait for completion
+
+		TestObservationRegistryAssert.then(observationRegistry).hasNumberOfObservationsEqualTo(1)
+				.hasSingleObservationThat().hasLowCardinalityKeyValue("messaging.system", "sqs")
+				.hasLowCardinalityKeyValue("messaging.source.name", "test-queue.fifo")
+				.hasHighCardinalityKeyValue("messaging.message.message-group.id", "test-group")
+				.hasHighCardinalityKeyValue("messaging.message.message-deduplication.id", "test-dedup-id");
+	}
+	
+	@Test
+	void shouldHandleMessageWithoutTraceparentHeader() throws Exception {
+
+		// given
+		Message<String> message = MessageBuilder.withPayload("test-payload")
+				.setHeader(SqsHeaders.SQS_QUEUE_NAME_HEADER, "test-queue")
+				// Explicitly NOT setting any traceparent or observation related headers
+				.build();
+
+		MessageProcessingContext<String> context = MessageProcessingContext.create();
+
+		when(messagePipeline.process(any(Message.class), eq(context)))
+				.thenReturn(CompletableFuture.completedFuture(null));
+
+		// when
+		CompletableFuture<Void> result = sink.emit(Collections.singleton(message), context);
+
+		// then
+		result.get();
+
+		then(messagePipeline).should().process(org.mockito.ArgumentMatchers
+				.<Message>argThat(msg -> msg.getHeaders().containsKey(ObservationThreadLocalAccessor.KEY)), any());
+		
+		// Verify an observation was created despite lack of traceparent
+		TestObservationRegistryAssert.then(observationRegistry).hasNumberOfObservationsEqualTo(1)
+				.hasSingleObservationThat().hasNameEqualTo("spring.aws.sqs.listener")
+			.doesNotHaveParentObservation();
+	}
+
+	private static class TestMessageProcessingPipelineSink extends AbstractMessageProcessingPipelineSink<String> {
+
+		@Override
+		protected CompletableFuture<Void> doEmit(Collection<Message<String>> messages,
+				MessageProcessingContext<String> context) {
+			// Process each message using the execute method
+			Message<String> message = messages.iterator().next(); // We're only testing with one message
+			return execute(message, context);
+		}
+
+		@Override
+		public void start() {
+			// No-op for testing
+		}
+
+		@Override
+		public void stop() {
+			// No-op for testing
+		}
+
+		@Override
+		public boolean isRunning() {
+			return true;
+		}
+	}
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/sink/adapter/AbstractDelegatingMessageListeningSinkAdapterObservationTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/sink/adapter/AbstractDelegatingMessageListeningSinkAdapterObservationTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.sink.adapter;
+
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import io.awspring.cloud.sqs.listener.MessageProcessingContext;
+import io.awspring.cloud.sqs.listener.ObservableComponent;
+import io.awspring.cloud.sqs.listener.SqsContainerOptions;
+import io.awspring.cloud.sqs.listener.sink.MessageSink;
+import io.awspring.cloud.sqs.support.observation.AbstractListenerObservation;
+import io.awspring.cloud.sqs.support.observation.SqsListenerObservation;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.messaging.Message;
+
+/**
+ * Tests for observability support in {@link AbstractDelegatingMessageListeningSinkAdapter}.
+ *
+ * @author Tomaz Fernandes
+ */
+class AbstractDelegatingMessageListeningSinkAdapterObservationTest {
+
+	private TestDelegatingMessageListeningSinkAdapter adapter;
+	private ObservableComponent observableDelegate;
+	private TestObservationRegistry observationRegistry;
+	private AbstractListenerObservation.Specifics<?> observationSpecifics;
+
+	@BeforeEach
+	void setUp() {
+		observationRegistry = TestObservationRegistry.create();
+		observableDelegate = mock(ObservableComponent.class, Mockito.withSettings().extraInterfaces(MessageSink.class));
+		observationSpecifics = new SqsListenerObservation.SqsSpecifics();
+
+		adapter = new TestDelegatingMessageListeningSinkAdapter((MessageSink<String>) observableDelegate);
+	}
+
+	@Test
+	void shouldDelegateObservationSpecifics() {
+		// given the adapter has been set up
+
+		// when
+		adapter.setObservationSpecifics(observationSpecifics);
+
+		// then
+		then(observableDelegate).should().setObservationSpecifics(observationSpecifics);
+	}
+
+	@Test
+	void shouldDelegateContainerOptionsWithObservationRegistry() {
+		// given
+		SqsContainerOptions options = SqsContainerOptions.builder().observationRegistry(observationRegistry).build();
+
+		// when
+		adapter.configure(options);
+
+		// then
+		then((MessageSink<String>) observableDelegate).should().configure(options);
+	}
+
+	/**
+	 * Test implementation of AbstractDelegatingMessageListeningSinkAdapter
+	 */
+	private static class TestDelegatingMessageListeningSinkAdapter
+			extends AbstractDelegatingMessageListeningSinkAdapter<String> {
+		protected TestDelegatingMessageListeningSinkAdapter(MessageSink<String> delegate) {
+			super(delegate);
+		}
+
+		@Override
+		public CompletableFuture<Void> emit(Collection<Message<String>> messages,
+				MessageProcessingContext<String> context) {
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateObservationTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateObservationTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.operations;
+
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.support.observation.SqsTemplateObservation;
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link SqsTemplate} observation support.
+ *
+ * @author Tomaz Fernandes
+ */
+class SqsTemplateObservationTest {
+
+	private SqsAsyncClient mockSqsAsyncClient;
+	private TestObservationRegistry observationRegistry;
+	private SqsTemplate sqsTemplate;
+	private String queueName;
+
+	@BeforeEach
+	void setUp() {
+		mockSqsAsyncClient = mock(SqsAsyncClient.class);
+		observationRegistry = TestObservationRegistry.create();
+		queueName = "test-queue";
+
+		given(mockSqsAsyncClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(
+				CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl(queueName).build()));
+
+		UUID messageId = UUID.randomUUID();
+		given(mockSqsAsyncClient.sendMessage(any(SendMessageRequest.class))).willReturn(CompletableFuture
+				.completedFuture(SendMessageResponse.builder().messageId(messageId.toString()).build()));
+
+		sqsTemplate = SqsTemplate.builder().sqsAsyncClient(mockSqsAsyncClient)
+				.configure(options -> options.observationRegistry(observationRegistry)).build();
+	}
+
+	@Test
+	void shouldTrackObservationWhenSendingMessage() {
+		// given
+		String payload = "test-payload";
+
+		// when
+		sqsTemplate.send(queueName, payload);
+
+		// then
+		TestObservationRegistryAssert.then(observationRegistry).hasNumberOfObservationsEqualTo(1)
+				.hasSingleObservationThat().hasNameEqualTo("spring.aws.sqs.template")
+				.hasLowCardinalityKeyValue("messaging.system", "sqs")
+				.hasLowCardinalityKeyValue("messaging.operation", "publish")
+				.hasLowCardinalityKeyValue("messaging.destination.name", queueName)
+				.hasLowCardinalityKeyValue("messaging.destination.kind", "queue");
+	}
+
+	@Test
+	void shouldSupportCustomObservationConvention() {
+		// given
+		SqsTemplateObservation.Convention customConvention = mock(SqsTemplateObservation.Convention.class);
+		given(customConvention.supportsContext(any())).willReturn(true);
+
+		String lowCardinalityCustomKeyName = "custom.lowCardinality.key";
+		String lowCardinalityCustomValue = "custom-lowCardinality-value";
+		String highCardinalityCustomKeyName = "custom.highCardinality.key";
+		String highCardinalityCustomValue = "custom-highCardinality-value";
+		given(customConvention.getLowCardinalityKeyValues(any()))
+				.willReturn(io.micrometer.common.KeyValues.of(lowCardinalityCustomKeyName, lowCardinalityCustomValue));
+		given(customConvention.getHighCardinalityKeyValues(any())).willReturn(
+				io.micrometer.common.KeyValues.of(highCardinalityCustomKeyName, highCardinalityCustomValue));
+
+		TestObservationRegistry customRegistry = TestObservationRegistry.create();
+
+		SqsTemplate templateWithCustomConvention = SqsTemplate.builder().sqsAsyncClient(mockSqsAsyncClient)
+				.configure(
+						options -> options.observationRegistry(customRegistry).observationConvention(customConvention))
+				.build();
+
+		// when
+		templateWithCustomConvention.send(queueName, "test-payload");
+
+		// then
+		TestObservationRegistryAssert.then(customRegistry).hasNumberOfObservationsEqualTo(1).hasSingleObservationThat()
+				.hasLowCardinalityKeyValue(lowCardinalityCustomKeyName, lowCardinalityCustomValue)
+				.hasHighCardinalityKeyValue(highCardinalityCustomKeyName, highCardinalityCustomValue);
+	}
+
+	@Test
+	void shouldAddMessageIdToObservation() {
+		// given
+		String payload = "test-payload";
+		UUID messageId = UUID.randomUUID();
+
+		given(mockSqsAsyncClient.sendMessage(any(SendMessageRequest.class))).willReturn(CompletableFuture
+				.completedFuture(SendMessageResponse.builder().messageId(messageId.toString()).build()));
+
+		// when
+		sqsTemplate.send(queueName, payload);
+
+		// then
+		TestObservationRegistryAssert.then(observationRegistry).hasNumberOfObservationsEqualTo(1)
+				.hasSingleObservationThat().hasHighCardinalityKeyValue("messaging.message.id", messageId.toString());
+	}
+
+	@Test
+	void shouldNotCreateObservationsWithNoopRegistry() {
+		// given
+		SqsTemplate defaultTemplate = SqsTemplate.builder().sqsAsyncClient(mockSqsAsyncClient).build();
+
+		// when - sending with a noop registry
+		defaultTemplate.send(queueName, "test-payload");
+
+		// then - the message is processed without errors
+	}
+
+	@Test
+	void shouldCaptureErrorsInObservation() {
+		// given
+		String payload = "test-payload";
+		RuntimeException testException = new RuntimeException(
+				"Expected test exception from shouldCaptureErrorsInObservation");
+
+		given(mockSqsAsyncClient.sendMessage(any(SendMessageRequest.class)))
+				.willReturn(CompletableFuture.failedFuture(testException));
+
+		try {
+			sqsTemplate.send(queueName, payload);
+		}
+		catch (Exception e) {
+			// Expected exception
+		}
+
+		// then
+		TestObservationRegistryAssert.then(observationRegistry).hasNumberOfObservationsEqualTo(1)
+				.hasSingleObservationThat().hasError().assertThatError().isInstanceOf(RuntimeException.class);
+	}
+
+	@Test
+	void shouldSupportCustomKeyValuesInActiveSending() {
+		// given
+		String payload = "test-payload";
+		UUID messageId = UUID.randomUUID();
+		
+		// Mock responses for the SQS client
+		given(mockSqsAsyncClient.sendMessage(any(SendMessageRequest.class))).willReturn(CompletableFuture
+				.completedFuture(SendMessageResponse.builder().messageId(messageId.toString()).build()));
+        
+		given(mockSqsAsyncClient.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(CompletableFuture
+				.completedFuture(GetQueueUrlResponse.builder().queueUrl(queueName).build()));
+		
+		// Create registry to capture observations
+		TestObservationRegistry customRegistry = TestObservationRegistry.create();
+		
+		// Create a custom convention extending the default one
+		SqsTemplateObservation.DefaultConvention customConvention = new SqsTemplateObservation.DefaultConvention() {
+			@Override
+			protected KeyValues getCustomHighCardinalityKeyValues(SqsTemplateObservation.Context context) {
+				return KeyValues.of("order.id", "order-123");
+			}
+			
+			@Override
+			protected KeyValues getCustomLowCardinalityKeyValues(SqsTemplateObservation.Context context) {
+				return KeyValues.of("order.type", "electronics");
+			}
+		};
+		
+		// Create message with FIFO headers
+		Message<String> message = MessageBuilder.withPayload(payload)
+				.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, "group-xyz")
+				.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, "dedup-abc")
+				.build();
+		
+		// Create a template with the custom convention
+		SqsTemplate templateWithCustomConvention = SqsTemplate.builder()
+				.sqsAsyncClient(mockSqsAsyncClient)
+				.configure(options -> options
+						.observationRegistry(customRegistry)
+						.observationConvention(customConvention))
+				.build();
+		
+		// when - send the message
+		templateWithCustomConvention.send(queueName, message);
+		
+		// then - verify the observations contain the expected values
+		TestObservationRegistryAssert.then(customRegistry)
+				.hasNumberOfObservationsEqualTo(1)
+				.hasSingleObservationThat()
+				// Custom values
+				.hasLowCardinalityKeyValue("order.type", "electronics")
+				// Default values
+				.hasLowCardinalityKeyValue("messaging.system", "sqs")
+				.hasLowCardinalityKeyValue("messaging.operation", "publish")
+				.hasLowCardinalityKeyValue("messaging.destination.name", queueName)
+				.hasLowCardinalityKeyValue("messaging.destination.kind", "queue")
+				.hasHighCardinalityKeyValue("messaging.message.id", messageId.toString());
+	}
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/observation/AbstractTemplateObservationTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/observation/AbstractTemplateObservationTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.support.observation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * Tests for {@link AbstractTemplateObservation}.
+ *
+ * @author Tomaz Fernandes
+ */
+class AbstractTemplateObservationTest {
+
+	@Test
+	void conventionShouldReturnExpectedValues() {
+		// given
+		TestConvention convention = new TestConvention();
+		String destinationName = "test-destination";
+
+		Message<String> message = MessageBuilder.createMessage("testPayload", new MessageHeaders(Map.of()));
+		AbstractTemplateObservation.Context context = new AbstractTemplateObservation.Context(message,
+				destinationName) {
+		};
+
+		// when
+		KeyValues lowCardinalityKeyValues = convention.getLowCardinalityKeyValues(context);
+		KeyValues highCardinalityKeyValues = convention.getHighCardinalityKeyValues(context);
+		String contextualName = convention.getContextualName(context);
+		String name = convention.getName();
+
+		// then
+		assertThat(lowCardinalityKeyValues.stream())
+				.anyMatch(kv -> kv.getKey().equals("messaging.system") && kv.getValue().equals("test"))
+				.anyMatch(kv -> kv.getKey().equals("messaging.operation") && kv.getValue().equals("publish"))
+				.anyMatch(
+						kv -> kv.getKey().equals("messaging.destination.name") && kv.getValue().equals(destinationName))
+				.anyMatch(kv -> kv.getKey().equals("messaging.destination.kind") && kv.getValue().equals("queue"));
+
+		assertThat(highCardinalityKeyValues).isEmpty();
+
+		assertThat(contextualName).isEqualTo(destinationName + " send");
+		assertThat(name).isEqualTo("spring.aws.test.template");
+	}
+
+	@Test
+	void specificsShouldProvideExpectedValues() {
+		// given
+		TestSpecifics specifics = new TestSpecifics();
+		String destinationName = "test-destination";
+		Message<String> message = MessageBuilder.withPayload("test-payload").build();
+
+		// when
+		AbstractTemplateObservation.Context context = specifics.createContext(message, destinationName);
+		ObservationConvention<AbstractTemplateObservation.Context> convention = specifics.getDefaultConvention();
+		AbstractTemplateObservation.Documentation documentationContext = specifics.getDocumentation();
+
+		// then
+		assertThat(context.getDestinationName()).isEqualTo(destinationName);
+		assertThat(convention).isInstanceOf(TestConvention.class);
+		assertThat(documentationContext).isInstanceOf(TestDocumentation.class);
+	}
+
+	private static class TestConvention
+			extends AbstractTemplateObservation.Convention<AbstractTemplateObservation.Context> {
+
+		@Override
+		protected String getMessagingSystem() {
+			return "test";
+		}
+
+		@Override
+		public boolean supportsContext(Observation.Context context) {
+			return true;
+		}
+
+		@Override
+		public String getName() {
+			return "spring.aws.test.template";
+		}
+
+		@Override
+		protected String getSourceKind() {
+			return "queue";
+		}
+	}
+
+	private static class TestDocumentation extends AbstractTemplateObservation.Documentation {
+
+		@Override
+		protected Class<? extends ObservationConvention<? extends Observation.Context>> getSpecificDefaultConvention() {
+			return TestConvention.class;
+		}
+
+		@Override
+		public String getName() {
+			return "spring.aws.test.template";
+		}
+	}
+
+	private static class TestSpecifics
+			implements AbstractTemplateObservation.Specifics<AbstractTemplateObservation.Context> {
+		private static final TestDocumentation DOCUMENTATION = new TestDocumentation();
+		private static final TestConvention CONVENTION = new TestConvention();
+
+		@Override
+		public AbstractTemplateObservation.Documentation getDocumentation() {
+			return DOCUMENTATION;
+		}
+
+		@Override
+		public AbstractTemplateObservation.Context createContext(Message<?> message, String destinationName) {
+			return new AbstractTemplateObservation.Context(message, destinationName) {
+			};
+		}
+
+		@Override
+		public AbstractTemplateObservation.Convention<AbstractTemplateObservation.Context> getDefaultConvention() {
+			return CONVENTION;
+		}
+	}
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/observation/AbstractTemplateObservationTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/observation/AbstractTemplateObservationTest.java
@@ -82,6 +82,32 @@ class AbstractTemplateObservationTest {
 		assertThat(documentationContext).isInstanceOf(TestDocumentation.class);
 	}
 
+	@Test
+	void shouldWhitelistAndBlockKeys() {
+		// given
+		String destinationName = "test-destination";
+		Message<String> message = MessageBuilder.withPayload("test-payload").build();
+		AbstractTemplateObservation.Context context = new AbstractTemplateObservation.Context(message, destinationName) {};
+
+		// when - test allowed keys
+		context.getSetter().set(context.getCarrier(), "baggage", "baggage-value");
+		context.getSetter().set(context.getCarrier(), "traceparent", "traceparent-value");
+		context.getSetter().set(context.getCarrier(), "tracestate", "tracestate-value");
+		context.getSetter().set(context.getCarrier(), "b3", "b3-value");
+
+		// when - test blocked keys
+		context.getSetter().set(context.getCarrier(), "blocked-key", "blocked-value");
+
+		// then
+		Map<String, Object> carrier = context.getCarrier();
+		assertThat(carrier)
+			.containsEntry("baggage", "baggage-value")
+			.containsEntry("traceparent", "traceparent-value")
+			.containsEntry("tracestate", "tracestate-value")
+			.containsEntry("b3", "b3-value")
+			.doesNotContainKey("blocked-key");
+	}
+
 	private static class TestConvention
 			extends AbstractTemplateObservation.Convention<AbstractTemplateObservation.Context> {
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/observation/MessageHeaderContextAccessorTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/observation/MessageHeaderContextAccessorTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.support.observation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * Tests for {@link MessageHeaderContextAccessor}.
+ *
+ * @author Tomaz Fernandes
+ */
+class MessageHeaderContextAccessorTest {
+
+	private MessageHeaderContextAccessor accessor;
+	private MessageHeaders headers;
+	private String testKey;
+	private String testValue;
+
+	@BeforeEach
+	void setUp() {
+		accessor = new MessageHeaderContextAccessor();
+		testKey = "test-key";
+		testValue = "test-value";
+		headers = MessageBuilder.withPayload("test-payload").setHeader(testKey, testValue).build().getHeaders();
+	}
+
+	@Test
+	void shouldReturnMessageHeadersAsReadableType() {
+		// when
+		Class<?> readableType = accessor.readableType();
+
+		// then
+		assertThat(readableType).isEqualTo(MessageHeaders.class);
+	}
+
+	@Test
+	void shouldReturnMessageHeadersAsWriteableType() {
+		// when
+		Class<?> writeableType = accessor.writeableType();
+
+		// then
+		assertThat(writeableType).isEqualTo(MessageHeaders.class);
+	}
+
+	@Test
+	void shouldReadValuesBasedOnPredicate() {
+		// given
+		Map<Object, Object> target = new HashMap<>();
+		Predicate<Object> keyPredicate = key -> key.equals(testKey);
+
+		// when
+		accessor.readValues(headers, keyPredicate, target);
+
+		// then
+		assertThat(target).hasSize(1).containsEntry(testKey, testValue);
+	}
+
+	@Test
+	void shouldNotReadValuesWhenPredicateDoesNotMatch() {
+		// given
+		Map<Object, Object> target = new HashMap<>();
+		Predicate<Object> keyPredicate = key -> key.equals("non-existent-key");
+
+		// when
+		accessor.readValues(headers, keyPredicate, target);
+
+		// then
+		assertThat(target).isEmpty();
+	}
+
+	@Test
+	void shouldReadSingleValue() {
+		// when
+		String value = accessor.readValue(headers, testKey);
+
+		// then
+		assertThat(value).isEqualTo(testValue);
+	}
+
+	@Test
+	void shouldReturnNullForMissingKey() {
+		// when
+		String value = accessor.readValue(headers, "non-existent-key");
+
+		// then
+		assertThat(value).isNull();
+	}
+
+	@Test
+	void shouldThrowExceptionWhenWritingValues() {
+		// given
+		Map<Object, Object> valuesToWrite = new HashMap<>();
+		valuesToWrite.put("key", "value");
+
+		// when/then
+		assertThatThrownBy(() -> accessor.writeValues(valuesToWrite, headers))
+				.isInstanceOf(UnsupportedOperationException.class)
+				.hasMessageContaining("Should not write values to the MessageHeaders");
+	}
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/observation/SqsListenerObservationTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/observation/SqsListenerObservationTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.support.observation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import io.micrometer.common.docs.KeyName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Tests for {@link SqsListenerObservation}.
+ *
+ * @author Tomaz Fernandes
+ */
+class SqsListenerObservationTest {
+
+	private SqsListenerObservation.SqsSpecifics sqsSpecifics;
+	private String queueName;
+
+	@BeforeEach
+	void setUp() {
+		sqsSpecifics = new SqsListenerObservation.SqsSpecifics();
+		queueName = "test-queue";
+	}
+
+	@Test
+	void shouldCreateContextWithQueueNameAndMessageId() {
+		// given
+		Message<String> message = MessageBuilder.withPayload("test-payload")
+			.setHeader(SqsHeaders.SQS_QUEUE_NAME_HEADER, queueName).build();
+
+		// when
+		SqsListenerObservation.Context context = sqsSpecifics.createContext(message);
+
+		// then
+		assertThat(context.getSourceName()).isEqualTo(queueName);
+		assertThat(context.getMessageId()).isEqualTo(message.getHeaders().getId().toString());
+		assertThat(context.getRemoteServiceName()).isEqualTo("AWS SQS");
+	}
+
+	@Test
+	void shouldHandleFifoQueueHeaders() {
+		// given
+		String groupId = "test-group";
+		String deduplicationId = "test-dedup-id";
+
+		Message<String> message = MessageBuilder.withPayload("test-payload")
+			.setHeader(SqsHeaders.SQS_QUEUE_NAME_HEADER, queueName)
+			.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, groupId)
+			.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, deduplicationId)
+			.build();
+
+		// when
+		SqsListenerObservation.Context context = sqsSpecifics.createContext(message);
+
+		// then
+		assertThat(context.getMessageGroupId()).isEqualTo(groupId);
+		assertThat(context.getMessageDeduplicationId()).isEqualTo(deduplicationId);
+
+		// Verify convention adds these as high cardinality keys
+		SqsListenerObservation.DefaultConvention convention = new SqsListenerObservation.DefaultConvention();
+		KeyValues highCardinalityKeys = convention.getHighCardinalityKeyValues(context);
+
+		assertThat(highCardinalityKeys.stream()
+			.anyMatch(keyValue -> keyValue.getKey().equals("messaging.message.message-group.id")
+				&& keyValue.getValue().equals(groupId)))
+			.isTrue();
+
+		assertThat(highCardinalityKeys.stream()
+			.anyMatch(keyValue -> keyValue.getKey().equals("messaging.message.message-deduplication.id")
+				&& keyValue.getValue().equals(deduplicationId)))
+			.isTrue();
+	}
+
+	@Test
+	void shouldReturnEmptyValuesForNonFifoQueue() {
+		// given
+		Message<String> message = MessageBuilder.withPayload("test-payload")
+			.setHeader(SqsHeaders.SQS_QUEUE_NAME_HEADER, queueName).build();
+
+		// when
+		SqsListenerObservation.Context context = sqsSpecifics.createContext(message);
+
+		// then
+		assertThat(context.getMessageGroupId()).isEmpty();
+		assertThat(context.getMessageDeduplicationId()).isEmpty();
+
+		// Verify convention doesn't add these as high cardinality keys
+		SqsListenerObservation.DefaultConvention convention = new SqsListenerObservation.DefaultConvention();
+		KeyValues highCardinalityKeys = convention.getSpecificHighCardinalityKeyValues(context);
+
+		assertThat(highCardinalityKeys.stream().count()).isEqualTo(0);
+	}
+
+	@Test
+	void shouldProvideCorrectConventionAndDocumentation() {
+		// when
+		var convention = sqsSpecifics.getDefaultConvention();
+		var documentation = sqsSpecifics.getDocumentation();
+
+		// then
+		assertThat(convention).isInstanceOf(SqsListenerObservation.DefaultConvention.class);
+		assertThat(documentation).isInstanceOf(SqsListenerObservation.Documentation.class);
+
+		// Verify convention values
+		SqsListenerObservation.DefaultConvention defaultConvention = (SqsListenerObservation.DefaultConvention) convention;
+		assertThat(defaultConvention.getMessagingSystem()).isEqualTo("sqs");
+		assertThat(defaultConvention.getSourceKind()).isEqualTo("queue");
+	}
+
+	@Test
+	void shouldSupportCustomKeyValues() {
+		// given
+		Message<String> message = MessageBuilder.withPayload("test-payload")
+			.setHeader(SqsHeaders.SQS_QUEUE_NAME_HEADER, queueName)
+			.setHeader("order-id", "12345")
+			.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_GROUP_ID_HEADER, "abcd")
+			.setHeader(SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER, "efgh")
+			.build();
+
+		SqsListenerObservation.Context context = sqsSpecifics.createContext(message);
+
+		// when
+		SqsListenerObservation.DefaultConvention customConvention = new SqsListenerObservation.DefaultConvention() {
+			@Override
+			protected KeyValues getCustomHighCardinalityKeyValues(SqsListenerObservation.Context context) {
+				return KeyValues.of("order.id", "12345");
+			}
+
+			@Override
+			protected KeyValues getCustomLowCardinalityKeyValues(SqsListenerObservation.Context context) {
+				return KeyValues.of("order.type", "custom order");
+			}
+		};
+
+		// then
+		KeyValues highCardinalityKeys = customConvention.getHighCardinalityKeyValues(context);
+
+		// Verify custom key is included
+		assertThat(highCardinalityKeys.stream()
+			.anyMatch(keyValue -> keyValue.getKey().equals("order.id")
+				&& keyValue.getValue().equals("12345")))
+			.isTrue();
+
+		// Verify it still includes default keys
+		Set<String> allHighCardinalityKeys = highCardinalityKeys.stream().map(KeyValue::getKey).collect(Collectors.toSet());
+
+		assertThat(Arrays.stream(SqsListenerObservation.Documentation.HighCardinalityTags.values())
+			.map(KeyName::asString))
+			.allMatch(allHighCardinalityKeys::contains);
+		assertThat(Arrays.stream(AbstractListenerObservation.Documentation.HighCardinalityTags.values())
+			.map(KeyName::asString))
+			.allMatch(allHighCardinalityKeys::contains);
+
+		KeyValues lowCardinalityKeyValues = customConvention.getLowCardinalityKeyValues(context);
+
+		// Verify custom value is included
+		assertThat(lowCardinalityKeyValues.stream()
+				.anyMatch(keyValue -> keyValue.getKey().equals("order.type") 
+					&& keyValue.getValue().equals("custom order")))
+				.isTrue();
+
+		// Verify it still includes default keys
+		Set<String> allLowCardinalityKeys = lowCardinalityKeyValues.stream().map(KeyValue::getKey).collect(Collectors.toSet());
+
+		assertThat(Arrays.stream(AbstractListenerObservation.Documentation.LowCardinalityTags.values())
+			.map(KeyName::asString))
+			.allMatch(allLowCardinalityKeys::contains);
+
+	}
+}


### PR DESCRIPTION
This PR Introduces Micrometer Observability Support for Spring Cloud AWS SQS.

### Features
- Automatic span creation for sending and receiving messages
- Automatic scope opening for non-async components
- Support for manual scope opening for async components
- Extensible / replaceable Observation Conventions for sending and receiving messages
- Extension point for supporting custom Thread Local operations for non-async components

Batch sending and receiving of messages is not supported to avoid increasing this PR further.

### Available Observations

Spring Cloud AWS SQS provides the following observations:

1. `spring.aws.sqs.template` - Records SQS operations performed through the `SqsTemplate`
2. `spring.aws.sqs.listener` - Records message processing through the `SqsMessageListenerContainer`

Both observations include the following common tags:

Low cardinality tags:
- `messaging.system`: "sqs"
- `messaging.operation`: "publish" (template) or "receive" (listener)
- `messaging.destination.name` or `messaging.source.name`: The queue name
- `messaging.destination.kind` or `messaging.source.kind`: "queue"

High cardinality tags:
- `messaging.message.id`: The SQS message ID from AWS.

For FIFO queues, the following additional high cardinality tags are included:
- `messaging.message.message-group.id`: The message group ID
- `messaging.message.message-deduplication.id`: The message deduplication ID


Resolves #1367