### PR TITLE
Add Error Handler Exponential and Linear Strategies

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -1380,6 +1380,181 @@ public SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFac
 }
 ----
 
+==== Exponential Backoff Full Jitter Error Handler
+This error handler applies an exponential backoff strategy with *full jitter*
+when retrying failed message processing. After calculating the exponential
+visibility timeout using the `ApproximateReceiveCount` message attribute, a
+random value between zero and the computed timeout is selected. The selected
+value becomes the new visibility timeout, spreading retries and helping to
+avoid spikes caused by synchronized retries.
+
+[cols="2,3,1,1"]
+|===
+| Name | Description | Required | Default
+| `initialVisibilityTimeoutSeconds` | Starting visibility timeout (in seconds)
+used on the first receive attempt. | No | 100
+| `multiplier` | Factor applied to the visibility timeout after each retry. A
+value greater than 1 increases the delay exponentially. | No | 2.0
+| `maxVisibilityTimeoutSeconds` | Maximum allowed visibility timeout in seconds.
+| No | 43200
+| `randomSupplier` | Supplier for the random value used to calculate the
+jitter. | No | `ThreadLocalRandom::current`
+|===
+
+NOTE: The maximum visibility timeout allowed by SQS is 43200 seconds (12 hours).
+If the value provided to the `maxVisibilityTimeoutSeconds` parameter exceeds
+this limit, an `IllegalArgumentException` will be thrown.
+
+When using auto-configured factory, simply declare a `@Bean` and the error
+handler will be set
+
+[source, java]
+----
+@Bean
+public ExponentialBackoffErrorHandlerWithFullJitter<Object> asyncErrorHandler() {
+        return ExponentialBackoffErrorHandlerWithFullJitter
+                .builder()
+                .initialVisibilityTimeoutSeconds(1)
+                .multiplier(2)
+                .maxVisibilityTimeoutSeconds(10)
+                .build();
+}
+----
+
+Alternatively, `ExponentialBackoffErrorHandlerWithFullJitter` can be set in the
+`MessageListenerContainerFactory` or directly in the `MessageListenerContainer`:
+
+[source, java]
+----
+@Bean
+public SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFactory() {
+        return SqsMessageListenerContainerFactory
+                .builder()
+                .sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
+                .errorHandler(ExponentialBackoffErrorHandlerWithFullJitter
+                        .builder()
+                        .initialVisibilityTimeoutSeconds(1)
+                        .multiplier(2)
+                        .maxVisibilityTimeoutSeconds(10)
+                        .build())
+                .build();
+}
+----
+
+==== Exponential Backoff Half Jitter Error Handler
+This variant also computes the visibility timeout exponentially but applies
+*half jitter*. The exponential delay is halved and a random value between zero
+and this half is added to it. The resulting timeout is then used to change the
+message visibility.
+
+[cols="2,3,1,1"]
+|===
+| Name | Description | Required | Default
+| `initialVisibilityTimeoutSeconds` | Starting visibility timeout (in seconds)
+used on the first receive attempt. | No | 100
+| `multiplier` | Factor applied to the visibility timeout after each retry. A
+value greater than 1 increases the delay exponentially. | No | 2.0
+| `maxVisibilityTimeoutSeconds` | Maximum allowed visibility timeout in seconds.
+| No | 43200
+| `randomSupplier` | Supplier for the random value used to calculate the
+jitter. | No | `ThreadLocalRandom::current`
+|===
+
+NOTE: The maximum visibility timeout allowed by SQS is 43200 seconds (12 hours).
+If the value provided to the `maxVisibilityTimeoutSeconds` parameter exceeds
+this limit, an `IllegalArgumentException` will be thrown.
+
+When using auto-configured factory, simply declare a `@Bean` and the error
+handler will be set
+
+[source, java]
+----
+@Bean
+public ExponentialBackoffErrorHandlerWithHalfJitter<Object> asyncErrorHandler() {
+        return ExponentialBackoffErrorHandlerWithHalfJitter
+                .builder()
+                .initialVisibilityTimeoutSeconds(1)
+                .multiplier(2)
+                .maxVisibilityTimeoutSeconds(10)
+                .build();
+}
+----
+
+Alternatively, `ExponentialBackoffErrorHandlerWithHalfJitter` can be set in the
+`MessageListenerContainerFactory` or directly in the `MessageListenerContainer`:
+
+[source, java]
+----
+@Bean
+public SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFactory() {
+        return SqsMessageListenerContainerFactory
+                .builder()
+                .sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
+                .errorHandler(ExponentialBackoffErrorHandlerWithHalfJitter
+                        .builder()
+                        .initialVisibilityTimeoutSeconds(1)
+                        .multiplier(2)
+                        .maxVisibilityTimeoutSeconds(10)
+                        .build())
+                .build();
+}
+----
+
+==== Linear Backoff Error Handler
+`LinearBackoffErrorHandler` increases the visibility timeout linearly whenever a
+message processing attempt fails. Instead of exponential growth, the timeout is
+incremented by a fixed value on each retry until the maximum is reached.
+
+[cols="2,3,1,1"]
+|===
+| Name | Description | Required | Default
+| `initialVisibilityTimeoutSeconds` | Initial visibility timeout (in seconds) for
+the first processing attempt. | No | 100
+| `increment` | Amount of seconds added to the visibility timeout after each
+retry. | No | 2
+| `maxVisibilityTimeoutSeconds` | Maximum allowed visibility timeout in seconds.
+| No | 43200
+|===
+
+NOTE: The maximum visibility timeout allowed by SQS is 43200 seconds (12 hours).
+If the value provided to the `maxVisibilityTimeoutSeconds` parameter exceeds
+this limit, an `IllegalArgumentException` will be thrown.
+
+When using auto-configured factory, simply declare a `@Bean` and the error
+handler will be set
+
+[source, java]
+----
+@Bean
+public LinearBackoffErrorHandler<Object> asyncErrorHandler() {
+        return LinearBackoffErrorHandler
+                .builder()
+                .initialVisibilityTimeoutSeconds(1)
+                .increment(2)
+                .maxVisibilityTimeoutSeconds(10)
+                .build();
+}
+----
+
+Alternatively, `LinearBackoffErrorHandler` can be set in the
+`MessageListenerContainerFactory` or directly in the `MessageListenerContainer`:
+
+[source, java]
+----
+@Bean
+public SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFactory() {
+        return SqsMessageListenerContainerFactory
+                .builder()
+                .sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
+                .errorHandler(LinearBackoffErrorHandler
+                        .builder()
+                        .initialVisibilityTimeoutSeconds(1)
+                        .increment(2)
+                        .maxVisibilityTimeoutSeconds(10)
+                        .build())
+                .build();
+}
+----
 === Message Conversion and Payload Deserialization
 
 Payloads are automatically deserialized from `JSON` for `@SqsListener` annotated methods using a `MappingJackson2MessageConverter`.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/errorhandler/BackoffVisibilityConstants.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/errorhandler/BackoffVisibilityConstants.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.errorhandler;
