### PR TITLE
Add `ExponentialBackoffErrorHandler` to manage message visibility tim…

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -1277,6 +1277,55 @@ public SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFac
 }
 ----
 
+==== Exponential Backoff Error Handler
+This error handler implements an exponential backoff strategy for retrying failed SQS message processing.
+
+The backoff duration is computed using the `ApproximateReceiveCount` message attribute, applying an exponential function to determine the delay. Once calculated, the handler sets the message's visibility timeout to the computed backoff value, postponing the message's reprocessing accordingly.
+
+[cols="2,3,1,1"]
+|===
+| Name | Description | Required | Default
+| `initialVisibilityTimeoutSeconds` | The starting visibility timeout (in seconds) applied when a message is received for the very first time. This serves as the base delay before any exponential backoff is applied. | No | 100
+| `multiplier` | The base factor by which the visibility timeout is multiplied for each retry attempt beyond the first. A value greater than 1 increases the delay exponentially; for example, a multiplier of 2 doubles the timeout on each subsequent receive. | No | 2.0
+| `maxVisibilityTimeoutSeconds` | The upper bound (in seconds) on the computed visibility timeout. Regardless of how large the exponential calculation grows, the final timeout will never exceed this cap. | No | 43200
+|===
+
+NOTE: The maximum visibility timeout allowed by SQS is 43200 seconds (12 hours). If the value provided to the `maxVisibilityTimeoutSeconds` parameter exceeds this limit, an `IllegalArgumentException` will be thrown.
+
+When using auto-configured factory, simply declare a `@Bean` and the error handler will be set
+
+[source, java]
+----
+@Bean
+public ExponentialBackoffErrorHandler<Object> asyncErrorHandler() {
+	return ExponentialBackoffErrorHandler
+		.builder()
+		.initialVisibilityTimeoutSeconds(1)
+		.multiplier(2)
+		.maxVisibilityTimeoutSeconds(10)
+		.build();
+}
+----
+
+Alternatively, `ExponentialBackoffErrorHandler` can be set in the `MessageListenerContainerFactory` or directly in the `MessageListenerContainer`:
+
+[source, java]
+----
+@Bean
+public SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFactory() {
+	return SqsMessageListenerContainerFactory
+		.builder()
+		.sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
+		.errorHandler(ExponentialBackoffErrorHandler
+			.builder()
+			.initialVisibilityTimeoutSeconds(1)
+			.multiplier(2)
+			.maxVisibilityTimeoutSeconds(10)
+			.build())
+		.build();
+}
+----
+
 === Message Conversion and Payload Deserialization
 
 Payloads are automatically deserialized from `JSON` for `@SqsListener` annotated methods using a `MappingJackson2MessageConverter`.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/Visibility.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/Visibility.java
