### PR TITLE
fix: polling future removed on exception

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSource.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -320,7 +320,7 @@ public abstract class AbstractPollingMessageSource<T, S> extends AbstractMessage
 
 	private <F> CompletableFuture<F> managePollingFuture(CompletableFuture<F> pollingFuture) {
 		this.pollingFutures.add(pollingFuture);
-		pollingFuture.thenRun(() -> this.pollingFutures.remove(pollingFuture));
+		pollingFuture.whenComplete((result, throwable) -> this.pollingFutures.remove(pollingFuture));
 		return pollingFuture;
 	}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSourceTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -351,6 +351,47 @@ class AbstractPollingMessageSourceTests {
 		then(policy).should().start(null);
 		then(policy).should(times(2)).backOff(backOffContext);
 
+	}
+
+	@Test
+	void shouldRemovePollingFutureOnException() throws InterruptedException {
+		String testName = "shouldClearPollingFuturesOnException";
+
+		SemaphoreBackPressureHandler backPressureHandler = SemaphoreBackPressureHandler.builder()
+			.acquireTimeout(Duration.ofMillis(100)).batchSize(10).totalPermits(10)
+			.throughputConfiguration(BackPressureMode.ALWAYS_POLL_MAX_MESSAGES).build();
+
+		AbstractPollingMessageSource<Object, Message> source = new AbstractPollingMessageSource<>() {
+			@Override
+			protected CompletableFuture<Collection<Message>> doPollForMessages(int messagesToRequest) {
+				return CompletableFuture.failedFuture(new RuntimeException("Simulating a polling error"));
+			}
+		};
+
+		BackOffPolicy policy = mock(BackOffPolicy.class);
+		BackOffContext ctx = mock(BackOffContext.class);
+		given(policy.start(null)).willReturn(ctx);
+
+		source.setBackPressureHandler(backPressureHandler);
+		source.setMessageSink((msgs, context) -> CompletableFuture.completedFuture(null));
+		source.setId(testName + " source");
+		source.setPollingEndpointName("test-queue");
+		source.configure(SqsContainerOptions.builder().pollBackOffPolicy(policy).build());
+		source.setTaskExecutor(createTaskExecutor(testName));
+		source.setAcknowledgementProcessor(getNoOpsAcknowledgementProcessor());
+
+		@SuppressWarnings("unchecked")
+		Collection<CompletableFuture<?>> futures = (Collection<CompletableFuture<?>>) ReflectionTestUtils
+			.getField(source, "pollingFutures");
+		// Verify that the pollingFutures collection is initially empty
+		assertThat(futures).isEmpty();
+
+		source.start();
+
+		// Verify that the pollingFutures collection is empty after the exceptional completion
+		assertThat(futures).isEmpty();
+
+		source.stop();
 	}
 
 	private static boolean doAwait(CountDownLatch processingLatch) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Changed `.thenRun()` method in method `managePollingFuture` in `AbstractPollingMessageSource` to `.whenComplete()` so if the polling future fails the future will be cleaned

## :bulb: Motivation and Context

Fixes [#1453](https://github.com/awspring/spring-cloud-aws/issues/1453)

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

@tomazfernandes Review changes and let me know if anything should be changed/added 
