### PR TITLE
Ability to override separator in DefaultDynamoDbTableNameResolver

### DIFF
--- a/docs/src/main/asciidoc/dynamodb.adoc
+++ b/docs/src/main/asciidoc/dynamodb.adoc
@@ -62,7 +62,11 @@ dynamoDbTemplate.save(person);
 
 ==== Resolving Table Name
 
-To resolve a table name for an entity, `DynamoDbTemplate` uses a bean of type `DynamoDbTableNameResolver`. The default implementation turns an entity class name into its snake case representation with the possibility of using a table name prefix (optional) and suffix (optional). Specify the `spring.cloud.aws.dynamodb.table-prefix` and `spring.cloud.aws.dynamodb.table-suffix` to provide a table name prefix and suffix. The prefix is prepended to the table name and suffix is appended to the table name. For example, if `spring.cloud.aws.dynamodb.table-prefix` is configured as `foo_` and `spring.cloud.aws.dynamodb.table-suffix` is configured as `_foo2` and the entity class is `Person`, then the default implementation resolves the table name as `foo_person_foo2`. You can configure both properties, only one of them or none. However if you do not specify `spring.cloud.aws.dynamodb.table-prefix` and `spring.cloud.aws.dynamodb.table-suffix`, the table name will be resolved as `person`.
+To resolve a table name for an entity, `DynamoDbTemplate` uses a bean of type `DynamoDbTableNameResolver`. The default implementation turns an entity class name into its snake case representation with the possibility of using a table name prefix (optional), suffix (optional), or overriding the separator (optional).
+
+Specify the `spring.cloud.aws.dynamodb.table-prefix` and `spring.cloud.aws.dynamodb.table-suffix` to provide a table name prefix and suffix. The prefix is prepended to the table name and suffix is appended to the table name. For example, if `spring.cloud.aws.dynamodb.table-prefix` is configured as `foo_` and `spring.cloud.aws.dynamodb.table-suffix` is configured as `_foo2` and the entity class is `Person`, then the default implementation resolves the table name as `foo_person_foo2`. You can configure both properties, only one of them or none. However if you do not specify `spring.cloud.aws.dynamodb.table-prefix` and `spring.cloud.aws.dynamodb.table-suffix`, the table name will be resolved as `person`.
+
+Specify the `spring.cloud.aws.dynamodb.table-separator` to override the `_` word separator.  For example if `spring.cloud.aws.dynamodb.table-separator` is configured as `-` and the entity class is `MoreComplexPerson`, then the table name will be resolved as `more-complex-person`.
 
 To use a custom implementation, declare a bean of type `DynamoDbTableNameResolver` and it will get injected into `DynamoDbTemplate` automatically during auto-configuration.
 
@@ -135,6 +139,7 @@ The Spring Boot Starter for DynamoDb provides the following configuration option
 | `spring.cloud.aws.dynamodb.region` | Configures region used by `DynamoDbClient`. | No |
 | `spring.cloud.aws.dynamodb.table-prefix` | Table name prefix used by the default `DynamoDbTableNameResolver` implementation. | No |
 | `spring.cloud.aws.dynamodb.table-suffix` | Table name suffix used by the default `DynamoDbTableNameResolver` implementation. | No |
