### PR TITLE
Add Spring Integration channel adapter for SQS

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -2241,7 +2241,7 @@ Sample IAM policy granting access to SQS:
 Starting with version 4.0, Spring Cloud AWS provides https://spring.io/projects/spring-integration[Spring Integration] channel adapters for Amazon SQS.
 
 The `SqsMessageHandler` is for publishing a single message (or their batch) to SQS queue configured explicitly on the `SqsMessageHandler` or resolved via SpEL expression against the request message.
-The logic of this `MessageHandler` is to consume Spring Integration messages from an `inputChannel` and internally it is heavily base on the `SqsAsyncOperations` mentioned above.
+The logic of this `MessageHandler` is to consume Spring Integration messages from an `inputChannel` and internally it is heavily based on the `SqsAsyncOperations` mentioned above.
 When the `SqsMessageHandler` is set into an `async` mode, the result of the send operation is produced as a reply message into the `outputChannel`.
 For a single request, the reply message is created based on the `SendResult`.
 With request message payload as a `Collection<Message<?>>`, the `SqsAsyncOperations.sendManyAsync()` is performed; the `SendResult.Batch` is produced as is as a payload of the reply message.
@@ -2276,5 +2276,5 @@ MessageProducer sqsMessageDrivenChannelAdapter(SqsAsyncClient sqsAsyncClient) {
 }
 ----
 
-The Spring Integration dependency in the `spring-cloud-aws-sqs` module is `optinal` to avoid unnecessary artifacts on classpath when Spring Integration is not used.
+The Spring Integration dependency in the `spring-cloud-aws-sqs` module is `optional` to avoid unnecessary artifacts on classpath when Spring Integration is not used.
 For convenience, a dedicated `spring-cloud-aws-starter-integration-sqs` is provided managing all the required dependencies for Spring Integration support with Amazon SQS.

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -2235,3 +2235,46 @@ Sample IAM policy granting access to SQS:
             "Resource": "yourARN"
         }
 ----
+
+=== Spring Integration Support
+
+Starting with version 4.0, Spring Cloud AWS provides https://spring.io/projects/spring-integration[Spring Integration] channel adapters for Amazon SQS.
+
+The `SqsMessageHandler` is for publishing a single message (or their batch) to SQS queue configured explicitly on the `SqsMessageHandler` or resolved via SpEL expression against the request message.
+The logic of this `MessageHandler` is to consume Spring Integration messages from an `inputChannel` and internally it is heavily base on the `SqsAsyncOperations` mentioned above.
+When the `SqsMessageHandler` is set into an `async` mode, the result of the send operation is produced as a reply message into the `outputChannel`.
+For a single request, the reply message is created based on the `SendResult`.
+With request message payload as a `Collection<Message<?>>`, the `SqsAsyncOperations.sendManyAsync()` is performed; the `SendResult.Batch` is produced as is as a payload of the reply message.
+The minimal configuration for this channel adapter is as follows:
+
+[source,java]
+----
+@Bean
+@ServiceActivator(inputChannel = "sqsSendChannel")
+MessageHandler sqsMessageHandler(SqsAsyncOperations sqsAsyncOperations) {
+    SqsMessageHandler sqsMessageHandler = new SqsMessageHandler(sqsAsyncOperations);
+    sqsMessageHandler.setQueue("queue1");
+    return sqsMessageHandler;
+}
+----
+
+The `SqsMessageDrivenChannelAdapter` is for consuming messages from one or more SQS queues.
+This channel adapter requires an `SqsAsyncClient` and internally is heavily based on the `SqsMessageListenerContainer` mentioned above.
+The `SqsContainerOptions` can be injected for further listener container customization.
+The consumed messages are then produced to the `outputChannel` for further Spring Integration processing.
+If the `ListenerMode` on the `SqsContainerOptions` is set to `BATCH`, the received `Collection<Message<?>>` is wrapped into a single message to produce.
+The Spring Integration https://docs.spring.io/spring-integration/reference/splitter.html[splitter] pattern could be used downstream for per-message processing.
+The minimal configuration for this channel adapter is as follows:
+
+[source,java]
+----
+@Bean
+MessageProducer sqsMessageDrivenChannelAdapter(SqsAsyncClient sqsAsyncClient) {
+    SqsMessageDrivenChannelAdapter adapter = new SqsMessageDrivenChannelAdapter(sqsAsyncClient, "testQueue");
+    adapter.setOutputChannelName("inputChannel");
+    return adapter;
+}
+----
+
+The Spring Integration dependency in the `spring-cloud-aws-sqs` module is `optinal` to avoid unnecessary artifacts on classpath when Spring Integration is not used.
+For convenience, a dedicated `spring-cloud-aws-starter-integration-sqs` is provided managing all the required dependencies for Spring Integration support with Amazon SQS.

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -216,6 +216,12 @@
 
 			<dependency>
 				<groupId>io.awspring.cloud</groupId>
