### PR TITLE
Rename bean producer method to a unique name in SqsManualAckSample

### DIFF
--- a/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/main/java/io/awspring/cloud/sqs/sample/SqsManualAckSample.java
+++ b/spring-cloud-aws-samples/spring-cloud-aws-sqs-sample/src/main/java/io/awspring/cloud/sqs/sample/SqsManualAckSample.java
@@ -41,7 +41,7 @@ public class SqsManualAckSample {
 	private static final Logger LOGGER = LoggerFactory.getLogger(SqsManualAckSample.class);
 
 	@Bean
-	public ApplicationRunner sendMessageToQueue(SqsTemplate sqsTemplate) {
+	public ApplicationRunner sendMessageToManualAckQueue(SqsTemplate sqsTemplate) {
 		LOGGER.info("Sending message");
 		return args -> sqsTemplate.send(to -> to.queue(NEW_USER_QUEUE).payload(new User(UUID.randomUUID(), "John")));
 	}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Rename one of the bean producer method in the Sqs samples

## :bulb: Motivation and Context
When running the sample, I was getting the following error
```
2025-05-09T23:38:50.402-03:00 ERROR 20717 --- [           main] o.s.b.d.LoggingFailureAnalysisReporter   : 

***************************
APPLICATION FAILED TO START
***************************

Description:

The bean 'sendMessageToQueue', defined in io.awspring.cloud.sqs.sample.SpringSqsSample, could not be registered. A bean with that name has already been defined in class path resource [io/awspring/cloud/sqs/sample/SqsManualAckSample.class] and overriding is disabled.

Action:

Consider renaming one of the beans or enabling overriding by setting spring.main.allow-bean-definition-overriding=true

```

## :green_heart: How did you test it?
Only by running the samples.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [X] All tests passing
- [X] No breaking changes