+| `spring.cloud.aws.dynamodb.table-separator` | Table name word separator used by the default `DynamoDbTableNameResolver` implementation. | No | `_`
 
 | `spring.cloud.aws.dynamodb.dax.idle-timeout-millis` |Timeout for idle connections with the DAX cluster. | No | `30000`
 | `spring.cloud.aws.dynamodb.dax.url` | DAX cluster endpoint. | Yes |

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbAutoConfiguration.java
@@ -140,7 +140,8 @@ public class DynamoDbAutoConfiguration {
 	@ConditionalOnMissingBean(DynamoDbTableNameResolver.class)
 	@Bean
 	public DefaultDynamoDbTableNameResolver dynamoDbTableNameResolver(DynamoDbProperties properties) {
-		return new DefaultDynamoDbTableNameResolver(properties.getTablePrefix(), properties.getTableSuffix());
+		return new DefaultDynamoDbTableNameResolver(properties.getTablePrefix(), properties.getTableSuffix(),
+				properties.getTableSeparator());
 	}
 
 	@ConditionalOnMissingBean(DynamoDbOperations.class)

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/dynamodb/DynamoDbProperties.java
@@ -47,6 +47,12 @@ public class DynamoDbProperties extends AwsClientProperties {
 	private String tableSuffix;
 
 	/**
+	 * The word separator used to resolve table names.
+	 */
+	@Nullable
+	private String tableSeparator;
+
+	/**
 	 * Properties that are used to configure {@link software.amazon.dax.ClusterDaxClient}.
 	 */
 	@NestedConfigurationProperty
@@ -60,12 +66,20 @@ public class DynamoDbProperties extends AwsClientProperties {
 		return tableSuffix;
 	}
 
+	public String getTableSeparator() {
+		return tableSeparator;
+	}
+
 	public void setTablePrefix(String tablePrefix) {
 		this.tablePrefix = tablePrefix;
 	}
 
 	public void setTableSuffix(String tableSuffix) {
 		this.tableSuffix = tableSuffix;
+	}
+
+	public void setTableSeparator(String tableSeparator) {
+		this.tableSeparator = tableSeparator;
 	}
 
 	public DaxProperties getDax() {

--- a/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DefaultDynamoDbTableNameResolver.java
+++ b/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DefaultDynamoDbTableNameResolver.java
@@ -36,17 +36,26 @@ public class DefaultDynamoDbTableNameResolver implements DynamoDbTableNameResolv
 	@Nullable
 	private final String tableSuffix;
 
-	public DefaultDynamoDbTableNameResolver(@Nullable String tablePrefix) {
-		this(tablePrefix, null);
-	}
+	@Nullable
+	private final String tableSeparator;
 
 	public DefaultDynamoDbTableNameResolver() {
-		this(null, null);
+		this(null, null, null);
+	}
+
+	public DefaultDynamoDbTableNameResolver(@Nullable String tablePrefix) {
+		this(tablePrefix, null, null);
 	}
 
 	public DefaultDynamoDbTableNameResolver(@Nullable String tablePrefix, @Nullable String tableSuffix) {
+		this(tablePrefix, tableSuffix, null);
+	}
+
+	public DefaultDynamoDbTableNameResolver(@Nullable String tablePrefix, @Nullable String tableSuffix,
+											@Nullable String tableSeparator) {
 		this.tablePrefix = tablePrefix;
 		this.tableSuffix = tableSuffix;
+		this.tableSeparator = tableSeparator;
 	}
 
 	@Override
@@ -55,9 +64,11 @@ public class DefaultDynamoDbTableNameResolver implements DynamoDbTableNameResolv
 
 		String prefix = StringUtils.hasText(tablePrefix) ? tablePrefix : "";
 		String suffix = StringUtils.hasText(tableSuffix) ? tableSuffix : "";
+		String separator = StringUtils.hasText(tableSeparator) ? tableSeparator : "_";
 
-		return prefix.concat(clazz.getSimpleName().replaceAll("(.)(\\p{Lu})", "$1_$2").toLowerCase(Locale.ROOT))
-				.concat(suffix);
+		return prefix
+			.concat(clazz.getSimpleName().replaceAll("(.)(\\p{Lu})", "$1" + separator + "$2").toLowerCase(Locale.ROOT))
+			.concat(suffix);
 	}
 
 }

--- a/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTableNameResolverTest.java
+++ b/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTableNameResolverTest.java
@@ -37,6 +37,9 @@ class DynamoDbTableNameResolverTest {
 	private static final DefaultDynamoDbTableNameResolver prefixedAndSuffixedTableNameResolver = new DefaultDynamoDbTableNameResolver(
 			"my_prefix_", "_my_suffix");
 
+	private static final DefaultDynamoDbTableNameResolver prefixedAndSuffixedTableAndSeparatorTableNameResolver = new DefaultDynamoDbTableNameResolver(
+			"prefix-", "-suffix", "-");
+
 	@Test
 	void resolveTableNameSuccessfully() {
 		assertThat(tableNameResolver.resolve(MoreComplexPerson.class)).isEqualTo("more_complex_person");
@@ -58,6 +61,14 @@ class DynamoDbTableNameResolverTest {
 	}
 
 	@Test
+	void resolvePrefixedAndSuffixedAndSeparatorTableNameSuccessfully() {
+		assertThat(prefixedAndSuffixedTableAndSeparatorTableNameResolver.resolve(MoreComplexPerson.class))
+				.isEqualTo("prefix-more-complex-person-suffix");
+		assertThat(prefixedAndSuffixedTableAndSeparatorTableNameResolver.resolve(Person.class))
+				.isEqualTo("prefix-person-suffix");
+	}
+
+	@Test
 	void resolvesTableNameFromRecord() {
 		assertThat(tableNameResolver.resolve(PersonRecord.class)).isEqualTo("person_record");
 	}
@@ -65,6 +76,12 @@ class DynamoDbTableNameResolverTest {
 	@Test
 	void resolvesPrefixedTableNameFromRecord() {
 		assertThat(prefixedTableNameResolver.resolve(PersonRecord.class)).isEqualTo("my_prefix_person_record");
+	}
+
+	@Test
+	void resolvePrefixedAndSuffixedAndSeparatorTableNameFromRecord() {
+		assertThat(prefixedAndSuffixedTableAndSeparatorTableNameResolver.resolve(PersonRecord.class))
+				.isEqualTo("prefix-person-record-suffix");
 	}
 
 	record PersonRecord(String name) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Added a new property `spring.cloud.aws.dynamodb.table-separator` that can be used to override the table name word separator when using `DefaultDynamoDbTableNameResolver`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

DynamoDb allows `_`, `-`, and `.` to be used in table names - previous `DefaultDynamoDbTableNameResolver` implementation hardcoded `_` as the separator.  

See #1376 🙂 

## :green_heart: How did you test it?
Unit tests added to `DynamoDbTableNameResolverTest` and tested locally.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
Let me know if any changes are needed! 🤓 