+				<artifactId>spring-cloud-aws-starter-integration-sqs</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>io.awspring.cloud</groupId>
 				<artifactId>spring-cloud-aws-test</artifactId>
 				<version>${project.version}</version>
 			</dependency>

--- a/spring-cloud-aws-sqs/pom.xml
+++ b/spring-cloud-aws-sqs/pom.xml
@@ -31,6 +31,11 @@
 			<artifactId>spring-context</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-core</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.retry</groupId>
 			<artifactId>spring-retry</artifactId>
 		</dependency>

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/integration/SqsMessageDrivenChannelAdapter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/integration/SqsMessageDrivenChannelAdapter.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.sqs.integration;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
+import io.awspring.cloud.sqs.listener.MessageListener;
+import io.awspring.cloud.sqs.listener.SqsContainerOptions;
+import io.awspring.cloud.sqs.listener.SqsMessageListenerContainer;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+import org.springframework.integration.endpoint.MessageProducerSupport;
+import org.springframework.integration.support.management.IntegrationManagedResource;
+import org.springframework.jmx.export.annotation.ManagedAttribute;
+import org.springframework.jmx.export.annotation.ManagedResource;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.util.Assert;
+
+/**
+ * The {@link MessageProducerSupport} implementation for the Amazon SQS
+ * {@code receiveMessage}. Works in 'listener' manner and delegates hard work to the
+ * {@link SqsMessageListenerContainer}.
+ *
+ * @author Artem Bilan
+ * @author Patrick Fitzsimons
+ *
+ * @since 4.0
+ *
+ * @see SqsMessageListenerContainerFactory
+ * @see MessageListener
+ */
+@ManagedResource
+@IntegrationManagedResource
+public class SqsMessageDrivenChannelAdapter extends MessageProducerSupport {
+
+	private final SqsMessageListenerContainerFactory.Builder<Object> sqsMessageListenerContainerFactory =
+		SqsMessageListenerContainerFactory.builder();
+
+	private final String[] queues;
+
+	private SqsContainerOptions sqsContainerOptions;
+
+	private SqsMessageListenerContainer<?> listenerContainer;
+
+	public SqsMessageDrivenChannelAdapter(SqsAsyncClient amazonSqs, String... queues) {
+		Assert.noNullElements(queues, "'queues' must not be empty");
+		this.sqsMessageListenerContainerFactory.sqsAsyncClient(amazonSqs);
+		this.queues = Arrays.copyOf(queues, queues.length);
+	}
+
+	public void setSqsContainerOptions(SqsContainerOptions sqsContainerOptions) {
+		this.sqsContainerOptions = sqsContainerOptions;
+	}
+
+	@Override
+	protected void onInit() {
+		super.onInit();
+		if (this.sqsContainerOptions != null) {
+			this.sqsMessageListenerContainerFactory.configure(sqsContainerOptionsBuilder ->
+				sqsContainerOptionsBuilder.fromBuilder(this.sqsContainerOptions.toBuilder()));
+		}
+		this.sqsMessageListenerContainerFactory.messageListener(new IntegrationMessageListener());
+		this.listenerContainer = this.sqsMessageListenerContainerFactory.build().createContainer(this.queues);
+	}
+
+	@Override
+	public String getComponentType() {
+		return "aws:sqs-message-driven-channel-adapter";
+	}
+
+	@Override
+	protected void doStart() {
+		this.listenerContainer.start();
+	}
+
+	@Override
+	protected void doStop() {
+		this.listenerContainer.stop();
+	}
+
+	@ManagedAttribute
+	public String[] getQueues() {
+		return Arrays.copyOf(this.queues, this.queues.length);
+	}
+
+	private class IntegrationMessageListener implements MessageListener<Object> {
+
+		IntegrationMessageListener() {
+		}
+
+		@Override
+		public void onMessage(Message<Object> message) {
+			sendMessage(message);
+		}
+
+		@Override
+		public void onMessage(Collection<Message<Object>> messages) {
+			onMessage(new GenericMessage<>(messages));
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/integration/SqsMessageHandler.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/integration/SqsMessageHandler.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.sqs.integration;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.operations.SendResult;
+import io.awspring.cloud.sqs.operations.SqsAsyncOperations;
+
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.common.LiteralExpression;
+import org.springframework.integration.MessageTimeoutException;
+import org.springframework.integration.expression.ExpressionUtils;
+import org.springframework.integration.expression.ValueExpression;
+import org.springframework.integration.handler.AbstractMessageProducingHandler;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+
+/**
+ * The {@link AbstractMessageProducingHandler} implementation for the Amazon SQS.
+ * All the logic based on the {@link SqsAsyncOperations#sendAsync(String, Message)}
+ * or {@link SqsAsyncOperations#sendManyAsync(String, Collection)} if the request message's payload
+ * is a collection of {@link Message} instances.
+ * <p>
+ * All the SQS-specific message attributes have to be provided in the respective message headers
+ * via {@link SqsHeaders.MessageSystemAttributes} constant values or with the {@link SqsAsyncOperations}.
+ * <p>
+ * This {@link AbstractMessageProducingHandler} produces a reply only in the {@link #isAsync()} mode.
+ * For a single request message the {@link SendResult} is converted to the reply message with respective headers.
+ * The {@link SendResult.Batch} is sent as a reply message's payload as is.
+ *
+ * @author Artem Bilan
+ *
+ * @since 4.0
+ *
+ * @see SqsAsyncOperations#sendAsync
+ * @see SqsAsyncOperations#sendManyAsync
+ * @see SqsHeaders.MessageSystemAttributes
+ */
+public class SqsMessageHandler extends AbstractMessageProducingHandler {
+
+	public static final long DEFAULT_SEND_TIMEOUT = 10000;
+
+	private final SqsAsyncOperations sqsAsyncOperations;
+
+	private Expression queueExpression;
+
+	private EvaluationContext evaluationContext;
+
+	private Expression sendTimeoutExpression = new ValueExpression<>(DEFAULT_SEND_TIMEOUT);
+
+	public SqsMessageHandler(SqsAsyncOperations sqsAsyncOperations) {
+		this.sqsAsyncOperations = sqsAsyncOperations;
+	}
+
+	public void setQueue(String queue) {
+		setQueueExpression(new LiteralExpression(queue));
+	}
+
+	public void setQueueExpressionString(String queueExpression) {
+		setQueueExpression(EXPRESSION_PARSER.parseExpression(queueExpression));
+	}
+
+	public void setQueueExpression(Expression queueExpression) {
+		this.queueExpression = queueExpression;
+	}
+
+	public void setSendTimeout(long sendTimeout) {
+		setSendTimeoutExpression(new ValueExpression<>(sendTimeout));
+	}
+
+	public void setSendTimeoutExpressionString(String sendTimeoutExpression) {
+		setSendTimeoutExpression(EXPRESSION_PARSER.parseExpression(sendTimeoutExpression));
+	}
+
+	public void setSendTimeoutExpression(Expression sendTimeoutExpression) {
+		Assert.notNull(sendTimeoutExpression, "'sendTimeoutExpression' must not be null");
+		this.sendTimeoutExpression = sendTimeoutExpression;
+	}
+
+	@Override
+	protected void onInit() {
+		Assert.notNull(this.queueExpression, "The SQS queue must be provided.");
+		super.onInit();
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+	}
+
+	@Override
+	protected boolean shouldCopyRequestHeaders() {
+		return false;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected void handleMessageInternal(Message<?> message) {
+		String queueName = this.queueExpression.getValue(this.evaluationContext, message, String.class);
+		Assert.hasText(queueName, "The 'queueExpression' must not evaluate to empty String.");
+		CompletableFuture<?> resultFuture;
+		if (message.getPayload() instanceof Collection<?> collection) {
+			Assert.notEmpty(collection, "The payload with a collection of messages must not be empty.");
+			Object next = collection.iterator().next();
+			Assert.isInstanceOf(Message.class, next,
+				"The payload with a collection of messages must contain 'Message' instances only.");
+			Collection<Message<Object>> messages = (Collection<Message<Object>>) collection;
+
+			resultFuture = this.sqsAsyncOperations.sendManyAsync(queueName, messages)
+				.thenApply((batchResult) -> getMessageBuilderFactory().withPayload(batchResult).build());
+		}
+		else {
+			resultFuture = this.sqsAsyncOperations.sendAsync(queueName, message)
+				.thenApply((sendResult) ->
+					getMessageBuilderFactory()
+						.fromMessage(sendResult.message())
+						.setHeader(SqsHeaders.SQS_QUEUE_NAME_HEADER, sendResult.endpoint())
+						.setHeader(SqsHeaders.MessageSystemAttributes.MESSAGE_ID, sendResult.messageId())
+						.copyHeaders(sendResult.additionalInformation())
+						.build());
+		}
+
+		if (isAsync()) {
+			sendOutputs(resultFuture, message);
+			return;
+		}
+
+		Long sendTimeout = this.sendTimeoutExpression.getValue(this.evaluationContext, message, Long.class);
+		if (sendTimeout == null || sendTimeout < 0) {
+			try {
+				resultFuture.get();
+			}
+			catch (InterruptedException | ExecutionException ex) {
+				throw new IllegalStateException(ex);
+			}
+		}
+		else {
+			try {
+				resultFuture.get(sendTimeout, TimeUnit.MILLISECONDS);
+			}
+			catch (TimeoutException te) {
+				throw new MessageTimeoutException(message, "Timeout waiting for response from Amazon SQS", te);
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				throw new IllegalStateException(ex);
+			}
+			catch (ExecutionException ex) {
+				throw new IllegalStateException(ex);
+			}
+		}
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsHeaders.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.awspring.cloud.sqs.listener;
 
 /**
@@ -20,8 +21,12 @@ package io.awspring.cloud.sqs.listener;
  * instances created from SQS messages. Can be used to retrieve headers from messages either through
  * {@link org.springframework.messaging.MessageHeaders#get} or
  * {@link org.springframework.messaging.handler.annotation.Header} parameter annotations.
+ *
  * @author Tomaz Fernandes
+ * @author Artem Bilan
+ *
  * @since 3.0
+ *
  * @see io.awspring.cloud.sqs.support.converter.SqsHeaderMapper
  */
 public class SqsHeaders {
@@ -127,14 +132,19 @@ public class SqsHeaders {
 		public static final String SQS_SENDER_ID = SQS_MSA_HEADER_PREFIX + "SenderId";
 
 		/**
-		 * SenderId header in a SQS message.
+		 * Sequence number header from an SQS send result.
 		 */
 		public static final String SQS_SEQUENCE_NUMBER = SQS_MSA_HEADER_PREFIX + "SequenceNumber";
 
 		/**
-		 * SenderId header in a SQS message.
+		 * Tracing header in the SQS message request.
 		 */
 		public static final String SQS_AWS_TRACE_HEADER = SQS_MSA_HEADER_PREFIX + "AWSTraceHeader";
+
+		/**
+		 * Message ID header from an SQS send result.
+		 */
+		public static final String MESSAGE_ID = SQS_MSA_HEADER_PREFIX + "messageId";
 
 	}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/BaseSqsIntegrationTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/BaseSqsIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.awspring.cloud.sqs.integration;
 
 import io.awspring.cloud.sqs.CompletableFutures;
@@ -37,7 +38,7 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 abstract class BaseSqsIntegrationTest {
 
 	private static final Logger logger = LoggerFactory.getLogger(BaseSqsIntegrationTest.class);

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageDrivenChannelAdapterTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageDrivenChannelAdapterTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2015-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.sqs.integration;
+
+import java.util.Map;
+
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.core.MessageProducer;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Artem Bilan
+ */
+@SpringJUnitConfig
+@DirtiesContext
+class SqsMessageDrivenChannelAdapterTests extends BaseSqsIntegrationTest {
+
+	static SqsAsyncClient AMAZON_SQS;
+
+	static String testQueueUrl;
+
+	@Autowired
+	PollableChannel inputChannel;
+
+	@BeforeAll
+	static void setup() {
+		AMAZON_SQS = createAsyncClient();
+		testQueueUrl = AMAZON_SQS.createQueue(request -> request.queueName("testQueue")).join().queueUrl();
+	}
+
+	@Test
+	void sqsMessageDrivenChannelAdapter() {
+		Map<String, MessageAttributeValue> attributes =
+			Map.of("someAttribute",
+				MessageAttributeValue.builder()
+					.stringValue("someValue")
+					.dataType("String")
+					.build());
+
+		AMAZON_SQS.sendMessageBatch(request ->
+			request.queueUrl(testQueueUrl)
+				.entries(SendMessageBatchRequestEntry.builder()
+						.messageBody("messageContent")
+						.id("messageContent_id")
+						.messageAttributes(attributes)
+						.build(),
+					SendMessageBatchRequestEntry.builder()
+						.messageBody("messageContent2")
+						.id("messageContent2_id")
+						.messageAttributes(attributes)
+						.build()));
+
+		org.springframework.messaging.Message<?> receive = this.inputChannel.receive(10000);
+		assertThat(receive).isNotNull();
+		assertThat((String) receive.getPayload()).isIn("messageContent", "messageContent2");
+		assertThat(receive.getHeaders().get(SqsHeaders.SQS_QUEUE_NAME_HEADER)).isEqualTo("testQueue");
+		assertThat(receive.getHeaders().get("someAttribute")).isEqualTo("someValue");
+
+		receive = this.inputChannel.receive(10000);
+		assertThat(receive).isNotNull();
+		assertThat((String) receive.getPayload()).isIn("messageContent", "messageContent2");
+		assertThat(receive.getHeaders().get(SqsHeaders.SQS_QUEUE_NAME_HEADER)).isEqualTo("testQueue");
+		assertThat(receive.getHeaders().get("someAttribute")).isEqualTo("someValue");
+	}
+
+	@Configuration
+	@EnableIntegration
+	static class ContextConfiguration {
+
+		@Bean
+		PollableChannel inputChannel() {
+			return new QueueChannel();
+		}
+
+		@Bean
+		MessageProducer sqsMessageDrivenChannelAdapter(PollableChannel inputChannel) {
+			SqsMessageDrivenChannelAdapter adapter = new SqsMessageDrivenChannelAdapter(AMAZON_SQS, "testQueue");
+			adapter.setOutputChannel(inputChannel);
+			return adapter;
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageHandlerTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageHandlerTests.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.sqs.integration;
+
+import java.util.List;
+import java.util.Map;
+
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.operations.SendResult;
+import io.awspring.cloud.sqs.operations.SqsAsyncOperations;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.expression.FunctionExpression;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 4.0
+ */
+@SpringJUnitConfig
+@DirtiesContext
+class SqsMessageHandlerTests extends BaseSqsIntegrationTest {
+
+	static SqsAsyncClient AMAZON_SQS;
+
+	@Autowired
+	MessageChannel sqsSendChannel;
+
+	@Autowired
+	MessageChannel sqsSendBatchChannel;
+
+	@Autowired
+	QueueChannel outputChannel;
+
+	@Autowired
+	SqsMessageHandler sqsMessageHandler;
+
+	@BeforeAll
+	static void setup() {
+		AMAZON_SQS = createAsyncClient();
+	}
+
+	@Test
+	void sqsMessageHandler() {
+		Message<String> message = MessageBuilder.withPayload("message1").build();
+
+		this.sqsSendChannel.send(message);
+
+		ReceiveMessageResponse receiveMessageResponse =
+			AMAZON_SQS.getQueueUrl(request -> request.queueName("queue1"))
+				.thenCompose(response ->
+					AMAZON_SQS.receiveMessage(request ->
+						request.queueUrl(response.queueUrl()).waitTimeSeconds(10)))
+				.join();
+
+		assertThat(receiveMessageResponse.hasMessages()).isTrue();
+		assertThat(receiveMessageResponse.messages().get(0).body()).isEqualTo("message1");
+
+		Message<String> message2 =
+			MessageBuilder.withPayload("message2")
+				.setHeader(SqsHeaders.SQS_QUEUE_NAME_HEADER, "queue2")
+				.setHeader("testHeader", "testValue")
+				.build();
+		this.sqsMessageHandler.setQueueExpression(
+			new FunctionExpression<Message<?>>(m -> m.getHeaders().get(SqsHeaders.SQS_QUEUE_NAME_HEADER)));
+
+		this.sqsSendChannel.send(message2);
+
+		receiveMessageResponse =
+			AMAZON_SQS.getQueueUrl(request -> request.queueName("queue2"))
+				.thenCompose(response ->
+					AMAZON_SQS.receiveMessage(request ->
+						request.queueUrl(response.queueUrl())
+							.messageAttributeNames(QueueAttributeName.ALL.toString())
+							.waitTimeSeconds(10)))
+				.join();
+
+		assertThat(receiveMessageResponse.hasMessages()).isTrue();
+		software.amazon.awssdk.services.sqs.model.Message sqsMessage = receiveMessageResponse.messages().get(0);
+		assertThat(sqsMessage.body()).isEqualTo("message2");
+
+		Map<String, MessageAttributeValue> messageAttributes = sqsMessage.messageAttributes();
+
+		assertThat(messageAttributes)
+			.doesNotContainKeys(MessageHeaders.ID, MessageHeaders.TIMESTAMP)
+			.containsKey("testHeader");
+		assertThat(messageAttributes.get("testHeader").stringValue()).isEqualTo("testValue");
+	}
+
+	@Test
+	void sqsBatchMessageHandler() {
+		GenericMessage<?> message =
+			new GenericMessage<>(List.of(new GenericMessage<>("batchItem1"), new GenericMessage<>("batchItem2")));
+
+		this.sqsSendBatchChannel.send(message);
+
+		Message<?> receive = this.outputChannel.receive(10000);
+		assertThat(receive).isNotNull()
+			.extracting(Message::getPayload)
+			.asInstanceOf(InstanceOfAssertFactories.type(SendResult.Batch.class))
+			.extracting(SendResult.Batch::successful)
+			.asInstanceOf(InstanceOfAssertFactories.LIST)
+			.hasSize(2);
+	}
+
+	@Configuration
+	@EnableIntegration
+	static class ContextConfiguration {
+
+		@Bean
+		SqsAsyncOperations sqsAsyncOperations() {
+			return SqsTemplate.newTemplate(AMAZON_SQS);
+		}
+
+		@Bean
+		@ServiceActivator(inputChannel = "sqsSendChannel")
+		MessageHandler sqsMessageHandler(SqsAsyncOperations sqsAsyncOperations) {
+			SqsMessageHandler sqsMessageHandler = new SqsMessageHandler(sqsAsyncOperations);
+			sqsMessageHandler.setQueue("queue1");
+			return sqsMessageHandler;
+		}
+
+		@Bean
+		@ServiceActivator(inputChannel = "sqsSendBatchChannel", outputChannel = "outputChannel")
+		MessageHandler sqsBatchMessageHandler(SqsAsyncOperations sqsAsyncOperations) {
+			SqsMessageHandler sqsMessageHandler = new SqsMessageHandler(sqsAsyncOperations);
+			sqsMessageHandler.setQueue("queue3");
+			sqsMessageHandler.setAsync(true);
+			return sqsMessageHandler;
+		}
+
+		@Bean
+		QueueChannel outputChannel() {
+			return new QueueChannel();
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-starters/spring-cloud-aws-starter-integration-sqs/pom.xml
+++ b/spring-cloud-aws-starters/spring-cloud-aws-starter-integration-sqs/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>spring-cloud-aws</artifactId>
+		<groupId>io.awspring.cloud</groupId>
+		<version>4.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<name>Spring Cloud AWS Starter for Spring Integration with SQS</name>
+	<artifactId>spring-cloud-aws-starter-integration-sqs</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.awspring.cloud</groupId>
+			<artifactId>spring-cloud-aws-starter-sqs</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-core</artifactId>
+		</dependency>
+	</dependencies>
+
+</project>


### PR DESCRIPTION
* The `SqsMessageHandler` is for producing Spring Integration to SQS. Uses `SqsAsyncOperations` internally.
* The `SqsMessageDrivenChannelAdapter` is for consuming messages from SQS. Uses `SqsMessageListenerContainer` internally.
* Added `SqsHeaders.MESSAGE_ID` constant to represent SQS send result's `messageId` attribute
* Mark The `BaseSqsIntegrationTest` as `disabledWithoutDocker = true` to avoid unnecessary build failure
* Add `spring-cloud-aws-starter-integration-sqs` to manage all the required dependencies for Spring Integration with SQS

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
