### PR TITLE
SQS: Properly handle `Error`s in listeners

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/adapter/AbstractMethodInvokingListenerAdapter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/adapter/AbstractMethodInvokingListenerAdapter.java
@@ -55,8 +55,8 @@ public abstract class AbstractMethodInvokingListenerAdapter<T> {
 		try {
 			return this.handlerMethod.invoke(message);
 		}
-		catch (Exception e) {
-			throw createListenerException(message, e);
+		catch (Throwable t) {
+			throw createListenerException(message, t);
 		}
 	}
 
@@ -69,8 +69,8 @@ public abstract class AbstractMethodInvokingListenerAdapter<T> {
 		try {
 			return this.handlerMethod.invoke(MessageBuilder.withPayload(messages).build());
 		}
-		catch (Exception e) {
-			throw createListenerException(messages, e);
+		catch (Throwable t) {
+			throw createListenerException(messages, t);
 		}
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/adapter/AsyncMessagingMessageListenerAdapter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/adapter/AsyncMessagingMessageListenerAdapter.java
@@ -49,8 +49,8 @@ public class AsyncMessagingMessageListenerAdapter<T> extends AbstractMethodInvok
 			return CompletableFutures.failedFuture(new IllegalArgumentException(
 					"Invalid return type for message " + MessageHeaderUtils.getId(message), e));
 		}
-		catch (Exception e) {
-			return CompletableFutures.failedFuture(e);
+		catch (Throwable t) {
+			return CompletableFutures.failedFuture(t);
 		}
 	}
 
@@ -68,8 +68,8 @@ public class AsyncMessagingMessageListenerAdapter<T> extends AbstractMethodInvok
 			return CompletableFutures.failedFuture(new IllegalArgumentException(
 					"Invalid return type for messages " + MessageHeaderUtils.getId(messages), e));
 		}
-		catch (Exception e) {
-			return CompletableFutures.failedFuture(e);
+		catch (Throwable t) {
+			return CompletableFutures.failedFuture(t);
 		}
 	}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/adapter/AbstractMethodInvokingListenerAdapterTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/adapter/AbstractMethodInvokingListenerAdapterTests.java
@@ -56,12 +56,12 @@ class AbstractMethodInvokingListenerAdapterTests {
 	}
 
 	@Test
-	void shouldWrapError() throws Exception {
+	void shouldWrapException() throws Exception {
 		MessageHeaders headers = new MessageHeaders(null);
 		InvocableHandlerMethod handlerMethod = mock(InvocableHandlerMethod.class);
 		Message<Object> message = mock(Message.class);
 		given(message.getHeaders()).willReturn(headers);
-		RuntimeException exception = new RuntimeException("Expected exception from shouldWrapError");
+		RuntimeException exception = new RuntimeException("Expected exception from shouldWrapException");
 		when(handlerMethod.invoke(message)).thenThrow(exception);
 		AbstractMethodInvokingListenerAdapter<Object> adapter = new AbstractMethodInvokingListenerAdapter<Object>(
 				handlerMethod) {
@@ -69,6 +69,22 @@ class AbstractMethodInvokingListenerAdapterTests {
 		assertThatThrownBy(() -> adapter.invokeHandler(message)).isInstanceOf(ListenerExecutionFailedException.class)
 				.asInstanceOf(type(ListenerExecutionFailedException.class))
 				.extracting(ListenerExecutionFailedException::getFailedMessage).isEqualTo(message);
+	}
+
+	@Test
+	void shouldWrapError() throws Exception {
+		MessageHeaders headers = new MessageHeaders(null);
+		InvocableHandlerMethod handlerMethod = mock(InvocableHandlerMethod.class);
+		Message<Object> message = mock(Message.class);
+		given(message.getHeaders()).willReturn(headers);
+		Error error = new Error("Expected exception from shouldWrapError");
+		when(handlerMethod.invoke(message)).thenThrow(error);
+		AbstractMethodInvokingListenerAdapter<Object> adapter = new AbstractMethodInvokingListenerAdapter<Object>(
+			handlerMethod) {
+		};
+		assertThatThrownBy(() -> adapter.invokeHandler(message)).isInstanceOf(ListenerExecutionFailedException.class)
+			.asInstanceOf(type(ListenerExecutionFailedException.class))
+			.extracting(ListenerExecutionFailedException::getFailedMessage).isEqualTo(message);
 	}
 
 	@Test
@@ -94,6 +110,27 @@ class AbstractMethodInvokingListenerAdapterTests {
 	}
 
 	@Test
+	void shouldWrapExceptionBatch() throws Exception {
+		MessageHeaders messageHeaders = new MessageHeaders(null);
+		InvocableHandlerMethod handlerMethod = mock(InvocableHandlerMethod.class);
+		Message<Object> message1 = mock(Message.class);
+		Message<Object> message2 = mock(Message.class);
+		Message<Object> message3 = mock(Message.class);
+		List<Message<Object>> batch = Arrays.asList(message1, message2, message3);
+		given(message1.getHeaders()).willReturn(messageHeaders);
+		given(message2.getHeaders()).willReturn(messageHeaders);
+		given(message3.getHeaders()).willReturn(messageHeaders);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldWrapExceptionBatch");
+		when(handlerMethod.invoke(any(Message.class))).thenThrow(exception);
+		AbstractMethodInvokingListenerAdapter<Object> adapter = new AbstractMethodInvokingListenerAdapter<Object>(
+				handlerMethod) {
+		};
+		assertThatThrownBy(() -> adapter.invokeHandler(batch)).isInstanceOf(ListenerExecutionFailedException.class)
+				.asInstanceOf(type(ListenerExecutionFailedException.class))
+				.extracting(ListenerExecutionFailedException::getFailedMessages).isEqualTo(batch);
+	}
+
+	@Test
 	void shouldWrapErrorBatch() throws Exception {
 		MessageHeaders messageHeaders = new MessageHeaders(null);
 		InvocableHandlerMethod handlerMethod = mock(InvocableHandlerMethod.class);
@@ -104,14 +141,14 @@ class AbstractMethodInvokingListenerAdapterTests {
 		given(message1.getHeaders()).willReturn(messageHeaders);
 		given(message2.getHeaders()).willReturn(messageHeaders);
 		given(message3.getHeaders()).willReturn(messageHeaders);
-		RuntimeException exception = new RuntimeException("Expected exception from shouldWrapErrorBatch");
-		when(handlerMethod.invoke(any(Message.class))).thenThrow(exception);
+		Error error = new Error("Expected exception from shouldWrapErrorBatch");
+		when(handlerMethod.invoke(any(Message.class))).thenThrow(error);
 		AbstractMethodInvokingListenerAdapter<Object> adapter = new AbstractMethodInvokingListenerAdapter<Object>(
-				handlerMethod) {
+			handlerMethod) {
 		};
 		assertThatThrownBy(() -> adapter.invokeHandler(batch)).isInstanceOf(ListenerExecutionFailedException.class)
-				.asInstanceOf(type(ListenerExecutionFailedException.class))
-				.extracting(ListenerExecutionFailedException::getFailedMessages).isEqualTo(batch);
+			.asInstanceOf(type(ListenerExecutionFailedException.class))
+			.extracting(ListenerExecutionFailedException::getFailedMessages).isEqualTo(batch);
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/adapter/AsyncMessagingMessageListenerAdapterTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/adapter/AsyncMessagingMessageListenerAdapterTests.java
@@ -58,14 +58,49 @@ class AsyncMessagingMessageListenerAdapterTests {
 	}
 
 	@Test
-	void shouldReturnFailedFutureOnThrownError() throws Exception {
+	void shouldReturnFailedFutureOnThrownException() throws Exception {
 		MessageHeaders headers = new MessageHeaders(null);
 		InvocableHandlerMethod handlerMethod = mock(InvocableHandlerMethod.class);
 		Message<Object> message = mock(Message.class);
 		RuntimeException exception = new RuntimeException(
-				"Expected exception from shouldReturnFailedFutureOnThrownError");
+				"Expected exception from shouldReturnFailedFutureOnThrownException");
 		given(message.getHeaders()).willReturn(headers);
 		given(handlerMethod.invoke(message)).willThrow(exception);
+		AsyncMessageListener<Object> adapter = new AsyncMessagingMessageListenerAdapter<>(handlerMethod);
+		CompletableFuture<Void> result = adapter.onMessage(message);
+		assertThat(result).isCompletedExceptionally();
+		assertThatThrownBy(result::join).isInstanceOf(CompletionException.class).extracting(Throwable::getCause)
+				.isInstanceOf(ListenerExecutionFailedException.class)
+				.asInstanceOf(type(ListenerExecutionFailedException.class))
+				.extracting(ListenerExecutionFailedException::getFailedMessage).isEqualTo(message);
+	}
+
+	@Test
+	void shouldReturnFailedFutureOnThrownError() throws Exception {
+		MessageHeaders headers = new MessageHeaders(null);
+		InvocableHandlerMethod handlerMethod = mock(InvocableHandlerMethod.class);
+		Message<Object> message = mock(Message.class);
+		Error error = new Error(
+			"Expected exception from shouldReturnFailedFutureOnThrownError");
+		given(message.getHeaders()).willReturn(headers);
+		given(handlerMethod.invoke(message)).willThrow(error);
+		AsyncMessageListener<Object> adapter = new AsyncMessagingMessageListenerAdapter<>(handlerMethod);
+		CompletableFuture<Void> result = adapter.onMessage(message);
+		assertThat(result).isCompletedExceptionally();
+		assertThatThrownBy(result::join).isInstanceOf(CompletionException.class).extracting(Throwable::getCause)
+			.isInstanceOf(ListenerExecutionFailedException.class)
+			.asInstanceOf(type(ListenerExecutionFailedException.class))
+			.extracting(ListenerExecutionFailedException::getFailedMessage).isEqualTo(message);
+	}
+
+	@Test
+	void shouldWrapCompletionException() throws Exception {
+		MessageHeaders headers = new MessageHeaders(null);
+		InvocableHandlerMethod handlerMethod = mock(InvocableHandlerMethod.class);
+		Message<Object> message = mock(Message.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldWrapCompletionException");
+		given(message.getHeaders()).willReturn(headers);
+		given(handlerMethod.invoke(message)).willReturn(CompletableFutures.failedFuture(exception));
 		AsyncMessageListener<Object> adapter = new AsyncMessagingMessageListenerAdapter<>(handlerMethod);
 		CompletableFuture<Void> result = adapter.onMessage(message);
 		assertThat(result).isCompletedExceptionally();
@@ -80,16 +115,16 @@ class AsyncMessagingMessageListenerAdapterTests {
 		MessageHeaders headers = new MessageHeaders(null);
 		InvocableHandlerMethod handlerMethod = mock(InvocableHandlerMethod.class);
 		Message<Object> message = mock(Message.class);
-		RuntimeException exception = new RuntimeException("Expected exception from shouldWrapCompletionError");
+		Error error = new Error("Expected exception from shouldWrapCompletionError");
 		given(message.getHeaders()).willReturn(headers);
-		given(handlerMethod.invoke(message)).willReturn(CompletableFutures.failedFuture(exception));
+		given(handlerMethod.invoke(message)).willReturn(CompletableFutures.failedFuture(error));
 		AsyncMessageListener<Object> adapter = new AsyncMessagingMessageListenerAdapter<>(handlerMethod);
 		CompletableFuture<Void> result = adapter.onMessage(message);
 		assertThat(result).isCompletedExceptionally();
 		assertThatThrownBy(result::join).isInstanceOf(CompletionException.class).extracting(Throwable::getCause)
-				.isInstanceOf(ListenerExecutionFailedException.class)
-				.asInstanceOf(type(ListenerExecutionFailedException.class))
-				.extracting(ListenerExecutionFailedException::getFailedMessage).isEqualTo(message);
+			.isInstanceOf(ListenerExecutionFailedException.class)
+			.asInstanceOf(type(ListenerExecutionFailedException.class))
+			.extracting(ListenerExecutionFailedException::getFailedMessage).isEqualTo(message);
 	}
 
 	@Test
@@ -127,7 +162,7 @@ class AsyncMessagingMessageListenerAdapterTests {
 	}
 
 	@Test
-	void shouldReturnFailedFutureOnErrorBatch() throws Exception {
+	void shouldReturnFailedFutureOnExceptionBatch() throws Exception {
 		Message<Object> message1 = mock(Message.class);
 		Message<Object> message2 = mock(Message.class);
 		Message<Object> message3 = mock(Message.class);
@@ -135,11 +170,56 @@ class AsyncMessagingMessageListenerAdapterTests {
 		MessageHeaders headers = new MessageHeaders(null);
 		InvocableHandlerMethod handlerMethod = mock(InvocableHandlerMethod.class);
 		RuntimeException exception = new RuntimeException(
-				"Expected exception from shouldReturnFailedFutureOnErrorBatch");
+				"Expected exception from shouldReturnFailedFutureOnExceptionBatch");
 		given(message1.getHeaders()).willReturn(headers);
 		given(message2.getHeaders()).willReturn(headers);
 		given(message3.getHeaders()).willReturn(headers);
 		given(handlerMethod.invoke(any(Message.class))).willThrow(exception);
+		AsyncMessageListener<Object> adapter = new AsyncMessagingMessageListenerAdapter<>(handlerMethod);
+		CompletableFuture<Void> result = adapter.onMessage(messages);
+		assertThat(result).isCompletedExceptionally();
+		assertThatThrownBy(result::join).isInstanceOf(CompletionException.class).extracting(Throwable::getCause)
+				.isInstanceOf(ListenerExecutionFailedException.class)
+				.asInstanceOf(type(ListenerExecutionFailedException.class))
+				.extracting(ListenerExecutionFailedException::getFailedMessages).isEqualTo(messages);
+	}
+
+	@Test
+	void shouldReturnFailedFutureOnErrorBatch() throws Exception {
+		Message<Object> message1 = mock(Message.class);
+		Message<Object> message2 = mock(Message.class);
+		Message<Object> message3 = mock(Message.class);
+		List<Message<Object>> messages = Arrays.asList(message1, message2, message3);
+		MessageHeaders headers = new MessageHeaders(null);
+		InvocableHandlerMethod handlerMethod = mock(InvocableHandlerMethod.class);
+		Error error = new Error(
+			"Expected exception from shouldReturnFailedFutureOnErrorBatch");
+		given(message1.getHeaders()).willReturn(headers);
+		given(message2.getHeaders()).willReturn(headers);
+		given(message3.getHeaders()).willReturn(headers);
+		given(handlerMethod.invoke(any(Message.class))).willThrow(error);
+		AsyncMessageListener<Object> adapter = new AsyncMessagingMessageListenerAdapter<>(handlerMethod);
+		CompletableFuture<Void> result = adapter.onMessage(messages);
+		assertThat(result).isCompletedExceptionally();
+		assertThatThrownBy(result::join).isInstanceOf(CompletionException.class).extracting(Throwable::getCause)
+			.isInstanceOf(ListenerExecutionFailedException.class)
+			.asInstanceOf(type(ListenerExecutionFailedException.class))
+			.extracting(ListenerExecutionFailedException::getFailedMessages).isEqualTo(messages);
+	}
+
+	@Test
+	void shouldWrapCompletionExceptionBatch() throws Exception {
+		Message<Object> message1 = mock(Message.class);
+		Message<Object> message2 = mock(Message.class);
+		Message<Object> message3 = mock(Message.class);
+		List<Message<Object>> messages = Arrays.asList(message1, message2, message3);
+		MessageHeaders headers = new MessageHeaders(null);
+		InvocableHandlerMethod handlerMethod = mock(InvocableHandlerMethod.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldWrapCompletionExceptionBatch");
+		given(message1.getHeaders()).willReturn(headers);
+		given(message2.getHeaders()).willReturn(headers);
+		given(message3.getHeaders()).willReturn(headers);
+		given(handlerMethod.invoke(any(Message.class))).willReturn(CompletableFutures.failedFuture(exception));
 		AsyncMessageListener<Object> adapter = new AsyncMessagingMessageListenerAdapter<>(handlerMethod);
 		CompletableFuture<Void> result = adapter.onMessage(messages);
 		assertThat(result).isCompletedExceptionally();
@@ -157,18 +237,18 @@ class AsyncMessagingMessageListenerAdapterTests {
 		List<Message<Object>> messages = Arrays.asList(message1, message2, message3);
 		MessageHeaders headers = new MessageHeaders(null);
 		InvocableHandlerMethod handlerMethod = mock(InvocableHandlerMethod.class);
-		RuntimeException exception = new RuntimeException("Expected exception from shouldWrapCompletionErrorBatch");
+		Error error = new Error("Expected exception from shouldWrapCompletionErrorBatch");
 		given(message1.getHeaders()).willReturn(headers);
 		given(message2.getHeaders()).willReturn(headers);
 		given(message3.getHeaders()).willReturn(headers);
-		given(handlerMethod.invoke(any(Message.class))).willReturn(CompletableFutures.failedFuture(exception));
+		given(handlerMethod.invoke(any(Message.class))).willReturn(CompletableFutures.failedFuture(error));
 		AsyncMessageListener<Object> adapter = new AsyncMessagingMessageListenerAdapter<>(handlerMethod);
 		CompletableFuture<Void> result = adapter.onMessage(messages);
 		assertThat(result).isCompletedExceptionally();
 		assertThatThrownBy(result::join).isInstanceOf(CompletionException.class).extracting(Throwable::getCause)
-				.isInstanceOf(ListenerExecutionFailedException.class)
-				.asInstanceOf(type(ListenerExecutionFailedException.class))
-				.extracting(ListenerExecutionFailedException::getFailedMessages).isEqualTo(messages);
+			.isInstanceOf(ListenerExecutionFailedException.class)
+			.asInstanceOf(type(ListenerExecutionFailedException.class))
+			.extracting(ListenerExecutionFailedException::getFailedMessages).isEqualTo(messages);
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
I updated the listener adapters to catch Throwable instead of Exception so that `ErrorHandler`s can handle Throwables as expected.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1379.


## :green_heart: How did you test it?
I added unit tests to the classes I modified and tested the change locally within my own project against the reproduction in the issue.

I would be happy to add an integration test if appropriate. If so could you give me some direction about your preferences for that?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
