### PR TITLE
Fix setting endpoint from connection details to `S3Presigner`.

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfiguration.java
@@ -116,6 +116,11 @@ public class S3AutoConfiguration {
 		else if (awsProperties.getEndpoint() != null) {
 			builder.endpointOverride(awsProperties.getEndpoint());
 		}
+		connectionDetails.ifAvailable(it -> {
+			if (it.getEndpoint() != null) {
+				builder.endpointOverride(it.getEndpoint());
+			}
+		});
 		Optional.ofNullable(awsProperties.getFipsEnabled()).ifPresent(builder::fipsEnabled);
 		Optional.ofNullable(awsProperties.getDualstackEnabled()).ifPresent(builder::dualstackEnabled);
 		return builder.build();

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3CrtAsyncClientAutoConfiguration.java
@@ -68,7 +68,7 @@ public class S3CrtAsyncClientAutoConfiguration {
 		S3CrtAsyncClientBuilder builder = S3AsyncClient.crtBuilder().credentialsProvider(credentialsProvider).region(
 				this.awsClientBuilderConfigurer.resolveRegion(this.properties, connectionDetails.getIfAvailable()));
 		Optional.ofNullable(connectionDetails.getIfAvailable()).map(AwsConnectionDetails::getEndpoint)
-			.ifPresent(builder::endpointOverride);
+				.ifPresent(builder::endpointOverride);
 		Optional.ofNullable(this.awsProperties.getEndpoint()).ifPresent(builder::endpointOverride);
 		Optional.ofNullable(this.properties.getEndpoint()).ifPresent(builder::endpointOverride);
 		Optional.ofNullable(this.properties.getCrossRegionEnabled()).ifPresent(builder::crossRegionAccessEnabled);

--- a/spring-cloud-aws-testcontainers/src/test/java/io/awspring/cloud/testcontainers/AwsContainerConnectionDetailsFactoryTest.java
+++ b/spring-cloud-aws-testcontainers/src/test/java/io/awspring/cloud/testcontainers/AwsContainerConnectionDetailsFactoryTest.java
@@ -30,6 +30,8 @@ import io.awspring.cloud.autoconfigure.ses.SesAutoConfiguration;
 import io.awspring.cloud.autoconfigure.sns.SnsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration;
 import io.awspring.cloud.s3.S3Template;
+import java.net.URL;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
@@ -46,9 +48,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.ses.SesClient;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
-
-import java.net.URL;
-import java.time.Duration;
 
 @SpringJUnitConfig
 @Testcontainers(disabledWithoutDocker = true)
@@ -97,9 +96,8 @@ class AwsContainerConnectionDetailsFactoryTest {
 	@Test
 	void configuresS3PresignedWithServiceConnection(@Autowired S3Template s3Template) {
 		URL signedGetURL = s3Template.createSignedGetURL("foo", "bar", Duration.ofMinutes(1));
-		assertThat(signedGetURL.getHost()).isNotNull()
-			.isNotEqualTo("foo.s3.amazonaws.com")
-			.as("Signed URL does not point to AWS as the endpoint has been overwritten by @ServiceConnection");
+		assertThat(signedGetURL.getHost()).isNotNull().isNotEqualTo("foo.s3.amazonaws.com")
+				.as("Signed URL does not point to AWS as the endpoint has been overwritten by @ServiceConnection");
 	}
 
 	@Test

--- a/spring-cloud-aws-testcontainers/src/test/java/io/awspring/cloud/testcontainers/AwsContainerConnectionDetailsFactoryTest.java
+++ b/spring-cloud-aws-testcontainers/src/test/java/io/awspring/cloud/testcontainers/AwsContainerConnectionDetailsFactoryTest.java
@@ -29,6 +29,7 @@ import io.awspring.cloud.autoconfigure.s3.S3CrtAsyncClientAutoConfiguration;
 import io.awspring.cloud.autoconfigure.ses.SesAutoConfiguration;
 import io.awspring.cloud.autoconfigure.sns.SnsAutoConfiguration;
 import io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration;
+import io.awspring.cloud.s3.S3Template;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
@@ -45,6 +46,9 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.ses.SesClient;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+import java.net.URL;
+import java.time.Duration;
 
 @SpringJUnitConfig
 @Testcontainers(disabledWithoutDocker = true)
@@ -88,6 +92,14 @@ class AwsContainerConnectionDetailsFactoryTest {
 	@Test
 	void configuresS3ClientWithServiceConnection(@Autowired S3Client client) {
 		assertThatCode(client::listBuckets).doesNotThrowAnyException();
+	}
+
+	@Test
+	void configuresS3PresignedWithServiceConnection(@Autowired S3Template s3Template) {
+		URL signedGetURL = s3Template.createSignedGetURL("foo", "bar", Duration.ofMinutes(1));
+		assertThat(signedGetURL.getHost()).isNotNull()
+			.isNotEqualTo("foo.s3.amazonaws.com")
+			.as("Signed URL does not point to AWS as the endpoint has been overwritten by @ServiceConnection");
 	}
 
 	@Test


### PR DESCRIPTION
`S3Presigner` auto-configuration did not take into account the endpoint override from `ConnectionDetails`.