@@ -28,6 +28,11 @@ import java.util.concurrent.CompletableFuture;
 public interface Visibility {
 
 	/**
+	 * The maximum visibility timeout interval, which corresponds to the maximum SQS visibility timeout of 12 hours.
+	 */
+	int MAX_VISIBILITY_TIMEOUT_SECONDS = 43200;
+
+	/**
 	 * Asynchronously changes the message visibility to the provided value.
 	 * @param seconds number of seconds to set the visibility of the message to.
 	 * @return a completable future.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/errorhandler/ErrorHandlerVisibilityHelper.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/errorhandler/ErrorHandlerVisibilityHelper.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.errorhandler;
+
+import io.awspring.cloud.sqs.MessageHeaderUtils;
+import io.awspring.cloud.sqs.listener.BatchVisibility;
+import io.awspring.cloud.sqs.listener.QueueMessageVisibility;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.listener.Visibility;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.messaging.Message;
+
+/**
+ * Utility methods for Error Handler.
+ *
+ * @author Bruno Garcia
+ * @author Rafael Pavarini
+ */
+public class ErrorHandlerVisibilityHelper {
+	public static <T> Map<Long, List<Message<T>>> groupMessagesByReceiveMessageCount(Collection<Message<T>> messages) {
+		return messages.stream().collect(Collectors.groupingBy(ErrorHandlerVisibilityHelper::getReceiveMessageCount));
+	}
+
+	public static <T> Collection<Message<?>> castMessages(Collection<Message<T>> messages) {
+		return new ArrayList<>(messages);
+	}
+
+	public static <T> Visibility getVisibility(Message<T> message) {
+		return MessageHeaderUtils.getHeader(message, SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class);
+	}
+
+	public static <T> BatchVisibility getVisibility(Collection<Message<T>> messages) {
+		Collection<Message<?>> castMessages = ErrorHandlerVisibilityHelper.castMessages(messages);
+		QueueMessageVisibility firstVisibilityMessage = (QueueMessageVisibility) ErrorHandlerVisibilityHelper
+				.getVisibility(messages.iterator().next());
+		return firstVisibilityMessage.toBatchVisibility(castMessages);
+
+	}
+
+	public static <T> long getReceiveMessageCount(Message<T> message) {
+		return Long.parseLong(MessageHeaderUtils.getHeaderAsString(message,
+				SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT));
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/errorhandler/ExponentialBackoffErrorHandler.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/errorhandler/ExponentialBackoffErrorHandler.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.errorhandler;
+
+import io.awspring.cloud.sqs.MessageHeaderUtils;
+import io.awspring.cloud.sqs.listener.BatchVisibility;
+import io.awspring.cloud.sqs.listener.Visibility;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+
+/**
+ * An implementation of an Exponential Backoff error handler for asynchronous message processing.
+ *
+ * <p>
+ * This error handler sets the SQS message visibility timeout exponentially based on the number of received attempts
+ * whenever an exception occurs.
+ *
+ * <p>
+ * When AcknowledgementMode is set to ON_SUCCESS (the default), returning a failed future prevents the message from
+ * being acknowledged.
+ *
+ * @author Bruno Garcia
+ * @author Rafael Pavarini
+ */
+
+public class ExponentialBackoffErrorHandler<T> implements AsyncErrorHandler<T> {
+	private static final Logger logger = LoggerFactory.getLogger(ExponentialBackoffErrorHandler.class);
+
+	private final int initialVisibilityTimeoutSeconds;
+	private final double multiplier;
+	private final int maxVisibilityTimeoutSeconds;
+
+	private ExponentialBackoffErrorHandler(int initialVisibilityTimeoutSeconds, double multiplier,
+			int maxVisibilityTimeoutSeconds) {
+		this.initialVisibilityTimeoutSeconds = initialVisibilityTimeoutSeconds;
+		this.multiplier = multiplier;
+		this.maxVisibilityTimeoutSeconds = maxVisibilityTimeoutSeconds;
+	}
+
+	@Override
+	public CompletableFuture<Void> handle(Message<T> message, Throwable t) {
+		return applyExponentialBackoffVisibilityTimeout(message)
+				.thenCompose(theVoid -> CompletableFuture.failedFuture(t));
+	}
+
+	@Override
+	public CompletableFuture<Void> handle(Collection<Message<T>> messages, Throwable t) {
+		return applyExponentialBackoffVisibilityTimeout(messages)
+				.thenCompose(theVoid -> CompletableFuture.failedFuture(t));
+	}
+
+	private CompletableFuture<Void> applyExponentialBackoffVisibilityTimeout(Collection<Message<T>> messages) {
+		CompletableFuture<?>[] futures = ErrorHandlerVisibilityHelper.groupMessagesByReceiveMessageCount(messages)
+				.entrySet().stream().map(entry -> {
+					int timeout = calculateTimeout(entry.getKey());
+					return applyBatchVisibilityChange(entry.getValue(), timeout);
+				}).toArray(CompletableFuture[]::new);
+
+		return CompletableFuture.allOf(futures);
+	}
+
+	private CompletableFuture<Void> applyBatchVisibilityChange(Collection<Message<T>> messages, int timeout) {
+		logger.debug("Changing batch visibility timeout to {} - Messages Id {}", timeout,
+				MessageHeaderUtils.getId(messages));
+		BatchVisibility visibility = ErrorHandlerVisibilityHelper.getVisibility(messages);
+		return visibility.changeToAsync(timeout).exceptionallyCompose(throwable -> {
+			logger.warn("Failed to change batch visibility timeout to {} - Messages Id {}", timeout,
+					MessageHeaderUtils.getId(messages), throwable);
+			return CompletableFuture.failedFuture(throwable);
+		});
+	}
+
+	private CompletableFuture<Void> applyExponentialBackoffVisibilityTimeout(Message<T> message) {
+		int timeout = calculateTimeout(message);
+		Visibility visibility = ErrorHandlerVisibilityHelper.getVisibility(message);
+		logger.debug("Changing visibility timeout to {} - Message Id {}", timeout, message.getHeaders().getId());
+		return visibility.changeToAsync(timeout).exceptionallyCompose(throwable -> {
+			logger.warn("Failed to change visibility timeout to {} - Message Id {}", timeout,
+					message.getHeaders().getId(), throwable);
+			return CompletableFuture.failedFuture(throwable);
+		});
+	}
+
+	private int calculateTimeout(Message<T> message) {
+		long receiveMessageCount = ErrorHandlerVisibilityHelper.getReceiveMessageCount(message);
+		return calculateTimeout(receiveMessageCount);
+	}
+
+	private int calculateTimeout(long receiveMessageCount) {
+		double exponential = initialVisibilityTimeoutSeconds * Math.pow(multiplier, receiveMessageCount - 1);
+		int seconds = (int) Math.min(exponential, (long) Integer.MAX_VALUE);
+		return Math.min(seconds, maxVisibilityTimeoutSeconds);
+	}
+
+	public static <T> Builder<T> builder() {
+		return new Builder<>();
+	}
+
+	public static class Builder<T> {
+
+		/**
+		 * The default initial visibility timeout.
+		 */
+		private static final int DEFAULT_INITIAL_VISIBILITY_TIMEOUT_SECONDS = 100;
+
+		/**
+		 * The default multiplier, which doubles the visibility timeout.
+		 */
+		private static final double DEFAULT_MULTIPLIER = 2.0;
+
+		private int initialVisibilityTimeoutSeconds = DEFAULT_INITIAL_VISIBILITY_TIMEOUT_SECONDS;
+		private double multiplier = DEFAULT_MULTIPLIER;
+		private int maxVisibilityTimeoutSeconds = Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS;
+
+		public Builder<T> initialVisibilityTimeoutSeconds(int initialVisibilityTimeoutSeconds) {
+			checkVisibilityTimeout(initialVisibilityTimeoutSeconds);
+			this.initialVisibilityTimeoutSeconds = initialVisibilityTimeoutSeconds;
+			return this;
+		}
+
+		public Builder<T> multiplier(double multiplier) {
+			Assert.isTrue(multiplier >= 1,
+					() -> "Invalid multiplier '" + multiplier + "'. Should be greater than " + "or equal to 1.");
+			this.multiplier = multiplier;
+			return this;
+		}
+
+		public Builder<T> maxVisibilityTimeoutSeconds(int maxVisibilityTimeoutSeconds) {
+			checkVisibilityTimeout(maxVisibilityTimeoutSeconds);
+			this.maxVisibilityTimeoutSeconds = maxVisibilityTimeoutSeconds;
+			return this;
+		}
+
+		public ExponentialBackoffErrorHandler<T> build() {
+			Assert.isTrue(initialVisibilityTimeoutSeconds <= maxVisibilityTimeoutSeconds,
+					"Initial visibility timeout must not exceed max visibility timeout");
+			return new ExponentialBackoffErrorHandler<T>(initialVisibilityTimeoutSeconds, multiplier,
+					maxVisibilityTimeoutSeconds);
+		}
+
+		private void checkVisibilityTimeout(long visibilityTimeout) {
+			Assert.isTrue(visibilityTimeout > 0,
+					() -> "Invalid visibility timeout '" + visibilityTimeout + "'. Should be greater than 0 ");
+			Assert.isTrue(visibilityTimeout <= Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS,
+					() -> "Invalid visibility timeout '" + visibilityTimeout + "'. Should be less than or equal to "
+							+ Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS);
+		}
+	}
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsErrorHandlerIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsErrorHandlerIntegrationTests.java
@@ -1,4 +1,22 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.integration;
+
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.sqs.MessageHeaderUtils;
@@ -6,8 +24,17 @@ import io.awspring.cloud.sqs.annotation.SqsListener;
 import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration;
 import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.listener.errorhandler.ExponentialBackoffErrorHandler;
 import io.awspring.cloud.sqs.listener.errorhandler.ImmediateRetryAsyncErrorHandler;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -18,25 +45,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.support.MessageBuilder;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
-
-import java.time.Duration;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static java.util.Collections.singletonMap;
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration tests for SQS ErrorHandler integration.
@@ -47,42 +60,48 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
-	
+
 	private static final Logger logger = LoggerFactory.getLogger(SqsErrorHandlerIntegrationTests.class);
 
 	static final String SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_QUEUE_NAME = "success_visibility_timeout_to_zero_test_queue";
-	
+
 	static final String SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_BATCH_QUEUE_NAME = "success_visibility_batch_timeout_to_zero_test_queue";
-	
+
 	static final String SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_FACTORY = "receivesMessageErrorFactory";
+
+	static final String SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_QUEUE_NAME = "success_exponential_backoff_error_handler";
+
+	static final String SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_BATCH_QUEUE_NAME = "success_exponential_batch_timeout_backoff_error_handler";
+
+	static final String SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_FACTORY = "receivesMessageExponentialErrorFactory";
 
 	@BeforeAll
 	static void beforeTests() {
 		SqsAsyncClient client = createAsyncClient();
 		CompletableFuture.allOf(
 				createQueue(client, SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_QUEUE_NAME,
-					singletonMap(QueueAttributeName.VISIBILITY_TIMEOUT, "500")),
+						singletonMap(QueueAttributeName.VISIBILITY_TIMEOUT, "500")),
 				createQueue(client, SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_BATCH_QUEUE_NAME,
-					singletonMap(QueueAttributeName.VISIBILITY_TIMEOUT, "500")))
-			.join();
+						singletonMap(QueueAttributeName.VISIBILITY_TIMEOUT, "500")),
+				createQueue(client, SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_QUEUE_NAME),
+				createQueue(client, SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_BATCH_QUEUE_NAME)).join();
 	}
-
 
 	@Autowired
 	LatchContainer latchContainer;
 
 	@Autowired
 	SqsTemplate sqsTemplate;
-	
+
 	@Autowired
 	ObjectMapper objectMapper;
-	
+
 	@Test
 	void receivesMessageVisibilityTimeout() throws Exception {
 		String messageBody = UUID.randomUUID().toString();
 		sqsTemplate.send(SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_QUEUE_NAME,
-			messageBody);
+				messageBody);
 
 		assertThat(latchContainer.receivesRetryMessageQuicklyLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
@@ -93,9 +112,30 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 
 		sqsTemplate.sendManyAsync(SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_BATCH_QUEUE_NAME, messages);
 		logger.debug("Sent message to queue {} with messageBody {}",
-			SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_BATCH_QUEUE_NAME, messages);
+				SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_BATCH_QUEUE_NAME, messages);
 
 		assertThat(latchContainer.receivesRetryBatchMessageQuicklyLatch.await(10, TimeUnit.SECONDS)).isTrue();
+	}
+
+	@Test
+	void receivesMessageExponentialBackOffErrorHandler() throws Exception {
+		String messageBody = UUID.randomUUID().toString();
+		sqsTemplate.send(SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_QUEUE_NAME, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}",
+				SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_QUEUE_NAME, messageBody);
+
+		assertThat(latchContainer.receivesRetryMessageExponentiallyLatch.await(20, TimeUnit.SECONDS)).isTrue();
+	}
+
+	@Test
+	void receivesBatchMessageExponentialBackOffErrorHandler() throws Exception {
+		List<Message<String>> messages = create10Messages("receivesMessageVisibilityTimeoutBatch");
+
+		sqsTemplate.sendManyAsync(SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_BATCH_QUEUE_NAME, messages);
+		logger.debug("Sent message to queue {} with messageBody {}",
+				SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_BATCH_QUEUE_NAME, messages);
+
+		assertThat(latchContainer.receivesRetryBatchMessageExponentiallyLatch.await(35, TimeUnit.SECONDS)).isTrue();
 	}
 
 	static class ImmediateRetryAsyncErrorHandlerListener {
@@ -107,16 +147,16 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 
 		private static final int MAX_EXPECTED_ELAPSED_TIME_BETWEEN_MSG_RECEIVES_IN_MS = 5000;
 
-		@SqsListener(queueNames = SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_QUEUE_NAME, messageVisibilitySeconds = "500", factory = SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_FACTORY, id = "visibilityErrHandler")
+		@SqsListener(queueNames = SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_QUEUE_NAME, messageVisibilitySeconds = "500", factory = SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_FACTORY, id = "visibilityErrorHandler")
 		CompletableFuture<Void> listen(Message<String> message,
-									   @Header(SqsHeaders.SQS_QUEUE_NAME_HEADER) String queueName) {
+				@Header(SqsHeaders.SQS_QUEUE_NAME_HEADER) String queueName) {
 			logger.info("Received message {} from queue {}", message, queueName);
 			String msgId = MessageHeaderUtils.getHeader(message, "id", UUID.class).toString();
 			Long prevReceivedMessageTimestamp = previousReceivedMessageTimestamps.get(msgId);
 			if (prevReceivedMessageTimestamp == null) {
 				previousReceivedMessageTimestamps.put(msgId, System.currentTimeMillis());
 				return CompletableFuture
-					.failedFuture(new RuntimeException("Expected exception from visibility-err-handler"));
+						.failedFuture(new RuntimeException("Expected exception from visibilityErrorHandler"));
 			}
 
 			long elapsedTimeBetweenMessageReceivesInMs = System.currentTimeMillis() - prevReceivedMessageTimestamp;
@@ -137,16 +177,17 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 
 		private static final int MAX_EXPECTED_ELAPSED_TIME_BETWEEN_BATCH_MSG_RECEIVES_IN_MS = 5000;
 
-		@SqsListener(queueNames = SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_BATCH_QUEUE_NAME, messageVisibilitySeconds = "500", factory = SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_FACTORY, id = "visibilityBatchErrHandler")
+		@SqsListener(queueNames = SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_BATCH_QUEUE_NAME, messageVisibilitySeconds = "500", factory = SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_FACTORY, id = "visibilityBatchErrorHandler")
 		CompletableFuture<Void> listen(List<Message<String>> messages) {
 			logger.info("Received messages {} from queue {}", MessageHeaderUtils.getId(messages),
-				messages.get(0).getHeaders().get(SqsHeaders.SQS_QUEUE_NAME_HEADER));
+					messages.get(0).getHeaders().get(SqsHeaders.SQS_QUEUE_NAME_HEADER));
 
-			for(Message<String> message : messages) {
+			for (Message<String> message : messages) {
 				String msgId = MessageHeaderUtils.getHeader(message, "id", UUID.class).toString();
 				if (!previousReceivedMessageTimestamps.containsKey(msgId)) {
 					previousReceivedMessageTimestamps.put(msgId, System.currentTimeMillis());
-					return CompletableFuture.failedFuture(new RuntimeException("Expected exception from visibility-err-handler"));
+					return CompletableFuture
+							.failedFuture(new RuntimeException("Expected exception from visibilityBatchErrorHandler"));
 				}
 				else {
 					long timediff = System.currentTimeMillis() - previousReceivedMessageTimestamps.get(msgId);
@@ -160,9 +201,86 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		}
 	}
 
+	static class ExponentialBackOffErrorHandlerListener {
+		@Autowired
+		LatchContainer latchContainer;
+		static Double multiplier = 2.0;
+		static Integer initialValueSeconds = 2;
+		long firstReceiveTimestamp;
+
+		@SqsListener(queueNames = SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_QUEUE_NAME, messageVisibilitySeconds = "10", factory = SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_FACTORY, id = "visibilityExponentialErrorHandler")
+		CompletableFuture<Void> listen(Message<String> message,
+				@Header(SqsHeaders.SQS_QUEUE_NAME_HEADER) String queueName) {
+			logger.info("Received message {} from queue {}", message, queueName);
+
+			long receiveCount = Long.parseLong(MessageHeaderUtils.getHeader(message,
+					SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class));
+
+			if (receiveCount < 4) {
+				return CompletableFuture.failedFuture(
+						new RuntimeException("Expected exception from visibilityExponentialErrorHandler"));
+			}
+
+			firstReceiveTimestamp = Long.parseLong(MessageHeaderUtils.getHeader(message,
+					SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_FIRST_RECEIVE_TIMESTAMP, String.class));
+			long currentTimestamp = MessageHeaderUtils.getHeader(message, MessageHeaders.TIMESTAMP, Long.class);
+
+			long elapsedTimeBetweenMessageReceivesInSeconds = (currentTimestamp - firstReceiveTimestamp) / 1000;
+			long expectedElapsedTime = calculateTotalElapsedExpectedTime(receiveCount);
+			if (elapsedTimeBetweenMessageReceivesInSeconds >= expectedElapsedTime) {
+				latchContainer.receivesRetryMessageExponentiallyLatch.countDown();
+			}
+
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+	static class ExponentialBackOffBatchErrorHandlerListener {
+		@Autowired
+		LatchContainer latchContainer;
+		Map<String, Long> counter = new ConcurrentHashMap<>();
+
+		@SqsListener(queueNames = SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_BATCH_QUEUE_NAME, messageVisibilitySeconds = "10", factory = SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_FACTORY, id = "visibilityExponentialBatchErrorHandler")
+		CompletableFuture<Void> listen(List<Message<String>> messages) {
+			logger.debug("Received messages {} from queue {}", MessageHeaderUtils.getId(messages),
+					messages.get(0).getHeaders().get(SqsHeaders.SQS_QUEUE_NAME_HEADER));
+
+			Collection<String> messagesReceiveCount = MessageHeaderUtils.getHeader(messages,
+					SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class);
+
+			boolean anyIsUnderRetryCount = messagesReceiveCount.stream()
+					.anyMatch(messageReceiveCount -> Long.parseLong(messageReceiveCount) < 5);
+
+			if (anyIsUnderRetryCount) {
+				return CompletableFuture.failedFuture(
+						new RuntimeException("Expected exception from visibilityExponentialBatchErrorHandler"));
+			}
+
+			for (Message<String> message : messages) {
+				long receiveCount = Long.parseLong(MessageHeaderUtils.getHeader(message,
+						SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class));
+				long firstReceiveTimestamp = Long.parseLong(MessageHeaderUtils.getHeader(message,
+						SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_FIRST_RECEIVE_TIMESTAMP, String.class));
+				long currentTimestamp = MessageHeaderUtils.getHeader(message, MessageHeaders.TIMESTAMP, Long.class);
+				long elapsedTimeBetweenMessageReceivesInSeconds = (currentTimestamp - firstReceiveTimestamp) / 1000;
+				long expectedElapsedTime = calculateTotalElapsedExpectedTime(receiveCount);
+				if (elapsedTimeBetweenMessageReceivesInSeconds >= expectedElapsedTime) {
+					latchContainer.receivesRetryBatchMessageExponentiallyLatch.countDown();
+				}
+				String msgId = MessageHeaderUtils.getHeader(message, "id", UUID.class).toString();
+				counter.put(msgId, elapsedTimeBetweenMessageReceivesInSeconds);
+			}
+			logger.info("Time elapsed by message {}", counter.toString());
+
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
 	static class LatchContainer {
 		final CountDownLatch receivesRetryMessageQuicklyLatch = new CountDownLatch(1);
 		final CountDownLatch receivesRetryBatchMessageQuicklyLatch = new CountDownLatch(10);
+		final CountDownLatch receivesRetryMessageExponentiallyLatch = new CountDownLatch(1);
+		final CountDownLatch receivesRetryBatchMessageExponentiallyLatch = new CountDownLatch(10);
 	}
 
 	@Import(SqsBootstrapConfiguration.class)
@@ -186,6 +304,26 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		}
 		// @formatter:on
 
+		// @formatter:off
+		@Bean(name = SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_FACTORY)
+		public SqsMessageListenerContainerFactory<Object> exponentialBackOffErrorHandler() {
+			return SqsMessageListenerContainerFactory
+				.builder()
+				.configure(options -> options
+					.maxConcurrentMessages(10)
+					.pollTimeout(Duration.ofSeconds(15))
+					.maxMessagesPerPoll(10)
+					.queueAttributeNames(Collections.singletonList(QueueAttributeName.QUEUE_ARN))
+					.maxDelayBetweenPolls(Duration.ofSeconds(15)))
+				.errorHandler(ExponentialBackoffErrorHandler.builder()
+					.initialVisibilityTimeoutSeconds(ExponentialBackOffErrorHandlerListener.initialValueSeconds)
+					.multiplier(ExponentialBackOffErrorHandlerListener.multiplier)
+					.build())
+				.sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
+				.build();
+		}
+		// @formatter:on
+
 		@Bean
 		ImmediateRetryAsyncErrorHandlerListener immediateRetryAsyncErrorHandlerListener() {
 			return new ImmediateRetryAsyncErrorHandlerListener();
@@ -194,6 +332,16 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		@Bean
 		ImmediateRetryAsyncBatchErrorHandlerListener immediateRetryAsyncBatchErrorHandlerListener() {
 			return new ImmediateRetryAsyncBatchErrorHandlerListener();
+		}
+
+		@Bean
+		ExponentialBackOffErrorHandlerListener exponentialBackOffErrorHandlerListener() {
+			return new ExponentialBackOffErrorHandlerListener();
+		}
+
+		@Bean
+		ExponentialBackOffBatchErrorHandlerListener exponentialBackOffBatchErrorHandlerListener() {
+			return new ExponentialBackOffBatchErrorHandlerListener();
 		}
 
 		LatchContainer latchContainer = new LatchContainer();
@@ -216,6 +364,14 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 
 	private List<Message<String>> create10Messages(String testName) {
 		return IntStream.range(0, 10).mapToObj(index -> testName + "-payload-" + index)
-			.map(payload -> MessageBuilder.withPayload(payload).build()).collect(Collectors.toList());
+				.map(payload -> MessageBuilder.withPayload(payload).build()).collect(Collectors.toList());
+	}
+
+	private static long calculateTotalElapsedExpectedTime(long receiveCount) {
+		double sum = 0;
+		for (int i = 0; i < receiveCount - 1; i++) {
+			sum += Math.pow(ExponentialBackOffErrorHandlerListener.multiplier, i);
+		}
+		return (long) (ExponentialBackOffErrorHandlerListener.initialValueSeconds * sum);
 	}
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/ErrorHandlerVisibilityHelperTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/ErrorHandlerVisibilityHelperTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.errorhandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import io.awspring.cloud.sqs.listener.BatchVisibility;
+import io.awspring.cloud.sqs.listener.QueueMessageVisibility;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.listener.Visibility;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Tests for {@link ErrorHandlerVisibilityHelper}.
+ *
+ * @author Bruno Garcia
+ * @author Rafael Pavarini
+ */
+class ErrorHandlerVisibilityHelperTest {
+
+	@Test
+	void getReceiveMessageCount() {
+		Message<Object> message = mock(Message.class);
+		MessageHeaders headers = mock(MessageHeaders.class);
+
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("30");
+
+		long receiveMessageCount = ErrorHandlerVisibilityHelper.getReceiveMessageCount(message);
+
+		assertThat(receiveMessageCount).isEqualTo(30L);
+	}
+
+	@Test
+	void getVisibility() {
+		Message<Object> message = mock(Message.class);
+		MessageHeaders headers = mock(MessageHeaders.class);
+		Visibility visibilityMock = mock(Visibility.class);
+
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibilityMock);
+
+		Visibility visibility = ErrorHandlerVisibilityHelper.getVisibility(message);
+
+		assertThat(visibility).isSameAs(visibilityMock);
+
+	}
+
+	@Test
+	void getVisibilityBatch() {
+		QueueMessageVisibility queueVisibility = mock(QueueMessageVisibility.class);
+		BatchVisibility expectedBatchVisibility = mock(BatchVisibility.class);
+		Message<Object> m1 = mock(Message.class);
+		Message<Object> m2 = mock(Message.class);
+		Message<Object> m3 = mock(Message.class);
+		MessageHeaders headers = mock(MessageHeaders.class);
+
+		given(m1.getHeaders()).willReturn(headers);
+		given(m2.getHeaders()).willReturn(headers);
+		given(m3.getHeaders()).willReturn(headers);
+
+		List<Message<Object>> batch = List.of(m1, m2, m3);
+		Collection<Message<?>> castMessages = new ArrayList<>(batch);
+
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(queueVisibility);
+		given(queueVisibility.toBatchVisibility(castMessages)).willReturn(expectedBatchVisibility);
+
+		BatchVisibility batchVisibility = ErrorHandlerVisibilityHelper.getVisibility(batch);
+
+		assertThat(batchVisibility).isSameAs(expectedBatchVisibility);
+	}
+
+	@Test
+	void castMessages() {
+		Message<Object> m1 = mock(Message.class);
+		Message<Object> m2 = mock(Message.class);
+		Message<Object> m3 = mock(Message.class);
+		List<Message<Object>> original = List.of(m1, m2, m3);
+
+		Collection<Message<?>> cast = ErrorHandlerVisibilityHelper.castMessages(original);
+
+		assertThat(cast).containsExactlyElementsOf(original);
+	}
+
+	@Test
+	void groupMessagesByReceiveMessageCount() {
+		Message<Object> lowMsg = mock(Message.class);
+		Message<Object> highMsg1 = mock(Message.class);
+		Message<Object> highMsg2 = mock(Message.class);
+
+		MessageHeaders lowHeaders = mock(MessageHeaders.class);
+		MessageHeaders highHeaders = mock(MessageHeaders.class);
+
+		given(lowMsg.getHeaders()).willReturn(lowHeaders);
+		given(highMsg1.getHeaders()).willReturn(highHeaders);
+		given(highMsg2.getHeaders()).willReturn(highHeaders);
+
+		given(lowHeaders.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("1");
+		given(highHeaders.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("30");
+
+		List<Message<Object>> batch = List.of(lowMsg, highMsg1, highMsg2);
+
+		Map<Long, List<Message<Object>>> grouped = ErrorHandlerVisibilityHelper
+				.groupMessagesByReceiveMessageCount(batch);
+
+		assertThat(grouped).hasSize(2);
+		assertThat(grouped.get(1L)).containsExactly(lowMsg);
+		assertThat(grouped.get(30L)).containsExactly(highMsg1, highMsg2);
+	}
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/ExponentialBackoffErrorHandlerTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/ExponentialBackoffErrorHandlerTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.errorhandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import io.awspring.cloud.sqs.listener.BatchVisibility;
+import io.awspring.cloud.sqs.listener.QueueMessageVisibility;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.listener.Visibility;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Tests for {@link ExponentialBackoffErrorHandler}.
+ *
+ * @author Bruno Garcia
+ * @author Rafael Pavarini
+ */
+class ExponentialBackoffErrorHandlerTest {
+
+	@Test
+	void shouldChangeVisibilityTimeoutExponentiallyWithDefaultInitialVisibilityTimeout() {
+		Message<Object> message = mock(Message.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		Visibility visibility = mock(Visibility.class);
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("1");
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		ExponentialBackoffErrorHandler<Object> handler = ExponentialBackoffErrorHandler.builder().build();
+
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(100);
+	}
+
+	@Test
+	void shouldChangeVisibilityTimeoutExponentiallyWithDefaultMaxVisibilityTimeout() {
+		Message<Object> message = mock(Message.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		Visibility visibility = mock(Visibility.class);
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("1");
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		ExponentialBackoffErrorHandler<Object> handler = ExponentialBackoffErrorHandler.builder()
+				.initialVisibilityTimeoutSeconds(43200).multiplier(2).build();
+
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(43200);
+	}
+
+	@Test
+	void shouldChangeVisibilityTimeoutExponentiallyWithCustomVisibilityTimeout() {
+		Message<Object> message = mock(Message.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		Visibility visibility = mock(Visibility.class);
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("1");
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		ExponentialBackoffErrorHandler<Object> handler = ExponentialBackoffErrorHandler.builder()
+				.initialVisibilityTimeoutSeconds(500).multiplier(2).build();
+
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(500);
+	}
+
+	@Test
+	void shouldChangeVisibilityTimeoutExponentiallyWithCustomVisibilityTimeoutAndMaxVisibilityTimeout() {
+		Message<Object> message = mock(Message.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		Visibility visibility = mock(Visibility.class);
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("1");
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		ExponentialBackoffErrorHandler<Object> handler = ExponentialBackoffErrorHandler.builder()
+				.maxVisibilityTimeoutSeconds(501).initialVisibilityTimeoutSeconds(500).multiplier(2).build();
+
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(500);
+
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("2");
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(501);
+	}
+
+	@Test
+	void shouldChangeVisibilityTimeoutExponentially() {
+		Message<Object> message = mock(Message.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		Visibility visibility = mock(Visibility.class);
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("1");
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		ExponentialBackoffErrorHandler<Object> handler = ExponentialBackoffErrorHandler.builder()
+				.initialVisibilityTimeoutSeconds(500).multiplier(2).build();
+
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(500);
+
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("2");
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(1000);
+
+	}
+
+	@Test
+	void shouldChangeVisibilityTimeoutExponentiallyBatch() {
+		Message<Object> message1 = mock(Message.class);
+		Message<Object> message2 = mock(Message.class);
+		Message<Object> message3 = mock(Message.class);
+		List<Message<Object>> batch = Arrays.asList(message1, message2, message3);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZeroBatch");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		MessageHeaders headers2 = mock(MessageHeaders.class);
+		QueueMessageVisibility visibility = mock(QueueMessageVisibility.class);
+		BatchVisibility batchvisibility = mock(BatchVisibility.class);
+		given(batchvisibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+		given(visibility.toBatchVisibility(any())).willReturn(batchvisibility);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers2.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.getId()).willReturn(UUID.randomUUID());
+		given(headers2.getId()).willReturn(UUID.randomUUID());
+		given(headers.get("id", UUID.class)).willReturn(UUID.randomUUID());
+		given(headers2.get("id", UUID.class)).willReturn(UUID.randomUUID());
+		given(message1.getHeaders()).willReturn(headers);
+		given(message2.getHeaders()).willReturn(headers2);
+		given(message3.getHeaders()).willReturn(headers);
+
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("1");
+		given(headers2.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("2");
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		ExponentialBackoffErrorHandler<Object> handler = ExponentialBackoffErrorHandler.builder()
+				.initialVisibilityTimeoutSeconds(500).multiplier(2).build();
+
+		assertThat(handler.handle(batch, exception)).isCompletedExceptionally();
+		then(batchvisibility).should(times(1)).changeToAsync(500);
+
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("2");
+		given(headers2.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("3");
+		assertThat(handler.handle(batch, exception)).isCompletedExceptionally();
+
+		then(batchvisibility).should(times(2)).changeToAsync(1000);
+		then(batchvisibility).should(times(1)).changeToAsync(2000);
+	}
+
+	@Test
+	void shouldApplyMaxVisibilityTimeoutWhenCalculatedTimeoutExceedsLimit() {
+		Message<Object> message = mock(Message.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		Visibility visibility = mock(Visibility.class);
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("11");
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		ExponentialBackoffErrorHandler<Object> handler = ExponentialBackoffErrorHandler.builder()
+				.multiplier(Integer.MAX_VALUE).build();
+
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS);
+	}
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/ImmediateRetryAsyncErrorHandlerTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/ImmediateRetryAsyncErrorHandlerTests.java
@@ -15,18 +15,6 @@
  */
 package io.awspring.cloud.sqs.listener.errorhandler;
 
-import io.awspring.cloud.sqs.listener.BatchVisibility;
-import io.awspring.cloud.sqs.listener.QueueMessageVisibility;
-import io.awspring.cloud.sqs.listener.SqsHeaders;
-import io.awspring.cloud.sqs.listener.Visibility;
-import org.junit.jupiter.api.Test;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHeaders;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,6 +22,17 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import io.awspring.cloud.sqs.listener.BatchVisibility;
+import io.awspring.cloud.sqs.listener.QueueMessageVisibility;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.listener.Visibility;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 
 /**
  * Tests for {@link ImmediateRetryAsyncErrorHandler}.
@@ -70,9 +69,8 @@ class ImmediateRetryAsyncErrorHandlerTests {
 
 		ImmediateRetryAsyncErrorHandler<Object> handler = new ImmediateRetryAsyncErrorHandler<>();
 
-		assertThatThrownBy(() -> handler.handle(message, exception))
-			.isInstanceOf(NullPointerException.class)
-			.hasMessageContaining("Header Sqs_VisibilityTimeout not found in message");
+		assertThatThrownBy(() -> handler.handle(message, exception)).isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("Header Sqs_VisibilityTimeout not found in message");
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [X] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
New ExponentialBackoffErrorHandler to change message visibility timeout exponentially based on the number of receive Message Count

## :bulb: Motivation and Context
As mentioned in (#1313), this enhancement enables reporting an error back to AWS SQS by exponentially increasing the message's visibility timeout, allowing it to be retried.

See #1314 


## :green_heart: How did you test it?
Unit test, Integration test, manual tests with a sample application

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] I updated reference documentation to reflect the change
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
- Update sample application
