### PR TITLE
qfeat(1463): enhance DefaultDynamoDbTableNameResolver with caching and improved table name resolution

### DIFF
--- a/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DefaultDynamoDbTableNameResolver.java
+++ b/spring-cloud-aws-dynamodb/src/main/java/io/awspring/cloud/dynamodb/DefaultDynamoDbTableNameResolver.java
@@ -16,8 +16,10 @@
 package io.awspring.cloud.dynamodb;
 
 import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
@@ -26,17 +28,15 @@ import org.springframework.util.StringUtils;
  * @author Matej Nedic
  * @author Arun Patra
  * @author Volodymyr Ivakhnenko
+ * @author Marcus Voltolim
  * @since 3.0
  */
 public class DefaultDynamoDbTableNameResolver implements DynamoDbTableNameResolver {
 
-	@Nullable
+	private final Map<Class<?>, String> tableNameCache = new ConcurrentHashMap<>();
+
 	private final String tablePrefix;
-
-	@Nullable
 	private final String tableSuffix;
-
-	@Nullable
 	private final String tableSeparator;
 
 	public DefaultDynamoDbTableNameResolver() {
@@ -51,24 +51,24 @@ public class DefaultDynamoDbTableNameResolver implements DynamoDbTableNameResolv
 		this(tablePrefix, tableSuffix, null);
 	}
 
-	public DefaultDynamoDbTableNameResolver(@Nullable String tablePrefix, @Nullable String tableSuffix,
-			@Nullable String tableSeparator) {
-		this.tablePrefix = tablePrefix;
-		this.tableSuffix = tableSuffix;
-		this.tableSeparator = tableSeparator;
+	public DefaultDynamoDbTableNameResolver(@Nullable String tablePrefix, @Nullable String tableSuffix, @Nullable String tableSeparator) {
+		this.tablePrefix = StringUtils.hasText(tablePrefix) ? tablePrefix : "";
+		this.tableSuffix = StringUtils.hasText(tableSuffix) ? tableSuffix : "";
+		this.tableSeparator = StringUtils.hasText(tableSeparator) ? tableSeparator : "_";
 	}
 
 	@Override
-	public String resolve(Class clazz) {
-		Assert.notNull(clazz, "clazz is required");
+	public <T> String resolve(Class<T> clazz) {
+		return tableNameCache.computeIfAbsent(clazz, this::resolveInternal);
+	}
 
-		String prefix = StringUtils.hasText(tablePrefix) ? tablePrefix : "";
-		String suffix = StringUtils.hasText(tableSuffix) ? tableSuffix : "";
-		String separator = StringUtils.hasText(tableSeparator) ? tableSeparator : "_";
+	private <T> String resolveInternal(Class<T> clazz) {
+		final String className = clazz.getSimpleName().replaceAll("(.)(\\p{Lu})", "$1" + tableSeparator + "$2");
+		return tablePrefix + className.toLowerCase(Locale.ROOT) + tableSuffix;
+	}
 
-		return prefix.concat(
-				clazz.getSimpleName().replaceAll("(.)(\\p{Lu})", "$1" + separator + "$2").toLowerCase(Locale.ROOT))
-				.concat(suffix);
+	Map<Class<?>, String> getTableNameCache() {
+		return tableNameCache;
 	}
 
 }

--- a/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTableNameResolverTest.java
+++ b/spring-cloud-aws-dynamodb/src/test/java/io/awspring/cloud/dynamodb/DynamoDbTableNameResolverTest.java
@@ -15,9 +15,9 @@
  */
 package io.awspring.cloud.dynamodb;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link DynamoDbTableNameResolver}.
@@ -28,60 +28,93 @@ import org.junit.jupiter.api.Test;
  */
 class DynamoDbTableNameResolverTest {
 
-	private static final DefaultDynamoDbTableNameResolver tableNameResolver = new DefaultDynamoDbTableNameResolver(
-			null);
+	private final DefaultDynamoDbTableNameResolver tableNameResolver = new DefaultDynamoDbTableNameResolver();
 
-	private static final DefaultDynamoDbTableNameResolver prefixedTableNameResolver = new DefaultDynamoDbTableNameResolver(
-			"my_prefix_");
+	private final DefaultDynamoDbTableNameResolver prefixedTableNameResolver = new DefaultDynamoDbTableNameResolver(
+		"my_prefix_");
 
-	private static final DefaultDynamoDbTableNameResolver prefixedAndSuffixedTableNameResolver = new DefaultDynamoDbTableNameResolver(
-			"my_prefix_", "_my_suffix");
+	private final DefaultDynamoDbTableNameResolver prefixedAndSuffixedTableNameResolver = new DefaultDynamoDbTableNameResolver(
+		"my_prefix_", "_my_suffix");
 
-	private static final DefaultDynamoDbTableNameResolver prefixedAndSuffixedTableAndSeparatorTableNameResolver = new DefaultDynamoDbTableNameResolver(
-			"prefix-", "-suffix", "-");
+	private final DefaultDynamoDbTableNameResolver prefixedAndSuffixedTableAndSeparatorTableNameResolver = new DefaultDynamoDbTableNameResolver(
+		"prefix-", "-suffix", "-");
 
 	@Test
 	void resolveTableNameSuccessfully() {
-		assertThat(tableNameResolver.resolve(MoreComplexPerson.class)).isEqualTo("more_complex_person");
-		assertThat(tableNameResolver.resolve(Person.class)).isEqualTo("person");
+		assertThat(tableNameResolver.resolve(MoreComplexPerson.class))
+			.isEqualTo("more_complex_person");
+		assertThat(tableNameResolver.resolve(Person.class))
+			.isEqualTo("person");
+		assertThat(tableNameResolver.getTableNameCache())
+			.hasSize(2);
 	}
 
 	@Test
 	void resolvePrefixedTableNameSuccessfully() {
 		assertThat(prefixedTableNameResolver.resolve(MoreComplexPerson.class))
-				.isEqualTo("my_prefix_more_complex_person");
-		assertThat(prefixedTableNameResolver.resolve(Person.class)).isEqualTo("my_prefix_person");
+			.isEqualTo("my_prefix_more_complex_person");
+		assertThat(prefixedTableNameResolver.resolve(Person.class))
+			.isEqualTo("my_prefix_person");
+		assertThat(prefixedTableNameResolver.getTableNameCache())
+			.hasSize(2);
 	}
 
 	@Test
 	void resolvePrefixedAndSuffixedTableNameSuccessfully() {
 		assertThat(prefixedAndSuffixedTableNameResolver.resolve(MoreComplexPerson.class))
-				.isEqualTo("my_prefix_more_complex_person_my_suffix");
-		assertThat(prefixedAndSuffixedTableNameResolver.resolve(Person.class)).isEqualTo("my_prefix_person_my_suffix");
+			.isEqualTo("my_prefix_more_complex_person_my_suffix");
+		assertThat(prefixedAndSuffixedTableNameResolver.resolve(Person.class))
+			.isEqualTo("my_prefix_person_my_suffix");
+		assertThat(prefixedAndSuffixedTableNameResolver.getTableNameCache())
+			.hasSize(2);
 	}
 
 	@Test
 	void resolvePrefixedAndSuffixedAndSeparatorTableNameSuccessfully() {
 		assertThat(prefixedAndSuffixedTableAndSeparatorTableNameResolver.resolve(MoreComplexPerson.class))
-				.isEqualTo("prefix-more-complex-person-suffix");
+			.isEqualTo("prefix-more-complex-person-suffix");
 		assertThat(prefixedAndSuffixedTableAndSeparatorTableNameResolver.resolve(Person.class))
-				.isEqualTo("prefix-person-suffix");
+			.isEqualTo("prefix-person-suffix");
+		assertThat(prefixedAndSuffixedTableAndSeparatorTableNameResolver.getTableNameCache())
+			.hasSize(2);
 	}
 
 	@Test
 	void resolvesTableNameFromRecord() {
-		assertThat(tableNameResolver.resolve(PersonRecord.class)).isEqualTo("person_record");
+		assertThat(tableNameResolver.resolve(PersonRecord.class))
+			.isEqualTo("person_record");
+		assertThat(tableNameResolver.getTableNameCache())
+			.hasSize(1);
 	}
 
 	@Test
 	void resolvesPrefixedTableNameFromRecord() {
-		assertThat(prefixedTableNameResolver.resolve(PersonRecord.class)).isEqualTo("my_prefix_person_record");
+		assertThat(prefixedTableNameResolver.resolve(PersonRecord.class))
+			.isEqualTo("my_prefix_person_record");
+		assertThat(prefixedTableNameResolver.getTableNameCache())
+			.hasSize(1);
 	}
 
 	@Test
 	void resolvePrefixedAndSuffixedAndSeparatorTableNameFromRecord() {
 		assertThat(prefixedAndSuffixedTableAndSeparatorTableNameResolver.resolve(PersonRecord.class))
-				.isEqualTo("prefix-person-record-suffix");
+			.isEqualTo("prefix-person-record-suffix");
+		assertThat(prefixedAndSuffixedTableAndSeparatorTableNameResolver.getTableNameCache())
+			.hasSize(1);
+	}
+
+	@Test
+	void resolveSameTableNameSuccessfully() {
+		assertThat(tableNameResolver.getTableNameCache())
+			.isEmpty();
+		assertThat(tableNameResolver.resolve(MoreComplexPerson.class))
+			.isEqualTo("more_complex_person");
+		assertThat(tableNameResolver.resolve(MoreComplexPerson.class))
+			.isEqualTo("more_complex_person");
+		assertThat(tableNameResolver.resolve(MoreComplexPerson.class))
+			.isEqualTo("more_complex_person");
+		assertThat(tableNameResolver.getTableNameCache())
+			.hasSize(1);
 	}
 
 	record PersonRecord(String name) {
@@ -92,4 +125,5 @@ class DynamoDbTableNameResolverTest {
 
 	private static class MoreComplexPerson {
 	}
+
 }


### PR DESCRIPTION
Resolves #1463 

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [X] Refactoring


## :scroll: Description
Enhance DefaultDynamoDbTableNameResolver with caching and improved table name resolution.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [] I updated reference documentation to reflect the change
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
