### PR TITLE
Add SqqListenerFilter for use by the annotation processor

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -125,6 +126,7 @@ public abstract class AbstractListenerAnnotationBeanPostProcessor<A extends Anno
 		}
 		annotatedMethods.entrySet().stream()
 				.map(entry -> createAndConfigureEndpoint(bean, entry.getKey(), entry.getValue()))
+				.filter(Objects::nonNull)
 				.forEach(this.endpointRegistrar::registerEndpoint);
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
@@ -65,15 +65,15 @@ public class SqsListenerAnnotationBeanPostProcessor extends AbstractListenerAnno
 		}
 
 		return SqsEndpoint.builder().queueNames(resolveEndpointNames(sqsListenerAnnotation.value()))
-					.factoryBeanName(resolveAsString(sqsListenerAnnotation.factory(), "factory"))
-					.id(getEndpointId(sqsListenerAnnotation.id()))
-					.pollTimeoutSeconds(resolveAsInteger(sqsListenerAnnotation.pollTimeoutSeconds(), "pollTimeoutSeconds"))
-					.maxMessagesPerPoll(resolveAsInteger(sqsListenerAnnotation.maxMessagesPerPoll(), "maxMessagesPerPoll"))
-					.maxConcurrentMessages(
-							resolveAsInteger(sqsListenerAnnotation.maxConcurrentMessages(), "maxConcurrentMessages"))
-					.messageVisibility(
-							resolveAsInteger(sqsListenerAnnotation.messageVisibilitySeconds(), "messageVisibility"))
-					.acknowledgementMode(resolveAcknowledgement(sqsListenerAnnotation.acknowledgementMode())).build();
+				.factoryBeanName(resolveAsString(sqsListenerAnnotation.factory(), "factory"))
+				.id(getEndpointId(sqsListenerAnnotation.id()))
+				.pollTimeoutSeconds(resolveAsInteger(sqsListenerAnnotation.pollTimeoutSeconds(), "pollTimeoutSeconds"))
+				.maxMessagesPerPoll(resolveAsInteger(sqsListenerAnnotation.maxMessagesPerPoll(), "maxMessagesPerPoll"))
+				.maxConcurrentMessages(
+						resolveAsInteger(sqsListenerAnnotation.maxConcurrentMessages(), "maxConcurrentMessages"))
+				.messageVisibility(
+						resolveAsInteger(sqsListenerAnnotation.messageVisibilitySeconds(), "messageVisibility"))
+				.acknowledgementMode(resolveAcknowledgement(sqsListenerAnnotation.acknowledgementMode())).build();
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
@@ -29,7 +29,10 @@ import io.awspring.cloud.sqs.support.resolver.VisibilityHandlerMethodArgumentRes
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 
@@ -44,22 +47,33 @@ public class SqsListenerAnnotationBeanPostProcessor extends AbstractListenerAnno
 
 	private static final String GENERATED_ID_PREFIX = "io.awspring.cloud.sqs.sqsListenerEndpointContainer#";
 
+	private final List<SqsListenerFilter> filters;
+
+	public SqsListenerAnnotationBeanPostProcessor(Optional<List<SqsListenerFilter>> filters) {
+		this.filters = filters.orElseGet(Collections::emptyList);
+	}
+
 	@Override
 	protected Class<SqsListener> getAnnotationClass() {
 		return SqsListener.class;
 	}
 
+	@Override
 	protected Endpoint createEndpoint(SqsListener sqsListenerAnnotation) {
+		if (filters.stream().anyMatch(f -> !f.createEndpoint(sqsListenerAnnotation))) {
+			return null;
+		}
+
 		return SqsEndpoint.builder().queueNames(resolveEndpointNames(sqsListenerAnnotation.value()))
-				.factoryBeanName(resolveAsString(sqsListenerAnnotation.factory(), "factory"))
-				.id(getEndpointId(sqsListenerAnnotation.id()))
-				.pollTimeoutSeconds(resolveAsInteger(sqsListenerAnnotation.pollTimeoutSeconds(), "pollTimeoutSeconds"))
-				.maxMessagesPerPoll(resolveAsInteger(sqsListenerAnnotation.maxMessagesPerPoll(), "maxMessagesPerPoll"))
-				.maxConcurrentMessages(
-						resolveAsInteger(sqsListenerAnnotation.maxConcurrentMessages(), "maxConcurrentMessages"))
-				.messageVisibility(
-						resolveAsInteger(sqsListenerAnnotation.messageVisibilitySeconds(), "messageVisibility"))
-				.acknowledgementMode(resolveAcknowledgement(sqsListenerAnnotation.acknowledgementMode())).build();
+					.factoryBeanName(resolveAsString(sqsListenerAnnotation.factory(), "factory"))
+					.id(getEndpointId(sqsListenerAnnotation.id()))
+					.pollTimeoutSeconds(resolveAsInteger(sqsListenerAnnotation.pollTimeoutSeconds(), "pollTimeoutSeconds"))
+					.maxMessagesPerPoll(resolveAsInteger(sqsListenerAnnotation.maxMessagesPerPoll(), "maxMessagesPerPoll"))
+					.maxConcurrentMessages(
+							resolveAsInteger(sqsListenerAnnotation.maxConcurrentMessages(), "maxConcurrentMessages"))
+					.messageVisibility(
+							resolveAsInteger(sqsListenerAnnotation.messageVisibilitySeconds(), "messageVisibility"))
+					.acknowledgementMode(resolveAcknowledgement(sqsListenerAnnotation.acknowledgementMode())).build();
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerFilter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerFilter.java
@@ -1,0 +1,10 @@
+package io.awspring.cloud.sqs.annotation;
+
+/**
+ * Predicate interface to filter {@link SqsListener} annotations during bean post-processing.
+ */
+@FunctionalInterface
+public interface SqsListenerFilter {
+
+	boolean createEndpoint(SqsListener annotation);
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/EndpointRegistrar.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/EndpointRegistrar.java
@@ -206,7 +206,9 @@ public class EndpointRegistrar implements BeanFactoryAware, SmartInitializingSin
 	 * @param endpoint the endpoint.
 	 */
 	public void registerEndpoint(Endpoint endpoint) {
-		this.endpoints.add(endpoint);
+		if (endpoint != null) {
+			this.endpoints.add(endpoint);
+		}
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/SqsBootstrapConfiguration.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/SqsBootstrapConfiguration.java
@@ -35,7 +35,7 @@ public class SqsBootstrapConfiguration implements ImportBeanDefinitionRegistrar 
 	public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
 		if (!registry.containsBeanDefinition(SqsBeanNames.SQS_LISTENER_ANNOTATION_BEAN_POST_PROCESSOR_BEAN_NAME)) {
 			registry.registerBeanDefinition(SqsBeanNames.SQS_LISTENER_ANNOTATION_BEAN_POST_PROCESSOR_BEAN_NAME,
-					new RootBeanDefinition(SqsListenerAnnotationBeanPostProcessor.class));
+					new RootBeanDefinition(SqsListenerAnnotationBeanPostProcessor.class, RootBeanDefinition.AUTOWIRE_BY_TYPE, true));
 		}
 
 		if (!registry.containsBeanDefinition(SqsBeanNames.ENDPOINT_REGISTRY_BEAN_NAME)) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
In [a discussion about skipping certain `@SqsListener` annotation at runtime](https://github.com/awspring/spring-cloud-aws/discussions/1407), it was suggested to provide a more convenient mechanism for applications. This is a suggested implementation of that idea.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [x ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