+
+import io.awspring.cloud.sqs.listener.Visibility;
+
+/**
+ * Constants for Backoff Error Handler.
+ *
+ * @author Bruno Garcia
+ * @author Rafael Pavarini
+ */
+public class BackoffVisibilityConstants {
+	/**
+	 * The default initial visibility timeout.
+	 */
+	static final int DEFAULT_INITIAL_VISIBILITY_TIMEOUT_SECONDS = 100;
+
+	/**
+	 * The default multiplier, which doubles the visibility timeout.
+	 */
+	static final double DEFAULT_MULTIPLIER = 2.0;
+	/**
+	 * The default increment used by {@link LinearBackoffErrorHandler}.
+	 */
+	static final int DEFAULT_INCREMENT = 2;
+
+	static final int DEFAULT_MAX_VISIBILITY_TIMEOUT_SECONDS = Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS;
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/errorhandler/ExponentialBackoffErrorHandlerWithFullJitter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/errorhandler/ExponentialBackoffErrorHandlerWithFullJitter.java
@@ -19,14 +19,17 @@ import io.awspring.cloud.sqs.MessageHeaderUtils;
 import io.awspring.cloud.sqs.listener.BatchVisibility;
 import io.awspring.cloud.sqs.listener.Visibility;
 import java.util.Collection;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
 /**
- * An implementation of an Exponential Backoff error handler for asynchronous message processing.
+ * An implementation of an Exponential Backoff with full jitter error handler for asynchronous message processing.
  *
  * <p>
  * This error handler sets the SQS message visibility timeout exponentially based on the number of received attempts
@@ -39,34 +42,36 @@ import org.springframework.util.Assert;
  * @author Bruno Garcia
  * @author Rafael Pavarini
  */
-
-public class ExponentialBackoffErrorHandler<T> implements AsyncErrorHandler<T> {
-	private static final Logger logger = LoggerFactory.getLogger(ExponentialBackoffErrorHandler.class);
+public class ExponentialBackoffErrorHandlerWithFullJitter<T> implements AsyncErrorHandler<T> {
+	private static final Logger logger = LoggerFactory.getLogger(ExponentialBackoffErrorHandlerWithFullJitter.class);
 
 	private final int initialVisibilityTimeoutSeconds;
 	private final double multiplier;
 	private final int maxVisibilityTimeoutSeconds;
+	private final Supplier<Random> randomSupplier;
 
-	private ExponentialBackoffErrorHandler(int initialVisibilityTimeoutSeconds, double multiplier,
-			int maxVisibilityTimeoutSeconds) {
+	private ExponentialBackoffErrorHandlerWithFullJitter(int initialVisibilityTimeoutSeconds, double multiplier,
+			int maxVisibilityTimeoutSeconds, Supplier<Random> randomSupplier) {
 		this.initialVisibilityTimeoutSeconds = initialVisibilityTimeoutSeconds;
 		this.multiplier = multiplier;
 		this.maxVisibilityTimeoutSeconds = maxVisibilityTimeoutSeconds;
+		this.randomSupplier = randomSupplier;
 	}
 
 	@Override
 	public CompletableFuture<Void> handle(Message<T> message, Throwable t) {
-		return applyExponentialBackoffVisibilityTimeout(message)
+		return applyExponentialBackoffVisibilityTimeoutWithFullJitter(message)
 				.thenCompose(theVoid -> CompletableFuture.failedFuture(t));
 	}
 
 	@Override
 	public CompletableFuture<Void> handle(Collection<Message<T>> messages, Throwable t) {
-		return applyExponentialBackoffVisibilityTimeout(messages)
+		return applyExponentialBackoffVisibilityTimeoutWithFullJitter(messages)
 				.thenCompose(theVoid -> CompletableFuture.failedFuture(t));
 	}
 
-	private CompletableFuture<Void> applyExponentialBackoffVisibilityTimeout(Collection<Message<T>> messages) {
+	private CompletableFuture<Void> applyExponentialBackoffVisibilityTimeoutWithFullJitter(
+			Collection<Message<T>> messages) {
 		CompletableFuture<?>[] futures = ErrorHandlerVisibilityHelper.groupMessagesByReceiveMessageCount(messages)
 				.entrySet().stream().map(entry -> {
 					int timeout = calculateTimeout(entry.getKey());
@@ -87,7 +92,7 @@ public class ExponentialBackoffErrorHandler<T> implements AsyncErrorHandler<T> {
 		});
 	}
 
-	private CompletableFuture<Void> applyExponentialBackoffVisibilityTimeout(Message<T> message) {
+	private CompletableFuture<Void> applyExponentialBackoffVisibilityTimeoutWithFullJitter(Message<T> message) {
 		int timeout = calculateTimeout(message);
 		Visibility visibility = ErrorHandlerVisibilityHelper.getVisibility(message);
 		logger.debug("Changing visibility timeout to {} - Message Id {}", timeout, message.getHeaders().getId());
@@ -104,12 +109,13 @@ public class ExponentialBackoffErrorHandler<T> implements AsyncErrorHandler<T> {
 	}
 
 	private int calculateTimeout(long receiveMessageCount) {
-		return ErrorHandlerVisibilityHelper.calculateVisibilityTimeoutExponentially(receiveMessageCount,
+		int timeout = ErrorHandlerVisibilityHelper.calculateVisibilityTimeoutExponentially(receiveMessageCount,
 				initialVisibilityTimeoutSeconds, multiplier, maxVisibilityTimeoutSeconds);
+		return randomSupplier.get().nextInt(timeout + 1);
 	}
 
-	public static <T> Builder<T> builder() {
-		return new Builder<>();
+	public static <T> ExponentialBackoffErrorHandlerWithFullJitter.Builder<T> builder() {
+		return new ExponentialBackoffErrorHandlerWithFullJitter.Builder<>();
 	}
 
 	public static class Builder<T> {
@@ -117,31 +123,40 @@ public class ExponentialBackoffErrorHandler<T> implements AsyncErrorHandler<T> {
 		private int initialVisibilityTimeoutSeconds = BackoffVisibilityConstants.DEFAULT_INITIAL_VISIBILITY_TIMEOUT_SECONDS;
 		private double multiplier = BackoffVisibilityConstants.DEFAULT_MULTIPLIER;
 		private int maxVisibilityTimeoutSeconds = BackoffVisibilityConstants.DEFAULT_MAX_VISIBILITY_TIMEOUT_SECONDS;
+		private Supplier<Random> randomSupplier = ThreadLocalRandom::current;
 
-		public Builder<T> initialVisibilityTimeoutSeconds(int initialVisibilityTimeoutSeconds) {
+		public ExponentialBackoffErrorHandlerWithFullJitter.Builder<T> initialVisibilityTimeoutSeconds(
+				int initialVisibilityTimeoutSeconds) {
 			ErrorHandlerVisibilityHelper.checkVisibilityTimeout(initialVisibilityTimeoutSeconds);
 			this.initialVisibilityTimeoutSeconds = initialVisibilityTimeoutSeconds;
 			return this;
 		}
 
-		public Builder<T> multiplier(double multiplier) {
+		public ExponentialBackoffErrorHandlerWithFullJitter.Builder<T> multiplier(double multiplier) {
 			Assert.isTrue(multiplier >= 1,
 					() -> "Invalid multiplier '" + multiplier + "'. Should be greater than " + "or equal to 1.");
 			this.multiplier = multiplier;
 			return this;
 		}
 
-		public Builder<T> maxVisibilityTimeoutSeconds(int maxVisibilityTimeoutSeconds) {
+		public ExponentialBackoffErrorHandlerWithFullJitter.Builder<T> maxVisibilityTimeoutSeconds(
+				int maxVisibilityTimeoutSeconds) {
 			ErrorHandlerVisibilityHelper.checkVisibilityTimeout(maxVisibilityTimeoutSeconds);
 			this.maxVisibilityTimeoutSeconds = maxVisibilityTimeoutSeconds;
 			return this;
 		}
 
-		public ExponentialBackoffErrorHandler<T> build() {
+		public ExponentialBackoffErrorHandlerWithFullJitter.Builder<T> randomSupplier(Supplier<Random> randomSupplier) {
+			Assert.notNull(randomSupplier, "randomSupplier cannot be null");
+			this.randomSupplier = randomSupplier;
+			return this;
+		}
+
+		public ExponentialBackoffErrorHandlerWithFullJitter<T> build() {
 			Assert.isTrue(initialVisibilityTimeoutSeconds <= maxVisibilityTimeoutSeconds,
 					"Initial visibility timeout must not exceed max visibility timeout");
-			return new ExponentialBackoffErrorHandler<>(initialVisibilityTimeoutSeconds, multiplier,
-					maxVisibilityTimeoutSeconds);
+			return new ExponentialBackoffErrorHandlerWithFullJitter<>(initialVisibilityTimeoutSeconds, multiplier,
+					maxVisibilityTimeoutSeconds, randomSupplier);
 		}
 	}
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/errorhandler/ExponentialBackoffErrorHandlerWithHalfJitter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/errorhandler/ExponentialBackoffErrorHandlerWithHalfJitter.java
@@ -19,14 +19,17 @@ import io.awspring.cloud.sqs.MessageHeaderUtils;
 import io.awspring.cloud.sqs.listener.BatchVisibility;
 import io.awspring.cloud.sqs.listener.Visibility;
 import java.util.Collection;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
 /**
- * An implementation of an Exponential Backoff error handler for asynchronous message processing.
+ * An implementation of an Exponential Backoff with half-jitter error handler for asynchronous message processing.
  *
  * <p>
  * This error handler sets the SQS message visibility timeout exponentially based on the number of received attempts
@@ -39,34 +42,36 @@ import org.springframework.util.Assert;
  * @author Bruno Garcia
  * @author Rafael Pavarini
  */
-
-public class ExponentialBackoffErrorHandler<T> implements AsyncErrorHandler<T> {
-	private static final Logger logger = LoggerFactory.getLogger(ExponentialBackoffErrorHandler.class);
+public class ExponentialBackoffErrorHandlerWithHalfJitter<T> implements AsyncErrorHandler<T> {
+	private static final Logger logger = LoggerFactory.getLogger(ExponentialBackoffErrorHandlerWithHalfJitter.class);
 
 	private final int initialVisibilityTimeoutSeconds;
 	private final double multiplier;
 	private final int maxVisibilityTimeoutSeconds;
+	private final Supplier<Random> randomSupplier;
 
-	private ExponentialBackoffErrorHandler(int initialVisibilityTimeoutSeconds, double multiplier,
-			int maxVisibilityTimeoutSeconds) {
+	private ExponentialBackoffErrorHandlerWithHalfJitter(int initialVisibilityTimeoutSeconds, double multiplier,
+			int maxVisibilityTimeoutSeconds, Supplier<Random> randomSupplier) {
 		this.initialVisibilityTimeoutSeconds = initialVisibilityTimeoutSeconds;
 		this.multiplier = multiplier;
 		this.maxVisibilityTimeoutSeconds = maxVisibilityTimeoutSeconds;
+		this.randomSupplier = randomSupplier;
 	}
 
 	@Override
 	public CompletableFuture<Void> handle(Message<T> message, Throwable t) {
-		return applyExponentialBackoffVisibilityTimeout(message)
+		return applyExponentialBackoffVisibilityTimeoutWithHalfJitter(message)
 				.thenCompose(theVoid -> CompletableFuture.failedFuture(t));
 	}
 
 	@Override
 	public CompletableFuture<Void> handle(Collection<Message<T>> messages, Throwable t) {
-		return applyExponentialBackoffVisibilityTimeout(messages)
+		return applyExponentialBackoffVisibilityTimeoutWithHalfJitter(messages)
 				.thenCompose(theVoid -> CompletableFuture.failedFuture(t));
 	}
 
-	private CompletableFuture<Void> applyExponentialBackoffVisibilityTimeout(Collection<Message<T>> messages) {
+	private CompletableFuture<Void> applyExponentialBackoffVisibilityTimeoutWithHalfJitter(
+			Collection<Message<T>> messages) {
 		CompletableFuture<?>[] futures = ErrorHandlerVisibilityHelper.groupMessagesByReceiveMessageCount(messages)
 				.entrySet().stream().map(entry -> {
 					int timeout = calculateTimeout(entry.getKey());
@@ -87,7 +92,7 @@ public class ExponentialBackoffErrorHandler<T> implements AsyncErrorHandler<T> {
 		});
 	}
 
-	private CompletableFuture<Void> applyExponentialBackoffVisibilityTimeout(Message<T> message) {
+	private CompletableFuture<Void> applyExponentialBackoffVisibilityTimeoutWithHalfJitter(Message<T> message) {
 		int timeout = calculateTimeout(message);
 		Visibility visibility = ErrorHandlerVisibilityHelper.getVisibility(message);
 		logger.debug("Changing visibility timeout to {} - Message Id {}", timeout, message.getHeaders().getId());
@@ -104,12 +109,15 @@ public class ExponentialBackoffErrorHandler<T> implements AsyncErrorHandler<T> {
 	}
 
 	private int calculateTimeout(long receiveMessageCount) {
-		return ErrorHandlerVisibilityHelper.calculateVisibilityTimeoutExponentially(receiveMessageCount,
+		int timeout = ErrorHandlerVisibilityHelper.calculateVisibilityTimeoutExponentially(receiveMessageCount,
 				initialVisibilityTimeoutSeconds, multiplier, maxVisibilityTimeoutSeconds);
+		int half = timeout / 2;
+		int jitter = randomSupplier.get().nextInt(0, half + 1);
+		return half + jitter;
 	}
 
-	public static <T> Builder<T> builder() {
-		return new Builder<>();
+	public static <T> ExponentialBackoffErrorHandlerWithHalfJitter.Builder<T> builder() {
+		return new ExponentialBackoffErrorHandlerWithHalfJitter.Builder<>();
 	}
 
 	public static class Builder<T> {
@@ -117,31 +125,40 @@ public class ExponentialBackoffErrorHandler<T> implements AsyncErrorHandler<T> {
 		private int initialVisibilityTimeoutSeconds = BackoffVisibilityConstants.DEFAULT_INITIAL_VISIBILITY_TIMEOUT_SECONDS;
 		private double multiplier = BackoffVisibilityConstants.DEFAULT_MULTIPLIER;
 		private int maxVisibilityTimeoutSeconds = BackoffVisibilityConstants.DEFAULT_MAX_VISIBILITY_TIMEOUT_SECONDS;
+		private Supplier<Random> randomSupplier = ThreadLocalRandom::current;
 
-		public Builder<T> initialVisibilityTimeoutSeconds(int initialVisibilityTimeoutSeconds) {
+		public ExponentialBackoffErrorHandlerWithHalfJitter.Builder<T> randomSupplier(Supplier<Random> randomSupplier) {
+			Assert.notNull(randomSupplier, "randomSupplier cannot be null");
+			this.randomSupplier = randomSupplier;
+			return this;
+		}
+
+		public ExponentialBackoffErrorHandlerWithHalfJitter.Builder<T> initialVisibilityTimeoutSeconds(
+				int initialVisibilityTimeoutSeconds) {
 			ErrorHandlerVisibilityHelper.checkVisibilityTimeout(initialVisibilityTimeoutSeconds);
 			this.initialVisibilityTimeoutSeconds = initialVisibilityTimeoutSeconds;
 			return this;
 		}
 
-		public Builder<T> multiplier(double multiplier) {
+		public ExponentialBackoffErrorHandlerWithHalfJitter.Builder<T> multiplier(double multiplier) {
 			Assert.isTrue(multiplier >= 1,
 					() -> "Invalid multiplier '" + multiplier + "'. Should be greater than " + "or equal to 1.");
 			this.multiplier = multiplier;
 			return this;
 		}
 
-		public Builder<T> maxVisibilityTimeoutSeconds(int maxVisibilityTimeoutSeconds) {
+		public ExponentialBackoffErrorHandlerWithHalfJitter.Builder<T> maxVisibilityTimeoutSeconds(
+				int maxVisibilityTimeoutSeconds) {
 			ErrorHandlerVisibilityHelper.checkVisibilityTimeout(maxVisibilityTimeoutSeconds);
 			this.maxVisibilityTimeoutSeconds = maxVisibilityTimeoutSeconds;
 			return this;
 		}
 
-		public ExponentialBackoffErrorHandler<T> build() {
+		public ExponentialBackoffErrorHandlerWithHalfJitter<T> build() {
 			Assert.isTrue(initialVisibilityTimeoutSeconds <= maxVisibilityTimeoutSeconds,
 					"Initial visibility timeout must not exceed max visibility timeout");
-			return new ExponentialBackoffErrorHandler<>(initialVisibilityTimeoutSeconds, multiplier,
-					maxVisibilityTimeoutSeconds);
+			return new ExponentialBackoffErrorHandlerWithHalfJitter<>(initialVisibilityTimeoutSeconds, multiplier,
+					maxVisibilityTimeoutSeconds, randomSupplier);
 		}
 	}
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsErrorHandlerIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsErrorHandlerIntegrationTests.java
@@ -17,6 +17,7 @@ package io.awspring.cloud.sqs.integration;
 
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.sqs.MessageHeaderUtils;
@@ -24,8 +25,8 @@ import io.awspring.cloud.sqs.annotation.SqsListener;
 import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration;
 import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
-import io.awspring.cloud.sqs.listener.errorhandler.ExponentialBackoffErrorHandler;
-import io.awspring.cloud.sqs.listener.errorhandler.ImmediateRetryAsyncErrorHandler;
+import io.awspring.cloud.sqs.listener.Visibility;
+import io.awspring.cloud.sqs.listener.errorhandler.*;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.time.Duration;
 import java.util.*;
@@ -33,8 +34,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -75,6 +78,21 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 
 	static final String SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_FACTORY = "receivesMessageExponentialErrorFactory";
 
+	static final String SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_QUEUE = "success_exponential_full_jitter_backoff_error_handler";
+
+	static final String SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_FACTORY = "success_exponential_full_jitter_backoff_error_handler_factory";
+
+	static final String SUCCESS_EXPONENTIAL_HALF_JITTER_BACKOFF_ERROR_HANDLER_QUEUE = "success_exponential_half_jitter_backoff_error_handler";
+	static final String SUCCESS_EXPONENTIAL_HALF_JITTER_BACKOFF_ERROR_HANDLER_FACTORY = "success_exponential_half_jitter_backoff_error_handler_factory";
+	static final String SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_BATCH_QUEUE = "success_exponential_full_jitter_backoff_error_handler_batch";
+
+	static final String SUCCESS_EXPONENTIAL_HALF_JITTER_BACKOFF_ERROR_HANDLER_BATCH_QUEUE = "success_exponential_half_jitter_backoff_error_handler_batch";
+
+	static final String SUCCESS_LINEAR_BACKOFF_ERROR_HANDLER_BATCH_QUEUE = "success_linear_backoff_error_handler_batch";
+	static final String SUCCESS_LINEAR_BACKOFF_ERROR_HANDLER_QUEUE = "success_linear_backoff_error_handler";
+
+	static final String SUCCESS_LINEAR_BACKOFF_ERROR_HANDLER_FACTORY = "success_linear_backoff_error_handler_factory";
+
 	@BeforeAll
 	static void beforeTests() {
 		SqsAsyncClient client = createAsyncClient();
@@ -84,7 +102,12 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 				createQueue(client, SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_BATCH_QUEUE_NAME,
 						singletonMap(QueueAttributeName.VISIBILITY_TIMEOUT, "500")),
 				createQueue(client, SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_QUEUE_NAME),
-				createQueue(client, SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_BATCH_QUEUE_NAME)).join();
+				createQueue(client, SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_BATCH_QUEUE_NAME),
+				createQueue(client, SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_QUEUE),
+				createQueue(client, SUCCESS_EXPONENTIAL_HALF_JITTER_BACKOFF_ERROR_HANDLER_QUEUE),
+				createQueue(client, SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_BATCH_QUEUE),
+				createQueue(client, SUCCESS_EXPONENTIAL_HALF_JITTER_BACKOFF_ERROR_HANDLER_BATCH_QUEUE),
+				createQueue(client, SUCCESS_LINEAR_BACKOFF_ERROR_HANDLER_BATCH_QUEUE)).join();
 	}
 
 	@Autowired
@@ -118,13 +141,46 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 	}
 
 	@Test
+	void receivesMessageLinearBackOffErrorHandler() throws Exception {
+		String messageBody = UUID.randomUUID().toString();
+		sqsTemplate.send(SUCCESS_LINEAR_BACKOFF_ERROR_HANDLER_QUEUE, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}", SUCCESS_LINEAR_BACKOFF_ERROR_HANDLER_QUEUE,
+				messageBody);
+
+		await().atLeast(20, TimeUnit.SECONDS).atMost(30, TimeUnit.SECONDS)
+				.until(() -> latchContainer.receivesRetryMessageLinearlyLatch.getCount() == 0);
+
+	}
+
+	@Test
 	void receivesMessageExponentialBackOffErrorHandler() throws Exception {
 		String messageBody = UUID.randomUUID().toString();
 		sqsTemplate.send(SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}",
 				SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_QUEUE_NAME, messageBody);
+		await().atLeast(10, TimeUnit.SECONDS).atMost(20, TimeUnit.SECONDS)
+				.until(() -> latchContainer.receivesRetryMessageExponentiallyLatch.getCount() == 0);
+	}
 
-		assertThat(latchContainer.receivesRetryMessageExponentiallyLatch.await(20, TimeUnit.SECONDS)).isTrue();
+	@Test
+	void receivesMessageExponentialFullJitterBackOffErrorHandler() throws Exception {
+		String messageBody = UUID.randomUUID().toString();
+		sqsTemplate.send(SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_QUEUE, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}",
+				SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_QUEUE, messageBody);
+
+		await().atLeast(64, TimeUnit.SECONDS).atMost(72, TimeUnit.SECONDS)
+				.until(() -> latchContainer.receivesRetryMessageFullJitterLatch.getCount() == 0);
+	}
+
+	@Test
+	void receivesMessageExponentialHalfJitterBackOffErrorHandler() throws Exception {
+		String messageBody = UUID.randomUUID().toString();
+		sqsTemplate.send(SUCCESS_EXPONENTIAL_HALF_JITTER_BACKOFF_ERROR_HANDLER_QUEUE, messageBody);
+		logger.debug("Sent message to queue {} with messageBody {}",
+				SUCCESS_EXPONENTIAL_HALF_JITTER_BACKOFF_ERROR_HANDLER_QUEUE, messageBody);
+
+		assertThat(latchContainer.receivesRetryMessageHalfJitterLatch.await(64, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -136,6 +192,41 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 				SUCCESS_EXPONENTIAL_BACKOFF_ERROR_HANDLER_BATCH_QUEUE_NAME, messages);
 
 		assertThat(latchContainer.receivesRetryBatchMessageExponentiallyLatch.await(35, TimeUnit.SECONDS)).isTrue();
+	}
+
+	@Test
+	void receivesBatchMessageExponentialFullJitterBackOffErrorHandler() throws Exception {
+		List<Message<String>> messages = create10Messages(
+				"receivesBatchMessageExponentialFullJitterBackOffErrorHandler");
+
+		sqsTemplate.sendManyAsync(SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_BATCH_QUEUE, messages);
+		logger.debug("Sent message to queue {} with messageBody {}",
+				SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_BATCH_QUEUE, messages);
+		await().atLeast(64, TimeUnit.SECONDS).atMost(72, TimeUnit.SECONDS)
+				.until(() -> latchContainer.receivesRetryBatchMessageFullJitterLatch.getCount() == 0);
+	}
+
+	@Test
+	void receivesBatchMessageExponentialHalfJitterBackOffErrorHandler() throws Exception {
+		List<Message<String>> messages = create10Messages(
+				"receivesBatchMessageExponentialHalfJitterBackOffErrorHandler");
+
+		sqsTemplate.sendManyAsync(SUCCESS_EXPONENTIAL_HALF_JITTER_BACKOFF_ERROR_HANDLER_BATCH_QUEUE, messages);
+		logger.debug("Sent message to queue {} with messageBody {}",
+				SUCCESS_EXPONENTIAL_HALF_JITTER_BACKOFF_ERROR_HANDLER_BATCH_QUEUE, messages);
+		await().atLeast(50, TimeUnit.SECONDS).atMost(64, TimeUnit.SECONDS)
+				.until(() -> latchContainer.receivesRetryBatchMessageHalfJitterLatch.getCount() == 0);
+	}
+
+	@Test
+	void receivesBatchMessageLinearBackOffErrorHandler() throws Exception {
+		List<Message<String>> messages = create10Messages("receivesBatchMessageLinearBackOffErrorHandler");
+
+		sqsTemplate.sendManyAsync(SUCCESS_LINEAR_BACKOFF_ERROR_HANDLER_BATCH_QUEUE, messages);
+		logger.debug("Sent message to queue {} with messageBody {}", SUCCESS_LINEAR_BACKOFF_ERROR_HANDLER_BATCH_QUEUE,
+				messages);
+		await().atLeast(20, TimeUnit.SECONDS).atMost(30, TimeUnit.SECONDS)
+				.until(() -> latchContainer.receivesRetryBatchMessageLinearlyLatch.getCount() == 0);
 	}
 
 	static class ImmediateRetryAsyncErrorHandlerListener {
@@ -235,6 +326,100 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		}
 	}
 
+	static class ExponentialBackOffJitterErrorHandlerListener {
+		@Autowired
+		LatchContainer latchContainer;
+		static Double multiplier = 2.0;
+		static Integer initialValueSeconds = 2;
+		long firstReceiveTimestamp;
+
+		@SqsListener(queueNames = SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_QUEUE, factory = SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_FACTORY, id = "visibilityExponentialFullJitterErrorHandler")
+		CompletableFuture<Void> listen(Message<String> message,
+				@Header(SqsHeaders.SQS_QUEUE_NAME_HEADER) String queueName) {
+			logger.info("Received message {} from queue {}", message, queueName);
+
+			long receiveCount = Long.parseLong(MessageHeaderUtils.getHeader(message,
+					SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class));
+
+			if (receiveCount < 7) {
+				return CompletableFuture.failedFuture(
+						new RuntimeException("Expected exception from visibilityExponentialErrorHandler"));
+			}
+
+			firstReceiveTimestamp = Long.parseLong(MessageHeaderUtils.getHeader(message,
+					SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_FIRST_RECEIVE_TIMESTAMP, String.class));
+			long currentTimestamp = MessageHeaderUtils.getHeader(message, MessageHeaders.TIMESTAMP, Long.class);
+
+			long elapsedTimeBetweenMessageReceivesInSeconds = (currentTimestamp - firstReceiveTimestamp) / 1000;
+			long expectedElapsedTime = calculateJitterTotalElapsedExpectedTime(receiveCount, false);
+			if (elapsedTimeBetweenMessageReceivesInSeconds >= expectedElapsedTime) {
+				latchContainer.receivesRetryMessageFullJitterLatch.countDown();
+			}
+
+			return CompletableFuture.completedFuture(null);
+		}
+
+		@SqsListener(queueNames = SUCCESS_EXPONENTIAL_HALF_JITTER_BACKOFF_ERROR_HANDLER_QUEUE, factory = SUCCESS_EXPONENTIAL_HALF_JITTER_BACKOFF_ERROR_HANDLER_FACTORY, id = "visibilityExponentialHalfJitterErrorHandler")
+		CompletableFuture<Void> listenHalf(Message<String> message,
+				@Header(SqsHeaders.SQS_QUEUE_NAME_HEADER) String queueName) {
+			logger.info("Received message {} from queue {}", message, queueName);
+
+			long receiveCount = Long.parseLong(MessageHeaderUtils.getHeader(message,
+					SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class));
+
+			if (receiveCount < 6) {
+				return CompletableFuture.failedFuture(
+						new RuntimeException("Expected exception from visibilityExponentialErrorHandler"));
+			}
+
+			firstReceiveTimestamp = Long.parseLong(MessageHeaderUtils.getHeader(message,
+					SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_FIRST_RECEIVE_TIMESTAMP, String.class));
+			long currentTimestamp = MessageHeaderUtils.getHeader(message, MessageHeaders.TIMESTAMP, Long.class);
+
+			long elapsedTimeBetweenMessageReceivesInSeconds = (currentTimestamp - firstReceiveTimestamp) / 1000;
+			long expectedElapsedTime = calculateJitterTotalElapsedExpectedTime(receiveCount, true);
+			if (elapsedTimeBetweenMessageReceivesInSeconds >= expectedElapsedTime) {
+				latchContainer.receivesRetryMessageHalfJitterLatch.countDown();
+			}
+
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+	static class LinearBackOffErrorHandlerListener {
+		@Autowired
+		LatchContainer latchContainer;
+		static int increment = 2;
+		static int initialValueSeconds = 2;
+		long firstReceiveTimestamp;
+
+		@SqsListener(queueNames = SUCCESS_LINEAR_BACKOFF_ERROR_HANDLER_QUEUE, factory = SUCCESS_LINEAR_BACKOFF_ERROR_HANDLER_FACTORY, id = "visibilityLinearErrorHandler")
+		CompletableFuture<Void> listen(Message<String> message,
+				@Header(SqsHeaders.SQS_QUEUE_NAME_HEADER) String queueName) {
+			logger.info("Received message {} from queue {}", message, queueName);
+
+			long receiveCount = Long.parseLong(MessageHeaderUtils.getHeader(message,
+					SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class));
+
+			if (receiveCount < 5) {
+				return CompletableFuture
+						.failedFuture(new RuntimeException("Expected exception from visibilityLinearErrorHandler"));
+			}
+
+			firstReceiveTimestamp = Long.parseLong(MessageHeaderUtils.getHeader(message,
+					SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_FIRST_RECEIVE_TIMESTAMP, String.class));
+			long currentTimestamp = MessageHeaderUtils.getHeader(message, MessageHeaders.TIMESTAMP, Long.class);
+
+			long elapsedTimeBetweenMessageReceivesInSeconds = (currentTimestamp - firstReceiveTimestamp) / 1000;
+			long expectedElapsedTime = calculateLinearTotalElapsedExpectedTime(receiveCount);
+			if (elapsedTimeBetweenMessageReceivesInSeconds >= expectedElapsedTime) {
+				latchContainer.receivesRetryMessageLinearlyLatch.countDown();
+			}
+
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
 	static class ExponentialBackOffBatchErrorHandlerListener {
 		@Autowired
 		LatchContainer latchContainer;
@@ -276,11 +461,129 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		}
 	}
 
+	static class ExponentialBackOffFullJitterBatchErrorHandlerListener {
+		@Autowired
+		LatchContainer latchContainer;
+
+		@SqsListener(queueNames = SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_BATCH_QUEUE, messageVisibilitySeconds = "10", factory = SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_FACTORY, id = "visibilityExponentialFullJitterBatchErrorHandler")
+		CompletableFuture<Void> listen(List<Message<String>> messages) {
+			logger.debug("Received messages {} from queue {}", MessageHeaderUtils.getId(messages),
+					messages.get(0).getHeaders().get(SqsHeaders.SQS_QUEUE_NAME_HEADER));
+
+			Collection<String> messagesReceiveCount = MessageHeaderUtils.getHeader(messages,
+					SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class);
+
+			boolean anyIsUnderRetryCount = messagesReceiveCount.stream()
+					.anyMatch(messageReceiveCount -> Long.parseLong(messageReceiveCount) < 7);
+
+			if (anyIsUnderRetryCount) {
+				return CompletableFuture.failedFuture(new RuntimeException(
+						"Expected exception from visibilityExponentialFullJitterBatchErrorHandler"));
+			}
+
+			for (Message<String> message : messages) {
+				long receiveCount = Long.parseLong(MessageHeaderUtils.getHeader(message,
+						SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class));
+				long firstReceiveTimestamp = Long.parseLong(MessageHeaderUtils.getHeader(message,
+						SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_FIRST_RECEIVE_TIMESTAMP, String.class));
+				long currentTimestamp = MessageHeaderUtils.getHeader(message, MessageHeaders.TIMESTAMP, Long.class);
+				long elapsedTimeBetweenMessageReceivesInSeconds = (currentTimestamp - firstReceiveTimestamp) / 1000;
+				long expectedElapsedTime = calculateJitterTotalElapsedExpectedTime(receiveCount, false);
+				if (elapsedTimeBetweenMessageReceivesInSeconds >= expectedElapsedTime) {
+					latchContainer.receivesRetryBatchMessageFullJitterLatch.countDown();
+				}
+			}
+
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+	static class ExponentialBackOffHalfJitterBatchErrorHandlerListener {
+		@Autowired
+		LatchContainer latchContainer;
+
+		@SqsListener(queueNames = SUCCESS_EXPONENTIAL_HALF_JITTER_BACKOFF_ERROR_HANDLER_BATCH_QUEUE, messageVisibilitySeconds = "10", factory = SUCCESS_EXPONENTIAL_HALF_JITTER_BACKOFF_ERROR_HANDLER_FACTORY, id = "visibilityExponentialHalfJitterBatchErrorHandler")
+		CompletableFuture<Void> listen(List<Message<String>> messages) {
+			logger.debug("Received messages {} from queue {}", MessageHeaderUtils.getId(messages),
+					messages.get(0).getHeaders().get(SqsHeaders.SQS_QUEUE_NAME_HEADER));
+
+			Collection<String> messagesReceiveCount = MessageHeaderUtils.getHeader(messages,
+					SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class);
+
+			boolean anyIsUnderRetryCount = messagesReceiveCount.stream()
+					.anyMatch(messageReceiveCount -> Long.parseLong(messageReceiveCount) < 6);
+
+			if (anyIsUnderRetryCount) {
+				return CompletableFuture.failedFuture(new RuntimeException(
+						"Expected exception from visibilityExponentialHalfJitterBatchErrorHandler"));
+			}
+
+			for (Message<String> message : messages) {
+				long receiveCount = Long.parseLong(MessageHeaderUtils.getHeader(message,
+						SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class));
+				long firstReceiveTimestamp = Long.parseLong(MessageHeaderUtils.getHeader(message,
+						SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_FIRST_RECEIVE_TIMESTAMP, String.class));
+				long currentTimestamp = MessageHeaderUtils.getHeader(message, MessageHeaders.TIMESTAMP, Long.class);
+				long elapsedTimeBetweenMessageReceivesInSeconds = (currentTimestamp - firstReceiveTimestamp) / 1000;
+				long expectedElapsedTime = calculateJitterTotalElapsedExpectedTime(receiveCount, true);
+				if (elapsedTimeBetweenMessageReceivesInSeconds >= expectedElapsedTime) {
+					latchContainer.receivesRetryBatchMessageHalfJitterLatch.countDown();
+				}
+			}
+
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+	static class LinearBackOffBatchErrorHandlerListener {
+		@Autowired
+		LatchContainer latchContainer;
+
+		@SqsListener(queueNames = SUCCESS_LINEAR_BACKOFF_ERROR_HANDLER_BATCH_QUEUE, factory = SUCCESS_LINEAR_BACKOFF_ERROR_HANDLER_FACTORY, id = "visibilityLinearBatchErrorHandler")
+		CompletableFuture<Void> listen(List<Message<String>> messages) {
+			logger.debug("Received messages {} from queue {}", MessageHeaderUtils.getId(messages),
+					messages.get(0).getHeaders().get(SqsHeaders.SQS_QUEUE_NAME_HEADER));
+
+			Collection<String> messagesReceiveCount = MessageHeaderUtils.getHeader(messages,
+					SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class);
+
+			boolean anyIsUnderRetryCount = messagesReceiveCount.stream()
+					.anyMatch(messageReceiveCount -> Long.parseLong(messageReceiveCount) < 5);
+
+			if (anyIsUnderRetryCount) {
+				return CompletableFuture.failedFuture(
+						new RuntimeException("Expected exception from visibilityLinearBatchErrorHandler"));
+			}
+
+			for (Message<String> message : messages) {
+				long receiveCount = Long.parseLong(MessageHeaderUtils.getHeader(message,
+						SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class));
+				long firstReceiveTimestamp = Long.parseLong(MessageHeaderUtils.getHeader(message,
+						SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_FIRST_RECEIVE_TIMESTAMP, String.class));
+				long currentTimestamp = MessageHeaderUtils.getHeader(message, MessageHeaders.TIMESTAMP, Long.class);
+				long elapsedTimeBetweenMessageReceivesInSeconds = (currentTimestamp - firstReceiveTimestamp) / 1000;
+				long expectedElapsedTime = calculateLinearTotalElapsedExpectedTime(receiveCount);
+				if (elapsedTimeBetweenMessageReceivesInSeconds >= expectedElapsedTime) {
+					latchContainer.receivesRetryBatchMessageLinearlyLatch.countDown();
+				}
+			}
+
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
 	static class LatchContainer {
 		final CountDownLatch receivesRetryMessageQuicklyLatch = new CountDownLatch(1);
 		final CountDownLatch receivesRetryBatchMessageQuicklyLatch = new CountDownLatch(10);
 		final CountDownLatch receivesRetryMessageExponentiallyLatch = new CountDownLatch(1);
 		final CountDownLatch receivesRetryBatchMessageExponentiallyLatch = new CountDownLatch(10);
+		final CountDownLatch receivesRetryMessageFullJitterLatch = new CountDownLatch(1);
+		final CountDownLatch receivesRetryMessageHalfJitterLatch = new CountDownLatch(1);
+		final CountDownLatch receivesRetryMessageLinearlyLatch = new CountDownLatch(1);
+
+		final CountDownLatch receivesRetryBatchMessageFullJitterLatch = new CountDownLatch(10);
+		final CountDownLatch receivesRetryBatchMessageHalfJitterLatch = new CountDownLatch(10);
+		final CountDownLatch receivesRetryBatchMessageLinearlyLatch = new CountDownLatch(10);
 	}
 
 	@Import(SqsBootstrapConfiguration.class)
@@ -324,6 +627,68 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		}
 		// @formatter:on
 
+		// @formatter:off
+		@Bean(name = SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_FACTORY)
+		public SqsMessageListenerContainerFactory<Object> exponentialBackOffFullJitterErrorHandler() {
+			return SqsMessageListenerContainerFactory
+				.builder()
+				.configure(options -> options
+					.maxConcurrentMessages(10)
+					.pollTimeout(Duration.ofSeconds(15))
+					.maxMessagesPerPoll(10)
+					.queueAttributeNames(Collections.singletonList(QueueAttributeName.QUEUE_ARN))
+					.maxDelayBetweenPolls(Duration.ofSeconds(15)))
+				.errorHandler(ExponentialBackoffErrorHandlerWithFullJitter.builder()
+					.initialVisibilityTimeoutSeconds(ExponentialBackOffJitterErrorHandlerListener.initialValueSeconds)
+					.multiplier(ExponentialBackOffJitterErrorHandlerListener.multiplier)
+					.randomSupplier(() -> new MockedRandomNextInt(getRandomFunction()))
+					.build())
+				.sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
+				.build();
+		}
+		// @formatter:on
+
+		//@formatter:off
+		@Bean(name = SUCCESS_EXPONENTIAL_HALF_JITTER_BACKOFF_ERROR_HANDLER_FACTORY)
+		public SqsMessageListenerContainerFactory<Object> exponentialBackOffHalfJitterErrorHandler() {
+			return SqsMessageListenerContainerFactory
+				.builder()
+				.configure(options -> options
+					.maxConcurrentMessages(10)
+					.pollTimeout(Duration.ofSeconds(15))
+					.maxMessagesPerPoll(10)
+					.queueAttributeNames(Collections.singletonList(QueueAttributeName.QUEUE_ARN))
+					.maxDelayBetweenPolls(Duration.ofSeconds(15)))
+				.errorHandler(ExponentialBackoffErrorHandlerWithHalfJitter.builder()
+					.initialVisibilityTimeoutSeconds(ExponentialBackOffJitterErrorHandlerListener.initialValueSeconds)
+					.multiplier(ExponentialBackOffJitterErrorHandlerListener.multiplier)
+					.randomSupplier(() -> new MockedRandomNextInt(getRandomFunction()))
+					.build())
+				.sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
+				.build();
+		}
+		// @formatter:on
+
+		//@formatter:off
+		@Bean(name = SUCCESS_LINEAR_BACKOFF_ERROR_HANDLER_FACTORY)
+		public SqsMessageListenerContainerFactory<Object> linearBackOffErrorHandler() {
+			return SqsMessageListenerContainerFactory
+				.builder()
+				.configure(options -> options
+					.maxConcurrentMessages(10)
+					.pollTimeout(Duration.ofSeconds(15))
+					.maxMessagesPerPoll(10)
+					.queueAttributeNames(Collections.singletonList(QueueAttributeName.QUEUE_ARN))
+					.maxDelayBetweenPolls(Duration.ofSeconds(15)))
+				.errorHandler(LinearBackoffErrorHandler.builder()
+					.initialVisibilityTimeoutSeconds(LinearBackOffErrorHandlerListener.initialValueSeconds)
+					.increment(LinearBackOffErrorHandlerListener.increment)
+					.build())
+				.sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
+				.build();
+		}
+		// @formatter:on
+
 		@Bean
 		ImmediateRetryAsyncErrorHandlerListener immediateRetryAsyncErrorHandlerListener() {
 			return new ImmediateRetryAsyncErrorHandlerListener();
@@ -344,6 +709,31 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 			return new ExponentialBackOffBatchErrorHandlerListener();
 		}
 
+		@Bean
+		ExponentialBackOffJitterErrorHandlerListener exponentialBackOffJitterErrorHandlerListener() {
+			return new ExponentialBackOffJitterErrorHandlerListener();
+		}
+
+		@Bean
+		ExponentialBackOffFullJitterBatchErrorHandlerListener exponentialBackOffFullJitterBatchErrorHandlerListener() {
+			return new ExponentialBackOffFullJitterBatchErrorHandlerListener();
+		}
+
+		@Bean
+		ExponentialBackOffHalfJitterBatchErrorHandlerListener exponentialBackOffHalfJitterBatchErrorHandlerListener() {
+			return new ExponentialBackOffHalfJitterBatchErrorHandlerListener();
+		}
+
+		@Bean
+		LinearBackOffBatchErrorHandlerListener linearBackOffBatchErrorHandlerListener() {
+			return new LinearBackOffBatchErrorHandlerListener();
+		}
+
+		@Bean
+		LinearBackOffErrorHandlerListener linearBackOffErrorHandlerListener() {
+			return new LinearBackOffErrorHandlerListener();
+		}
+
 		LatchContainer latchContainer = new LatchContainer();
 
 		@Bean
@@ -362,6 +752,10 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		}
 	}
 
+	private static @NotNull Function<Integer, Integer> getRandomFunction() {
+		return timeout -> timeout / 2;
+	}
+
 	private List<Message<String>> create10Messages(String testName) {
 		return IntStream.range(0, 10).mapToObj(index -> testName + "-payload-" + index)
 				.map(payload -> MessageBuilder.withPayload(payload).build()).collect(Collectors.toList());
@@ -373,5 +767,45 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 			sum += Math.pow(ExponentialBackOffErrorHandlerListener.multiplier, i);
 		}
 		return (long) (ExponentialBackOffErrorHandlerListener.initialValueSeconds * sum);
+	}
+
+	private static long calculateJitterTotalElapsedExpectedTime(long receiveCount, boolean halfJitter) {
+		long sum = 0;
+		for (int i = 0; i < receiveCount - 1; i++) {
+			long timeout = (long) (ExponentialBackOffJitterErrorHandlerListener.initialValueSeconds
+					* Math.pow(ExponentialBackOffJitterErrorHandlerListener.multiplier, i));
+			if (halfJitter) {
+				long half = timeout / 2;
+				sum += half + (half + 1) / 2;
+			}
+			else {
+				sum += (timeout + 1) / 2;
+			}
+		}
+		return sum;
+	}
+
+	private static long calculateLinearTotalElapsedExpectedTime(long receiveCount) {
+		return ErrorHandlerVisibilityHelper.calculateVisibilityTimeoutLinearly(receiveCount,
+				LinearBackOffErrorHandlerListener.initialValueSeconds, LinearBackOffErrorHandlerListener.increment,
+				Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS);
+	}
+
+	static class MockedRandomNextInt extends Random {
+		final Function<Integer, Integer> nextInt;
+
+		MockedRandomNextInt(Function<Integer, Integer> nextInt) {
+			this.nextInt = nextInt;
+		}
+
+		@Override
+		public int nextInt(int bound) {
+			return nextInt.apply(bound);
+		}
+
+		@Override
+		public int nextInt(int origin, int bound) {
+			return nextInt.apply(bound);
+		}
 	}
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/BaseExponentialBackoffErrorHandlerJitterTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/BaseExponentialBackoffErrorHandlerJitterTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.errorhandler;
+
+import java.util.Collection;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.springframework.messaging.Message;
+
+public abstract class BaseExponentialBackoffErrorHandlerJitterTest {
+	static class BaseTestCase {
+		String sqsApproximateReceiveCount;
+		Supplier<Random> randomSupplier;
+		int initialVisibilityTimeoutSeconds;
+		double multiplier;
+		int VisibilityTimeoutExpectedFullJitter;
+		int VisibilityTimeoutExpectedHalfJitter;
+
+		BaseTestCase sqsApproximateReceiveCount(String sqsApproximateReceiveCount) {
+			this.sqsApproximateReceiveCount = sqsApproximateReceiveCount;
+			return this;
+		}
+
+		BaseTestCase randomSupplier(Supplier<Random> randomSupplier) {
+			this.randomSupplier = randomSupplier;
+			return this;
+		}
+
+		BaseTestCase initialVisibilityTimeoutSeconds(int initialVisibilityTimeoutSeconds) {
+			this.initialVisibilityTimeoutSeconds = initialVisibilityTimeoutSeconds;
+			return this;
+		}
+
+		BaseTestCase multiplier(double multiplier) {
+			this.multiplier = multiplier;
+			return this;
+		}
+
+		BaseTestCase VisibilityTimeoutExpectedHalfJitter(int VisibilityTimeoutExpectedHalfJitter) {
+			this.VisibilityTimeoutExpectedHalfJitter = VisibilityTimeoutExpectedHalfJitter;
+			return this;
+		}
+
+		BaseTestCase VisibilityTimeoutExpectedFullJitter(int VisibilityTimeoutExpectedFullJitter) {
+			this.VisibilityTimeoutExpectedFullJitter = VisibilityTimeoutExpectedFullJitter;
+			return this;
+		}
+
+		CompletableFuture<Void> calculateWithVisibilityTimeoutExpectedHalfJitter(Message<Object> message, Throwable t) {
+			ExponentialBackoffErrorHandlerWithHalfJitter<Object> handler = ExponentialBackoffErrorHandlerWithHalfJitter
+					.builder().randomSupplier(this.randomSupplier)
+					.initialVisibilityTimeoutSeconds(this.initialVisibilityTimeoutSeconds).multiplier(this.multiplier)
+					.build();
+
+			return handler.handle(message, t);
+		}
+
+		CompletableFuture<Void> calculateWithVisibilityTimeoutExpectedHalfJitter(Collection<Message<Object>> messages,
+				Throwable t) {
+			ExponentialBackoffErrorHandlerWithHalfJitter<Object> handler = ExponentialBackoffErrorHandlerWithHalfJitter
+					.builder().randomSupplier(this.randomSupplier)
+					.initialVisibilityTimeoutSeconds(this.initialVisibilityTimeoutSeconds).multiplier(this.multiplier)
+					.build();
+
+			return handler.handle(messages, t);
+		}
+
+		CompletableFuture<Void> calculateWithVisibilityTimeoutExpectedFullJitter(Message<Object> message, Throwable t) {
+			ExponentialBackoffErrorHandlerWithFullJitter<Object> handler = ExponentialBackoffErrorHandlerWithFullJitter
+					.builder().randomSupplier(this.randomSupplier)
+					.initialVisibilityTimeoutSeconds(this.initialVisibilityTimeoutSeconds).multiplier(this.multiplier)
+					.build();
+
+			return handler.handle(message, t);
+		}
+
+		CompletableFuture<Void> calculateWithVisibilityTimeoutExpectedFullJitter(Collection<Message<Object>> messages,
+				Throwable t) {
+			ExponentialBackoffErrorHandlerWithFullJitter<Object> handler = ExponentialBackoffErrorHandlerWithFullJitter
+					.builder().randomSupplier(this.randomSupplier)
+					.initialVisibilityTimeoutSeconds(this.initialVisibilityTimeoutSeconds).multiplier(this.multiplier)
+					.build();
+
+			return handler.handle(messages, t);
+		}
+	}
+
+	static class MockedRandomNextInt extends Random {
+		final Function<Integer, Integer> nextInt;
+
+		MockedRandomNextInt(Function<Integer, Integer> nextInt) {
+			this.nextInt = nextInt;
+		}
+
+		@Override
+		public int nextInt(int bound) {
+			return nextInt.apply(bound);
+		}
+
+		@Override
+		public int nextInt(int origin, int bound) {
+			return nextInt.apply(bound);
+		}
+	}
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/ExponentialBackoffErrorHandlerJitterTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/ExponentialBackoffErrorHandlerJitterTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.errorhandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import io.awspring.cloud.sqs.listener.BatchVisibility;
+import io.awspring.cloud.sqs.listener.QueueMessageVisibility;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.listener.Visibility;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Tests for {@link ExponentialBackoffErrorHandlerWithFullJitter} and
+ * {@link ExponentialBackoffErrorHandlerWithHalfJitter}.
+ *
+ * @author Bruno Garcia
+ * @author Rafael Pavarini
+ */
+class ExponentialBackoffErrorHandlerJitterTest extends BaseExponentialBackoffErrorHandlerJitterTest {
+	static Supplier<Random> midRandomSupplier = () -> new MockedRandomNextInt(timeout -> timeout / 2);
+	static Supplier<Random> maxRandomSupplier = () -> new MockedRandomNextInt(timeout -> timeout - 1);
+
+	@ParameterizedTest
+	@MethodSource("testCases")
+	void calculateExponentialFullJitter(BaseTestCase baseTestCase) {
+		Message<Object> message = mock(Message.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		Visibility visibility = mock(Visibility.class);
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn(baseTestCase.sqsApproximateReceiveCount);
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		assertThat(baseTestCase.calculateWithVisibilityTimeoutExpectedFullJitter(message, exception))
+				.isCompletedExceptionally();
+		then(visibility).should().changeToAsync(baseTestCase.VisibilityTimeoutExpectedFullJitter);
+	}
+
+	@ParameterizedTest
+	@MethodSource("testCases")
+	void calculateExponentialFullJitterCollection(BaseTestCase baseTestCase) {
+		Message<Object> message1 = mock(Message.class);
+		Message<Object> message2 = mock(Message.class);
+		Message<Object> message3 = mock(Message.class);
+		List<Message<Object>> messages = Arrays.asList(message1, message2, message3);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		QueueMessageVisibility visibility = mock(QueueMessageVisibility.class);
+		BatchVisibility batchvisibility = mock(BatchVisibility.class);
+		given(batchvisibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+		given(batchvisibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+		given(visibility.toBatchVisibility(any())).willReturn(batchvisibility);
+		given(message1.getHeaders()).willReturn(headers);
+		given(message2.getHeaders()).willReturn(headers);
+		given(message3.getHeaders()).willReturn(headers);
+		given(headers.getId()).willReturn(UUID.randomUUID());
+		given(headers.get("id", UUID.class)).willReturn(UUID.randomUUID());
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn(baseTestCase.sqsApproximateReceiveCount);
+		given(batchvisibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		assertThat(baseTestCase.calculateWithVisibilityTimeoutExpectedFullJitter(messages, exception))
+				.isCompletedExceptionally();
+		then(batchvisibility).should(times(1)).changeToAsync(baseTestCase.VisibilityTimeoutExpectedFullJitter);
+	}
+
+	@ParameterizedTest
+	@MethodSource("testCases")
+	void calculateExponentialHalfJitterCollection(BaseTestCase baseTestCase) {
+		Message<Object> message1 = mock(Message.class);
+		Message<Object> message2 = mock(Message.class);
+		Message<Object> message3 = mock(Message.class);
+		List<Message<Object>> messages = Arrays.asList(message1, message2, message3);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		QueueMessageVisibility visibility = mock(QueueMessageVisibility.class);
+		BatchVisibility batchvisibility = mock(BatchVisibility.class);
+		given(batchvisibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+		given(batchvisibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+		given(visibility.toBatchVisibility(any())).willReturn(batchvisibility);
+		given(message1.getHeaders()).willReturn(headers);
+		given(message2.getHeaders()).willReturn(headers);
+		given(message3.getHeaders()).willReturn(headers);
+		given(headers.getId()).willReturn(UUID.randomUUID());
+		given(headers.get("id", UUID.class)).willReturn(UUID.randomUUID());
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn(baseTestCase.sqsApproximateReceiveCount);
+		given(batchvisibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		assertThat(baseTestCase.calculateWithVisibilityTimeoutExpectedHalfJitter(messages, exception))
+				.isCompletedExceptionally();
+		then(batchvisibility).should(times(1)).changeToAsync(baseTestCase.VisibilityTimeoutExpectedHalfJitter);
+	}
+
+	@ParameterizedTest
+	@MethodSource("testCases")
+	void calculateExponentialHalfJitter(BaseTestCase baseTestCase) {
+		Message<Object> message = mock(Message.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		Visibility visibility = mock(Visibility.class);
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn(baseTestCase.sqsApproximateReceiveCount);
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		assertThat(baseTestCase.calculateWithVisibilityTimeoutExpectedHalfJitter(message, exception))
+				.isCompletedExceptionally();
+		then(visibility).should().changeToAsync(baseTestCase.VisibilityTimeoutExpectedHalfJitter);
+
+	}
+
+	private static Collection<BaseTestCase> testCases() {
+		return List.of(
+				baseTestCaseMidRandomSupplier().sqsApproximateReceiveCount("1").VisibilityTimeoutExpectedHalfJitter(
+						(int) ((BackoffVisibilityConstants.DEFAULT_INITIAL_VISIBILITY_TIMEOUT_SECONDS * 1.5) / 2))
+						.VisibilityTimeoutExpectedFullJitter(
+								BackoffVisibilityConstants.DEFAULT_INITIAL_VISIBILITY_TIMEOUT_SECONDS / 2),
+
+				baseTestCaseMidRandomSupplier().sqsApproximateReceiveCount("2").VisibilityTimeoutExpectedHalfJitter(150)
+						.VisibilityTimeoutExpectedFullJitter(100),
+
+				baseTestCaseMidRandomSupplier().sqsApproximateReceiveCount("3").VisibilityTimeoutExpectedHalfJitter(300)
+						.VisibilityTimeoutExpectedFullJitter(200),
+
+				baseTestCaseMidRandomSupplier().sqsApproximateReceiveCount("5")
+						.VisibilityTimeoutExpectedHalfJitter(1200).VisibilityTimeoutExpectedFullJitter(800),
+
+				baseTestCaseMidRandomSupplier().sqsApproximateReceiveCount("7")
+						.VisibilityTimeoutExpectedHalfJitter(4800).VisibilityTimeoutExpectedFullJitter(3200),
+
+				baseTestCaseMidRandomSupplier().sqsApproximateReceiveCount("11")
+						.VisibilityTimeoutExpectedHalfJitter(Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS / 2
+								+ Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS / 4)
+						.VisibilityTimeoutExpectedFullJitter(Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS / 2),
+
+				baseTestCaseMidRandomSupplier().sqsApproximateReceiveCount("13")
+						.VisibilityTimeoutExpectedHalfJitter(Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS / 2
+								+ Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS / 4)
+						.VisibilityTimeoutExpectedFullJitter(Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS / 2),
+
+				baseTestCaseMaxRandomSupplier().sqsApproximateReceiveCount("1")
+						.VisibilityTimeoutExpectedHalfJitter(
+								BackoffVisibilityConstants.DEFAULT_INITIAL_VISIBILITY_TIMEOUT_SECONDS)
+						.VisibilityTimeoutExpectedFullJitter(
+								BackoffVisibilityConstants.DEFAULT_INITIAL_VISIBILITY_TIMEOUT_SECONDS),
+
+				baseTestCaseMaxRandomSupplier().sqsApproximateReceiveCount("2").VisibilityTimeoutExpectedHalfJitter(200)
+						.VisibilityTimeoutExpectedFullJitter(200),
+
+				baseTestCaseMaxRandomSupplier().sqsApproximateReceiveCount("3").VisibilityTimeoutExpectedHalfJitter(400)
+						.VisibilityTimeoutExpectedFullJitter(400),
+
+				baseTestCaseMaxRandomSupplier().sqsApproximateReceiveCount("5")
+						.VisibilityTimeoutExpectedHalfJitter(1600).VisibilityTimeoutExpectedFullJitter(1600),
+
+				baseTestCaseMaxRandomSupplier().sqsApproximateReceiveCount("7")
+						.VisibilityTimeoutExpectedHalfJitter(6400).VisibilityTimeoutExpectedFullJitter(6400),
+
+				baseTestCaseMaxRandomSupplier().sqsApproximateReceiveCount("11")
+						.VisibilityTimeoutExpectedHalfJitter(Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS)
+						.VisibilityTimeoutExpectedFullJitter(Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS),
+
+				baseTestCaseMaxRandomSupplier().sqsApproximateReceiveCount("13")
+						.VisibilityTimeoutExpectedHalfJitter(Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS)
+						.VisibilityTimeoutExpectedFullJitter(Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS));
+	}
+
+	private static BaseTestCase baseTestCaseMidRandomSupplier() {
+		return new BaseTestCase()
+				.initialVisibilityTimeoutSeconds(BackoffVisibilityConstants.DEFAULT_INITIAL_VISIBILITY_TIMEOUT_SECONDS)
+				.randomSupplier(midRandomSupplier).multiplier(BackoffVisibilityConstants.DEFAULT_MULTIPLIER);
+	}
+
+	private static BaseTestCase baseTestCaseMaxRandomSupplier() {
+		return new BaseTestCase()
+				.initialVisibilityTimeoutSeconds(BackoffVisibilityConstants.DEFAULT_INITIAL_VISIBILITY_TIMEOUT_SECONDS)
+				.randomSupplier(maxRandomSupplier).multiplier(BackoffVisibilityConstants.DEFAULT_MULTIPLIER);
+	}
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/LinearBackoffErrorHandlerTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/LinearBackoffErrorHandlerTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.errorhandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import io.awspring.cloud.sqs.listener.BatchVisibility;
+import io.awspring.cloud.sqs.listener.QueueMessageVisibility;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.listener.Visibility;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Tests for {@link LinearBackoffErrorHandler}.
+ *
+ * @author Bruno Garcia
+ * @author Rafael Pavarini
+ */
+class LinearBackoffErrorHandlerTest {
+	@Test
+	void shouldChangeVisibilityTimeoutLinearlyWithDefaultInitialVisibilityTimeout() {
+		Message<Object> message = mock(Message.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		Visibility visibility = mock(Visibility.class);
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("1");
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		LinearBackoffErrorHandler<Object> handler = LinearBackoffErrorHandler.builder().build();
+
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(100);
+	}
+
+	@Test
+	void shouldChangeVisibilityTimeoutLinearlyWithDefaultMaxVisibilityTimeout() {
+		Message<Object> message = mock(Message.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		Visibility visibility = mock(Visibility.class);
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("1");
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		LinearBackoffErrorHandler<Object> handler = LinearBackoffErrorHandler.builder()
+				.initialVisibilityTimeoutSeconds(43200).increment(20000).build();
+
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS);
+	}
+
+	@Test
+	void shouldChangeVisibilityTimeoutLinearlyWithCustomVisibilityTimeout() {
+		Message<Object> message = mock(Message.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		Visibility visibility = mock(Visibility.class);
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("1");
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		LinearBackoffErrorHandler<Object> handler = LinearBackoffErrorHandler.builder()
+				.initialVisibilityTimeoutSeconds(500).increment(2).build();
+
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(500);
+	}
+
+	@Test
+	void shouldChangeVisibilityTimeoutLinearlyWithCustomVisibilityTimeoutAndMaxVisibilityTimeout() {
+		Message<Object> message = mock(Message.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		Visibility visibility = mock(Visibility.class);
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("1");
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		LinearBackoffErrorHandler<Object> handler = LinearBackoffErrorHandler.builder().maxVisibilityTimeoutSeconds(501)
+				.initialVisibilityTimeoutSeconds(500).increment(2).build();
+
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(500);
+
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("2");
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(501);
+	}
+
+	@Test
+	void shouldChangeVisibilityTimeoutLinearly() {
+		Message<Object> message = mock(Message.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		Visibility visibility = mock(Visibility.class);
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("1");
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		LinearBackoffErrorHandler<Object> handler = LinearBackoffErrorHandler.builder()
+				.initialVisibilityTimeoutSeconds(500).increment(2).build();
+
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(500);
+
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("2");
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(502);
+
+	}
+
+	@Test
+	void shouldChangeVisibilityTimeoutLinearlyBatch() {
+		Message<Object> message1 = mock(Message.class);
+		Message<Object> message2 = mock(Message.class);
+		Message<Object> message3 = mock(Message.class);
+		List<Message<Object>> batch = Arrays.asList(message1, message2, message3);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZeroBatch");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		MessageHeaders headers2 = mock(MessageHeaders.class);
+		QueueMessageVisibility visibility = mock(QueueMessageVisibility.class);
+		BatchVisibility batchvisibility = mock(BatchVisibility.class);
+		given(batchvisibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+		given(visibility.toBatchVisibility(any())).willReturn(batchvisibility);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers2.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.getId()).willReturn(UUID.randomUUID());
+		given(headers2.getId()).willReturn(UUID.randomUUID());
+		given(headers.get("id", UUID.class)).willReturn(UUID.randomUUID());
+		given(headers2.get("id", UUID.class)).willReturn(UUID.randomUUID());
+		given(message1.getHeaders()).willReturn(headers);
+		given(message2.getHeaders()).willReturn(headers2);
+		given(message3.getHeaders()).willReturn(headers);
+
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("1");
+		given(headers2.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("2");
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		LinearBackoffErrorHandler<Object> handler = LinearBackoffErrorHandler.builder()
+				.initialVisibilityTimeoutSeconds(500).increment(2).build();
+
+		assertThat(handler.handle(batch, exception)).isCompletedExceptionally();
+		then(batchvisibility).should(times(1)).changeToAsync(500);
+
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("2");
+		given(headers2.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("3");
+		assertThat(handler.handle(batch, exception)).isCompletedExceptionally();
+
+		then(batchvisibility).should(times(2)).changeToAsync(502);
+		then(batchvisibility).should(times(1)).changeToAsync(504);
+	}
+
+	@Test
+	void shouldApplyMaxVisibilityTimeoutWhenCalculatedTimeoutExceedsLimit() {
+		Message<Object> message = mock(Message.class);
+		RuntimeException exception = new RuntimeException("Expected exception from shouldChangeVisibilityToZero");
+		MessageHeaders headers = mock(MessageHeaders.class);
+		Visibility visibility = mock(Visibility.class);
+		given(message.getHeaders()).willReturn(headers);
+		given(headers.get(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Visibility.class)).willReturn(visibility);
+		given(headers.get(SqsHeaders.MessageSystemAttributes.SQS_APPROXIMATE_RECEIVE_COUNT, String.class))
+				.willReturn("11");
+		given(visibility.changeToAsync(anyInt())).willReturn(CompletableFuture.completedFuture(null));
+
+		LinearBackoffErrorHandler<Object> handler = LinearBackoffErrorHandler.builder().increment(Integer.MAX_VALUE)
+				.build();
+
+		assertThat(handler.handle(message, exception)).isCompletedExceptionally();
+		then(visibility).should().changeToAsync(Visibility.MAX_VISIBILITY_TIMEOUT_SECONDS);
+	}
+
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [X] New feature
- [X] Enhancement
- [X] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Add `ExponentialBackoffErrorHandlerWithFullJitter`, `ExponentialBackoffErrorHandlerWithHalfJitter`, `LinearBackoffErrorHandler` to manage message visibility timeouts and implement exponential backoff logic for retries in SQS (#1314)


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As mentioned in (#1381), this enhancement enables reporting an error back to AWS SQS by exponentially increasing the message's visibility timeout and applies  an exponential backoff strategy with *full jitter* or *half jitter*
when retrying failed message processing, allowing it to be retried. We also add the linear backoff error handler behavior `LinearBackoffErrorHandler` that increases the visibility timeout linearly whenever a
message processing attempt fails.

We also refactoring some error handling parts to better separate of responsibility and maintenance.

## :green_heart: How did you test it?
Unit test, Integration test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] I updated reference documentation to reflect the change
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
- Create a BackOffErrorHandlerFactory, where we can set the parameters we want and it'll return the proper implementation.
