### PR TITLE
Add Spring Integration channel adapters for SNS

### DIFF
--- a/docs/src/main/asciidoc/sns.adoc
+++ b/docs/src/main/asciidoc/sns.adoc
@@ -296,3 +296,93 @@ Sample IAM policy granting access to SNS:
     ]
 }
 ----
+
+=== Spring Integration Support
+
+Starting with version 4.0, Spring Cloud AWS provides https://spring.io/projects/spring-integration[Spring Integration] channel adapters for Amazon SNS.
+
+The `SnsInboundChannelAdapter` is an extension of `HttpRequestHandlingMessagingGateway` and must be as a part of Spring MVC application.
+Its URL must be used from the AWS Management Console to add this endpoint as a subscriber to the SNS Topic.
+However, before receiving any notification itself, this HTTP endpoint must confirm the subscription.
+
+See `SnsInboundChannelAdapter` JavaDocs for more information.
+
+An important option of this adapter to consider is `handleNotificationStatus`.
+This `boolean` flag indicates if the adapter should send `SubscriptionConfirmation/UnsubscribeConfirmation` message to the `output-channel` or not.
+If that is a case, the `SnsHeaders.NOTIFICATION_STATUS_HEADER` message header is present in the message with the `NotificationStatus` object, which can be used in the downstream flow to confirm subscription or not.
+Or "re-confirm" it in the case of `UnsubscribeConfirmation` message.
+
+In addition, the `SnsHeaders.SNS_MESSAGE_TYPE_HEADER` message header is represented to simplify a routing in the downstream flow.
+
+The Java Configuration is pretty simple:
+
+[source,java]
+----
+@SpringBootApplication
+public static class MyConfiguration {
+
+	@Autowired
+	private SnsClient amazonSns;
+
+	@Bean
+    public PollableChannel inputChannel() {
+    	return new QueueChannel();
+    }
+
+    @Bean
+    public HttpRequestHandler sqsMessageDrivenChannelAdapter(PollableChannel inputChannel) {
+    	SnsInboundChannelAdapter adapter = new SnsInboundChannelAdapter(amazonSns(), "/mySampleTopic");
+    	adapter.setRequestChannel(inputChannel);
+    	adapter.setHandleNotificationStatus(true);
+    	return adapter;
+    }
+}
+----
+
+Note: by default, the message `payload` is a `Map` converted from the received Topic JSON message.
+For the convenience a `payload-expression` is provided with the `Message` as a root object of the evaluation context.
+Hence, even some HTTP headers, populated by the `DefaultHttpHeaderMapper`, are available for the evaluation context.
+
+
+The `SnsMessageHandler` is a simple one-way Outbound Channel Adapter to send Topic Notification using `SnsAsyncClient` service.
+
+This Channel Adapter (`MessageHandler`) accepts these options:
+
+- `topic-arn` (`topic-arn-expression`) - the SNS Topic to send notification for.
+- `subject` (`subject-expression`) - the SNS Notification Subject;
+- `body-expression` - the SpEL expression to evaluate the `message` property for the `software.amazon.awssdk.services.sns.model.PublishRequest`.
+- `resource-id-resolver` - a `ResourceIdResolver` bean reference to resolve logical topic names to physical resource ids;
+
+See `SnsMessageHandler` JavaDocs for more information.
+
+The Java Config looks like:
+
+[source,java]
+----
+@Bean
+public MessageHandler snsMessageHandler() {
+    SnsMessageHandler handler = new SnsMessageHandler(amazonSns());
+    handler.setTopicArn("arn:aws:sns:eu-west:123456789012:test");
+    String bodyExpression = "T(SnsBodyBuilder).withDefault(payload).forProtocols(payload.substring(0, 140), 'sms')";
+    handler.setBodyExpression(spelExpressionParser.parseExpression(bodyExpression));
+
+    // message-group ID and deduplication ID are used for FIFO topics
+    handler.setMessageGroupId("foo-messages");
+    String deduplicationExpression = "headers.id";
+    handler.setMessageDeduplicationIdExpression(new FunctionExpression<Message<?>>(m -> m.getHeaders().get(MessageHeaders.ID)));
+    return handler;
+}
+----
+
+NOTE: the `bodyExpression` can be evaluated to a `io.awspring.cloud.sns.integration.SnsBodyBuilder` allowing the configuration of a `json` `messageStructure` for the `PublishRequest` and provide separate messages for different protocols.
+The same `SnsBodyBuilder` rule is applied for the raw `payload` if the `bodyExpression` hasn't been configured.
+
+NOTE: if the `payload` of `requestMessage` is a `software.amazon.awssdk.services.sns.model.PublishRequest` already, the `SnsMessageHandler` doesn't do anything with it, and it is sent as-is.
+
+The `SnsMessageHandler` can be configured with the `HeaderMapper` to map message headers to the SNS message attributes.
+See `SnsHeaderMapper` implementation for more information and also consult with https://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html[Amazon SNS Message Attributes] about value types and restrictions.
+
+The `SnsMessageHandler` supports sending to SNS FIFO topics using the `messageGroupId`/`messageGroupIdExpression` and `messageDeduplicationIdExpression` properties.
+
+The Spring Integration dependency in the `spring-cloud-aws-sns` module is `optional` to avoid unnecessary artifacts on classpath when Spring Integration is not used.
+For convenience, a dedicated `spring-cloud-aws-starter-integration-sns` is provided managing all the required dependencies for Spring Integration support with Amazon SNS.

--- a/docs/src/main/asciidoc/sns.adoc
+++ b/docs/src/main/asciidoc/sns.adoc
@@ -331,7 +331,7 @@ public static class MyConfiguration {
 
     @Bean
     public HttpRequestHandler sqsMessageDrivenChannelAdapter(PollableChannel inputChannel) {
-    	SnsInboundChannelAdapter adapter = new SnsInboundChannelAdapter(amazonSns(), "/mySampleTopic");
+    	SnsInboundChannelAdapter adapter = new SnsInboundChannelAdapter(this.amazonSns, "/mySampleTopic");
     	adapter.setRequestChannel(inputChannel);
     	adapter.setHandleNotificationStatus(true);
     	return adapter;
@@ -360,8 +360,8 @@ The Java Config looks like:
 [source,java]
 ----
 @Bean
-public MessageHandler snsMessageHandler() {
-    SnsMessageHandler handler = new SnsMessageHandler(amazonSns());
+public MessageHandler snsMessageHandler(SnsAsyncClient amazonSns) {
+    SnsMessageHandler handler = new SnsMessageHandler(amazonSns);
     handler.setTopicArn("arn:aws:sns:eu-west:123456789012:test");
     String bodyExpression = "T(SnsBodyBuilder).withDefault(payload).forProtocols(payload.substring(0, 140), 'sms')";
     handler.setBodyExpression(spelExpressionParser.parseExpression(bodyExpression));

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,9 @@
 		<module>spring-cloud-aws-starters/spring-cloud-aws-starter-secrets-manager</module>
 		<module>spring-cloud-aws-starters/spring-cloud-aws-starter-ses</module>
 		<module>spring-cloud-aws-starters/spring-cloud-aws-starter-sns</module>
+		<module>spring-cloud-aws-starters/spring-cloud-aws-starter-integration-sns</module>
 		<module>spring-cloud-aws-starters/spring-cloud-aws-starter-sqs</module>
+		<module>spring-cloud-aws-starters/spring-cloud-aws-starter-integration-sqs</module>
 		<module>spring-cloud-aws-samples</module>
 		<module>spring-cloud-aws-test</module>
 		<module>spring-cloud-aws-modulith</module>

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -210,6 +210,12 @@
 
 			<dependency>
 				<groupId>io.awspring.cloud</groupId>
+				<artifactId>spring-cloud-aws-starter-integration-sns</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>io.awspring.cloud</groupId>
 				<artifactId>spring-cloud-aws-starter-sqs</artifactId>
 				<version>${project.version}</version>
 			</dependency>

--- a/spring-cloud-aws-sns/pom.xml
+++ b/spring-cloud-aws-sns/pom.xml
@@ -37,6 +37,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-http</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
 			<optional>true</optional>

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/SnsAsyncTopicArnResolver.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/SnsAsyncTopicArnResolver.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sns.core;
+
+import org.springframework.util.Assert;
+import software.amazon.awssdk.arns.Arn;
+import software.amazon.awssdk.services.sns.SnsAsyncClient;
+
+/**
+ * A {@link TopicArnResolver} implementation to determine topic ARN by name against an {@link SnsAsyncClient}.
+ *
+ * @author Artem Bilan
+ *
+ * @since 4.0
+ */
+public class SnsAsyncTopicArnResolver implements TopicArnResolver {
+	private final SnsAsyncClient snsClient;
+
+	public SnsAsyncTopicArnResolver(SnsAsyncClient snsClient) {
+		Assert.notNull(snsClient, "snsClient is required");
+		this.snsClient = snsClient;
+	}
+
+	/**
+	 * Resolve topic ARN by topic name. If topicName is already an ARN, it returns {@link Arn}. If topicName is just a
+	 * string with a topic name, it attempts to create a topic or if the topic already exists, just returns its ARN.
+	 */
+	@Override
+	public Arn resolveTopicArn(String topicName) {
+		Assert.notNull(topicName, "topicName must not be null");
+		if (topicName.toLowerCase().startsWith("arn:")) {
+			return Arn.fromString(topicName);
+		}
+		else {
+			// if the topic exists, createTopic returns a successful response with the topic arn
+			return Arn.fromString(this.snsClient.createTopic(request -> request.name(topicName)).join().topicArn());
+		}
+	}
+
+}

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/SnsHeaders.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/SnsHeaders.java
@@ -15,16 +15,25 @@
  */
 package io.awspring.cloud.sns.core;
 
+import io.awspring.cloud.sns.handlers.NotificationStatus;
+import io.awspring.cloud.sns.integration.SnsInboundChannelAdapter;
 import org.springframework.messaging.Message;
 import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
 
 /**
  * SNS specific headers that can be applied to Spring Messaging {@link Message}.
  *
  * @author Matej Nedic
+ * @author Artem Bilan
  * @since 3.0.0
  */
 public final class SnsHeaders {
+
+	/**
+	 * SNS Headers prefix to be used by all headers added by the framework.
+	 */
+	public static final String SNS_HEADER_PREFIX = "Sns_";
 
 	/**
 	 * Notification subject. The value of this header is set to {@link PublishRequest#subject()}.
@@ -42,6 +51,29 @@ public final class SnsHeaders {
 	 * {@link PublishRequest#messageDeduplicationId()}}}.
 	 */
 	public static final String MESSAGE_DEDUPLICATION_ID_HEADER = "message-deduplication-id";
+
+	/**
+	 * Topic ARN header where the message has been published. The value of this header is set from
+	 * {@link PublishRequest#topicArn()}.
+	 */
+	public static final String TOPIC_HEADER = SNS_HEADER_PREFIX + "topicArn";
+
+	/**
+	 * Message id header as a unique identifier assigned to the published message, or from a received message. The value
+	 * of this header is set from {@link PublishResponse#messageId()}.
+	 */
+	public static final String MESSAGE_ID_HEADER = SNS_HEADER_PREFIX + "messageId";
+
+	/**
+	 * The {@link NotificationStatus} header for manual confirmation on reception. The value of this header is set from
+	 * {@link SnsInboundChannelAdapter}.
+	 */
+	public static final String NOTIFICATION_STATUS_HEADER = SNS_HEADER_PREFIX + "notificationStatus";
+
+	/**
+	 * The {@value SNS_MESSAGE_TYPE_HEADER} header for the received SNS message type.
+	 */
+	public static final String SNS_MESSAGE_TYPE_HEADER = SNS_HEADER_PREFIX + "messageType";
 
 	private SnsHeaders() {
 

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/integration/SnsBodyBuilder.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/integration/SnsBodyBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sns.integration;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.util.Assert;
+
+/**
+ * A utility class to simplify an SNS Message body building. Can be used from the
+ * {@code SnsMessageHandler#bodyExpression} definition or directly in case of manual
+ * {@link software.amazon.awssdk.services.sns.model.PublishRequest} building.
+ *
+ * @author Artem Bilan
+ *
+ * @since 4.0
+ */
+public final class SnsBodyBuilder {
+
+	private final Map<String, String> snsMessage = new HashMap<>();
+
+	private SnsBodyBuilder(String defaultMessage) {
+		Assert.hasText(defaultMessage, "defaultMessage must not be empty.");
+		this.snsMessage.put("default", defaultMessage);
+	}
+
+	public SnsBodyBuilder forProtocols(String message, String... protocols) {
+		Assert.hasText(message, "message must not be empty.");
+		Assert.notEmpty(protocols, "protocols must not be empty.");
+		for (String protocol : protocols) {
+			Assert.hasText(protocol, "protocols must not contain empty elements.");
+			this.snsMessage.put(protocol, message);
+		}
+		return this;
+	}
+
+	public String build() {
+		StringBuilder stringBuilder = new StringBuilder("{");
+		for (Map.Entry<String, String> entry : this.snsMessage.entrySet()) {
+			stringBuilder.append("\"").append(entry.getKey()).append("\":\"")
+					.append(entry.getValue().replaceAll("\"", "\\\\\"")).append("\",");
+		}
+		return stringBuilder.substring(0, stringBuilder.length() - 1) + "}";
+	}
+
+	public static SnsBodyBuilder withDefault(String defaultMessage) {
+		return new SnsBodyBuilder(defaultMessage);
+	}
+
+}

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/integration/SnsHeaderMapper.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/integration/SnsHeaderMapper.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sns.integration;
+
+import io.awspring.cloud.sns.core.SnsHeaders;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.integration.mapping.HeaderMapper;
+import org.springframework.integration.support.utils.PatternMatchUtils;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.NativeMessageHeaderAccessor;
+import org.springframework.util.Assert;
+import org.springframework.util.MimeType;
+import org.springframework.util.NumberUtils;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+
+/**
+ * The {@link HeaderMapper} implementation for the mapping from headers to SNS message attributes.
+ * <p>
+ * On the Inbound side, the SNS message is fully mapped from the JSON to the message payload. Only important HTTP
+ * headers are mapped to the message headers.
+ *
+ * @author Artem Bilan
+ *
+ * @since 2.0
+ */
+public class SnsHeaderMapper implements HeaderMapper<Map<String, MessageAttributeValue>> {
+
+	private final Log logger = LogFactory.getLog(SnsHeaderMapper.class);
+
+	private volatile String[] outboundHeaderNames = { "!" + MessageHeaders.ID, "!" + MessageHeaders.TIMESTAMP,
+			"!" + NativeMessageHeaderAccessor.NATIVE_HEADERS, "!" + SnsHeaders.MESSAGE_ID_HEADER,
+			"!" + SnsHeaders.TOPIC_HEADER, "*", };
+
+	/**
+	 * Provide the header names that should be mapped to an AWS request object attributes (for outbound adapters) from a
+	 * Spring Integration Message's headers. The values can also contain simple wildcard patterns (e.g. "foo*" or
+	 * "*foo") to be matched. Also supports negated ('!') patterns. First match wins (positive or negative). To match
+	 * the names starting with {@code !} symbol, you have to escape it prepending with the {@code \} symbol in the
+	 * pattern definition. Defaults to map all ({@code *}) if the type is supported by SQS. The
+	 * {@link MessageHeaders#ID}, {@link MessageHeaders#TIMESTAMP}, {@link NativeMessageHeaderAccessor#NATIVE_HEADERS},
+	 * {@link SnsHeaders#MESSAGE_ID_HEADER and {@link SnsHeaders#TOPIC_HEADER} are ignored by default.
+	 * @param outboundHeaderNames The inbound header names.
+	 */
+	public void setOutboundHeaderNames(String... outboundHeaderNames) {
+		Assert.notNull(outboundHeaderNames, "'outboundHeaderNames' must not be null.");
+		Assert.noNullElements(outboundHeaderNames, "'outboundHeaderNames' must not contains null elements.");
+		Arrays.sort(outboundHeaderNames);
+		this.outboundHeaderNames = outboundHeaderNames;
+	}
+
+	@Override
+	public void fromHeaders(MessageHeaders headers, Map<String, MessageAttributeValue> target) {
+		for (Map.Entry<String, Object> messageHeader : headers.entrySet()) {
+			String messageHeaderName = messageHeader.getKey();
+			Object messageHeaderValue = messageHeader.getValue();
+
+			if (Boolean.TRUE.equals(PatternMatchUtils.smartMatch(messageHeaderName, this.outboundHeaderNames))) {
+				if (messageHeaderValue instanceof UUID || messageHeaderValue instanceof MimeType
+						|| messageHeaderValue instanceof Boolean || messageHeaderValue instanceof String) {
+
+					target.put(messageHeaderName, getStringMessageAttribute(messageHeaderValue.toString()));
+				}
+				else if (messageHeaderValue instanceof Number) {
+					target.put(messageHeaderName, getNumberMessageAttribute(messageHeaderValue));
+				}
+				else if (messageHeaderValue instanceof ByteBuffer byteBuffer) {
+					target.put(messageHeaderName, getBinaryMessageAttribute(byteBuffer));
+				}
+				else if (messageHeaderValue instanceof byte[] bytes) {
+					target.put(messageHeaderName, getBinaryMessageAttribute(ByteBuffer.wrap(bytes)));
+				}
+				else {
+					if (this.logger.isWarnEnabled()) {
+						this.logger.warn(String.format(
+								"Message header with name '%s' and type '%s' cannot be sent as"
+										+ " message attribute because it is not supported by the current AWS service.",
+								messageHeaderName, messageHeaderValue.getClass().getName()));
+					}
+				}
+
+			}
+		}
+	}
+
+	private MessageAttributeValue getBinaryMessageAttribute(ByteBuffer messageHeaderValue) {
+		return buildMessageAttribute("Binary", messageHeaderValue);
+	}
+
+	private MessageAttributeValue getStringMessageAttribute(String messageHeaderValue) {
+		return buildMessageAttribute("String", messageHeaderValue);
+	}
+
+	private MessageAttributeValue getNumberMessageAttribute(Object messageHeaderValue) {
+		Assert.isTrue(NumberUtils.STANDARD_NUMBER_TYPES.contains(messageHeaderValue.getClass()),
+				"Only standard number types are accepted as message header.");
+
+		return buildMessageAttribute("Number." + messageHeaderValue.getClass().getName(), messageHeaderValue);
+	}
+
+	private MessageAttributeValue buildMessageAttribute(String dataType, Object value) {
+		MessageAttributeValue.Builder messageAttributeValue = MessageAttributeValue.builder().dataType(dataType);
+		if (value instanceof ByteBuffer byteBuffer) {
+			messageAttributeValue.binaryValue(SdkBytes.fromByteBuffer(byteBuffer));
+		}
+		else {
+			messageAttributeValue.stringValue(value.toString());
+		}
+
+		return messageAttributeValue.build();
+	}
+
+	@Override
+	public Map<String, Object> toHeaders(Map<String, MessageAttributeValue> source) {
+		throw new UnsupportedOperationException("The mapping from AWS Response Message is not supported");
+	}
+
+}

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/integration/SnsHeaderMapper.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/integration/SnsHeaderMapper.java
@@ -40,7 +40,7 @@ import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
  *
  * @author Artem Bilan
  *
- * @since 2.0
+ * @since 4.0
  */
 public class SnsHeaderMapper implements HeaderMapper<Map<String, MessageAttributeValue>> {
 
@@ -55,7 +55,7 @@ public class SnsHeaderMapper implements HeaderMapper<Map<String, MessageAttribut
 	 * Spring Integration Message's headers. The values can also contain simple wildcard patterns (e.g. "foo*" or
 	 * "*foo") to be matched. Also supports negated ('!') patterns. First match wins (positive or negative). To match
 	 * the names starting with {@code !} symbol, you have to escape it prepending with the {@code \} symbol in the
-	 * pattern definition. Defaults to map all ({@code *}) if the type is supported by SQS. The
+	 * pattern definition. Defaults to map all ({@code *}) if the type is supported by SNS. The
 	 * {@link MessageHeaders#ID}, {@link MessageHeaders#TIMESTAMP}, {@link NativeMessageHeaderAccessor#NATIVE_HEADERS},
 	 * {@link SnsHeaders#MESSAGE_ID_HEADER and {@link SnsHeaders#TOPIC_HEADER} are ignored by default.
 	 * @param outboundHeaderNames The inbound header names.
@@ -101,22 +101,23 @@ public class SnsHeaderMapper implements HeaderMapper<Map<String, MessageAttribut
 		}
 	}
 
-	private MessageAttributeValue getBinaryMessageAttribute(ByteBuffer messageHeaderValue) {
+	private static MessageAttributeValue getBinaryMessageAttribute(ByteBuffer messageHeaderValue) {
 		return buildMessageAttribute("Binary", messageHeaderValue);
 	}
 
-	private MessageAttributeValue getStringMessageAttribute(String messageHeaderValue) {
+	private static MessageAttributeValue getStringMessageAttribute(String messageHeaderValue) {
 		return buildMessageAttribute("String", messageHeaderValue);
 	}
 
-	private MessageAttributeValue getNumberMessageAttribute(Object messageHeaderValue) {
-		Assert.isTrue(NumberUtils.STANDARD_NUMBER_TYPES.contains(messageHeaderValue.getClass()),
+	private static MessageAttributeValue getNumberMessageAttribute(Object messageHeaderValue) {
+		Class<?> messageHeaderValueClass = messageHeaderValue.getClass();
+		Assert.isTrue(NumberUtils.STANDARD_NUMBER_TYPES.contains(messageHeaderValueClass),
 				"Only standard number types are accepted as message header.");
 
-		return buildMessageAttribute("Number." + messageHeaderValue.getClass().getName(), messageHeaderValue);
+		return buildMessageAttribute("Number." + messageHeaderValueClass.getName(), messageHeaderValue);
 	}
 
-	private MessageAttributeValue buildMessageAttribute(String dataType, Object value) {
+	private static MessageAttributeValue buildMessageAttribute(String dataType, Object value) {
 		MessageAttributeValue.Builder messageAttributeValue = MessageAttributeValue.builder().dataType(dataType);
 		if (value instanceof ByteBuffer byteBuffer) {
 			messageAttributeValue.binaryValue(SdkBytes.fromByteBuffer(byteBuffer));

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/integration/SnsInboundChannelAdapter.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/integration/SnsInboundChannelAdapter.java
@@ -94,8 +94,8 @@ public class SnsInboundChannelAdapter extends HttpRequestHandlingMessagingGatewa
 	}
 
 	/**
-	 * The flag indicating if the adapter should send {@code SubscriptionConfirmation/UnsubscribeConfirmation}
-	 * message to the `output-channel` or not.
+	 * The flag indicating if the adapter should send {@code SubscriptionConfirmation/UnsubscribeConfirmation} message
+	 * to the `output-channel` or not.
 	 * @param handleNotificationStatus the flag to set. Default is {@code false}.
 	 */
 	public void setHandleNotificationStatus(boolean handleNotificationStatus) {

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/integration/SnsInboundChannelAdapter.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/integration/SnsInboundChannelAdapter.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sns.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.awspring.cloud.sns.core.SnsHeaders;
+import io.awspring.cloud.sns.handlers.NotificationStatus;
+import io.awspring.cloud.sns.handlers.NotificationStatusHandlerMethodArgumentResolver;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.integration.expression.ValueExpression;
+import org.springframework.integration.http.inbound.HttpRequestHandlingMessagingGateway;
+import org.springframework.integration.http.inbound.RequestMapping;
+import org.springframework.integration.mapping.HeaderMapper;
+import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+import org.springframework.web.multipart.MultipartResolver;
+import software.amazon.awssdk.services.sns.SnsClient;
+
+/**
+ * The {@link HttpRequestHandlingMessagingGateway} extension for the Amazon WS SNS HTTP(S) endpoints. Accepts all
+ * {@code x-amz-sns-message-type}s, converts the received Topic JSON message to the {@link Map} using
+ * {@link org.springframework.http.converter.json.MappingJackson2HttpMessageConverter} and send it to the provided
+ * {@link #getRequestChannel()} as {@link Message} {@code payload}.
+ * <p>
+ * The mapped url must be configured inside the Amazon Web Service platform as a subscription. Before receiving any
+ * notification itself, this HTTP endpoint must confirm the subscription.
+ * <p>
+ * The {@link #handleNotificationStatus} flag (defaults to {@code false}) indicates that this endpoint should send the
+ * {@code SubscriptionConfirmation/UnsubscribeConfirmation} messages to the provided {@link #getRequestChannel()}. If
+ * that, the {@link SnsHeaders#NOTIFICATION_STATUS_HEADER} header is populated with the {@link NotificationStatus}
+ * value. In that case it is a responsibility of the application to {@link NotificationStatus#confirmSubscription()} or
+ * not.
+ * <p>
+ * By default, this endpoint just does {@link NotificationStatus#confirmSubscription()} for the
+ * {@code SubscriptionConfirmation} message type. And does nothing for the {@code UnsubscribeConfirmation}.
+ * <p>
+ * For the convenience on the underlying message flow routing a {@link SnsHeaders#SNS_MESSAGE_TYPE_HEADER} header is
+ * present.
+ *
+ * @author Artem Bilan
+ * @author Kamil Przerwa
+ *
+ * @since 4.0
+ */
+@SuppressWarnings("removal")
+public class SnsInboundChannelAdapter extends HttpRequestHandlingMessagingGateway {
+
+	private final NotificationStatusResolver notificationStatusResolver;
+
+	private final org.springframework.http.converter.json.MappingJackson2HttpMessageConverter jackson2HttpMessageConverter = new org.springframework.http.converter.json.MappingJackson2HttpMessageConverter();
+
+	private final String[] path;
+
+	private volatile boolean handleNotificationStatus;
+
+	private volatile Expression payloadExpression;
+
+	private EvaluationContext evaluationContext;
+
+	public SnsInboundChannelAdapter(SnsClient amazonSns, String... path) {
+		super(false);
+		Assert.notNull(amazonSns, "'amazonSns' must not be null.");
+		Assert.notNull(path, "'path' must not be null.");
+		Assert.noNullElements(path, "'path' must not contain null elements.");
+		this.path = path;
+		this.notificationStatusResolver = new NotificationStatusResolver(amazonSns);
+		this.jackson2HttpMessageConverter
+				.setSupportedMediaTypes(Arrays.asList(MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN));
+	}
+
+	/**
+	 * The flag indicating if the adapter should send {@code SubscriptionConfirmation/UnsubscribeConfirmation}
+	 * message to the `output-channel` or not.
+	 * @param handleNotificationStatus the flag to set. Default is {@code false}.
+	 */
+	public void setHandleNotificationStatus(boolean handleNotificationStatus) {
+		this.handleNotificationStatus = handleNotificationStatus;
+	}
+
+	@Override
+	protected void onInit() {
+		super.onInit();
+		RequestMapping requestMapping = new RequestMapping();
+		requestMapping.setMethods(HttpMethod.POST);
+		requestMapping.setHeaders("x-amz-sns-message-type");
+		requestMapping.setPathPatterns(this.path);
+		super.setStatusCodeExpression(new ValueExpression<>(HttpStatus.NO_CONTENT));
+		super.setMessageConverters(Collections.singletonList(this.jackson2HttpMessageConverter));
+		super.setRequestPayloadTypeClass(HashMap.class);
+		super.setRequestMapping(requestMapping);
+		if (this.payloadExpression != null) {
+			this.evaluationContext = createEvaluationContext();
+		}
+	}
+
+	@Override
+	public String getComponentType() {
+		return "aws:sns-inbound-channel-adapter";
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected void send(Object object) {
+		Message<?> message = (Message<?>) object;
+		Map<String, String> payload = (HashMap<String, String>) message.getPayload();
+		AbstractIntegrationMessageBuilder<?> messageToSendBuilder;
+		if (this.payloadExpression != null) {
+			messageToSendBuilder = getMessageBuilderFactory()
+					.withPayload(this.payloadExpression.getValue(this.evaluationContext, message))
+					.copyHeaders(message.getHeaders());
+		}
+		else {
+			messageToSendBuilder = getMessageBuilderFactory().fromMessage(message);
+		}
+
+		String type = payload.get("Type");
+		if ("SubscriptionConfirmation".equals(type) || "UnsubscribeConfirmation".equals(type)) {
+			JsonNode content = this.jackson2HttpMessageConverter.getObjectMapper().valueToTree(payload);
+			NotificationStatus notificationStatus = this.notificationStatusResolver.resolveNotificationStatus(content);
+			if (this.handleNotificationStatus) {
+				messageToSendBuilder.setHeader(SnsHeaders.NOTIFICATION_STATUS_HEADER, notificationStatus);
+			}
+			else {
+				if ("SubscriptionConfirmation".equals(type)) {
+					notificationStatus.confirmSubscription();
+				}
+				return;
+			}
+		}
+		messageToSendBuilder.setHeader(SnsHeaders.SNS_MESSAGE_TYPE_HEADER, type).setHeader(SnsHeaders.MESSAGE_ID_HEADER,
+				payload.get("MessageId"));
+
+		super.send(messageToSendBuilder.build());
+	}
+
+	@Override
+	public void setPayloadExpression(Expression payloadExpression) {
+		this.payloadExpression = payloadExpression;
+	}
+
+	@Override
+	public void setHeaderExpressions(Map<String, Expression> headerExpressions) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setMessageConverters(List<HttpMessageConverter<?>> messageConverters) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setMergeWithDefaultConverters(boolean mergeWithDefaultConverters) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setHeaderMapper(HeaderMapper<HttpHeaders> headerMapper) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setRequestMapping(RequestMapping requestMapping) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setRequestPayloadTypeClass(Class<?> requestPayloadType) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setExtractReplyPayload(boolean extractReplyPayload) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setMultipartResolver(MultipartResolver multipartResolver) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setStatusCodeExpression(Expression statusCodeExpression) {
+		throw new UnsupportedOperationException();
+	}
+
+	private static class NotificationStatusResolver extends NotificationStatusHandlerMethodArgumentResolver {
+
+		NotificationStatusResolver(SnsClient amazonSns) {
+			super(amazonSns);
+		}
+
+		NotificationStatus resolveNotificationStatus(JsonNode content) {
+			return (NotificationStatus) doResolveArgumentFromNotificationMessage(content, null, null);
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/integration/SnsMessageHandler.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/integration/SnsMessageHandler.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sns.integration;
+
+import io.awspring.cloud.sns.core.CachingTopicArnResolver;
+import io.awspring.cloud.sns.core.SnsAsyncTopicArnResolver;
+import io.awspring.cloud.sns.core.SnsHeaders;
+import io.awspring.cloud.sns.core.TopicArnResolver;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.TypeLocator;
+import org.springframework.expression.common.LiteralExpression;
+import org.springframework.expression.spel.support.StandardTypeLocator;
+import org.springframework.integration.MessageTimeoutException;
+import org.springframework.integration.expression.ExpressionUtils;
+import org.springframework.integration.expression.ValueExpression;
+import org.springframework.integration.handler.AbstractMessageProducingHandler;
+import org.springframework.integration.mapping.HeaderMapper;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+import software.amazon.awssdk.services.sns.SnsAsyncClient;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
+
+/**
+ * The {@link AbstractMessageProducingHandler} implementation to send SNS Notifications
+ * ({@link SnsAsyncClient#publish(PublishRequest)}) to the provided {@code topicArn} (or evaluated at runtime against
+ * {@link Message}).
+ * <p>
+ * The SNS Message subject can be evaluated as a result of {@link #subjectExpression}.
+ * <p>
+ * The algorithm to populate an SNS Message body is like:
+ * <ul>
+ * <li>If the {@code payload instanceof PublishRequest} it is used as is for publishing.</li>
+ * <li>If the {@link #bodyExpression} is specified, it is used to be evaluated against {@code requestMessage}.</li>
+ * <li>If the evaluation result (or {@code payload}) is instance of {@link SnsBodyBuilder}, the SNS Message is built
+ * from there and the {@code messageStructure} of the {@link PublishRequest} is set to {@code json}. For the convenience
+ * the package {@code org.springframework.integration.aws.support} is imported to the {@link #evaluationContext} to
+ * allow bypassing it for the {@link SnsBodyBuilder} from the {@link #bodyExpression} definition. For example:
+ * 
+ * <pre class="code">
+ * {@code
+ * String bodyExpression = "SnsBodyBuilder.withDefault(payload).forProtocols(payload.substring(0, 140), 'sms')";
+ * snsMessageHandler.setBodyExpression(spelExpressionParser.parseExpression(bodyExpression));
+ * }
+ * </pre>
+ * 
+ * </li>
+ * <li>Otherwise the {@code payload} (or the {@link #bodyExpression} evaluation result) is converted to the
+ * {@link String} using {@link #getConversionService()}.</li>
+ * </ul>
+ *
+ * @author Artem Bilan
+ * @author Christopher Smith
+ *
+ * @since 4.0
+ *
+ * @see SnsAsyncClient
+ * @see PublishRequest
+ * @see SnsBodyBuilder
+ */
+public class SnsMessageHandler extends AbstractMessageProducingHandler {
+
+	private final SnsAsyncClient amazonSns;
+
+	private Expression topicArnExpression;
+
+	private TopicArnResolver topicArnResolver;
+
+	private Expression subjectExpression;
+
+	private Expression messageGroupIdExpression;
+
+	private Expression messageDeduplicationIdExpression;
+
+	private Expression bodyExpression;
+
+	protected static final long DEFAULT_SEND_TIMEOUT = 10000;
+
+	private EvaluationContext evaluationContext;
+
+	private Expression sendTimeoutExpression = new ValueExpression<>(DEFAULT_SEND_TIMEOUT);
+
+	private HeaderMapper<Map<String, MessageAttributeValue>> headerMapper;
+
+	private boolean headerMapperSet;
+
+	public SnsMessageHandler(SnsAsyncClient amazonSns) {
+		Assert.notNull(amazonSns, "amazonSns must not be null.");
+		this.amazonSns = amazonSns;
+		this.topicArnResolver = new CachingTopicArnResolver(new SnsAsyncTopicArnResolver(this.amazonSns));
+	}
+
+	public void setTopicArn(String topicArn) {
+		Assert.hasText(topicArn, "topicArn must not be empty.");
+		this.topicArnExpression = new LiteralExpression(topicArn);
+	}
+
+	public void setTopicArnExpression(Expression topicArnExpression) {
+		Assert.notNull(topicArnExpression, "topicArnExpression must not be null.");
+		this.topicArnExpression = topicArnExpression;
+	}
+
+	/**
+	 * Provide a custom {@link TopicArnResolver}; defaults to {@link SnsAsyncTopicArnResolver}.
+	 * @param topicArnResolver the {@link TopicArnResolver} to use.
+	 */
+	public void setTopicArnResolver(TopicArnResolver topicArnResolver) {
+		Assert.notNull(topicArnResolver, "'topicArnResolver' must not be null.");
+		this.topicArnResolver = topicArnResolver;
+	}
+
+	public void setSubject(String subject) {
+		Assert.hasText(subject, "subject must not be empty.");
+		this.subjectExpression = new LiteralExpression(subject);
+	}
+
+	public void setSubjectExpression(Expression subjectExpression) {
+		Assert.notNull(subjectExpression, "subjectExpression must not be null.");
+		this.subjectExpression = subjectExpression;
+	}
+
+	/**
+	 * A fixed message-group ID to be set for messages sent to an SNS FIFO topic from this handler. Equivalent to
+	 * calling {{@link #setMessageGroupIdExpression(Expression)} with a literal string expression.
+	 * @param messageGroupId the group ID to be used for all messages sent from this handler
+	 */
+	public void setMessageGroupId(String messageGroupId) {
+		Assert.hasText(messageGroupId, "messageGroupId must not be empty.");
+		this.messageGroupIdExpression = new LiteralExpression(messageGroupId);
+	}
+
+	/**
+	 * The {@link Expression} to determine the
+	 * <a href="https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html">message group</a> for messages
+	 * sent to an SNS FIFO topic from this handler.
+	 * @param messageGroupIdExpression the {@link Expression} to produce the message-group ID
+	 */
+	public void setMessageGroupIdExpression(Expression messageGroupIdExpression) {
+		Assert.notNull(messageGroupIdExpression, "messageGroupIdExpression must not be null.");
+		this.messageGroupIdExpression = messageGroupIdExpression;
+	}
+
+	/**
+	 * The {@link Expression} to determine the deduplication ID for this message. SNS FIFO topics
+	 * <a href="https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html">require a message deduplication ID to
+	 * be specified</a>, either in the adapter configuration or on a {@link PublishRequest} payload of the request
+	 * {@link Message}, unless content-based deduplication is enabled on the topic.
+	 * @param messageDeduplicationIdExpression the {@link Expression} to produce the message deduplication ID
+	 */
+	public void setMessageDeduplicationIdExpression(Expression messageDeduplicationIdExpression) {
+		Assert.notNull(messageDeduplicationIdExpression, "messageDeduplicationIdExpression must not be null.");
+		this.messageDeduplicationIdExpression = messageDeduplicationIdExpression;
+	}
+
+	/**
+	 * The {@link Expression} to produce the SNS notification message. If it evaluates to the {@link SnsBodyBuilder} the
+	 * {@code messageStructure} of the {@link PublishRequest} is set to {@code json}. Otherwise, the
+	 * {@link #getConversionService()} is used to convert the evaluation result to the {@link String} without setting
+	 * the {@code messageStructure}.
+	 * @param bodyExpression the {@link Expression} to produce the SNS notification message.
+	 */
+	public void setBodyExpression(Expression bodyExpression) {
+		Assert.notNull(bodyExpression, "bodyExpression must not be null.");
+		this.bodyExpression = bodyExpression;
+	}
+
+	public void setSendTimeout(long sendTimeout) {
+		setSendTimeoutExpression(new ValueExpression<>(sendTimeout));
+	}
+
+	public void setSendTimeoutExpressionString(String sendTimeoutExpression) {
+		setSendTimeoutExpression(EXPRESSION_PARSER.parseExpression(sendTimeoutExpression));
+	}
+
+	public void setSendTimeoutExpression(Expression sendTimeoutExpression) {
+		Assert.notNull(sendTimeoutExpression, "'sendTimeoutExpression' must not be null");
+		this.sendTimeoutExpression = sendTimeoutExpression;
+	}
+
+	/**
+	 * Specify a {@link HeaderMapper} to map outbound headers.
+	 * @param headerMapper the {@link HeaderMapper} to map outbound headers.
+	 */
+	public void setHeaderMapper(HeaderMapper<Map<String, MessageAttributeValue>> headerMapper) {
+		this.headerMapper = headerMapper;
+		this.headerMapperSet = true;
+	}
+
+	@Override
+	public String getComponentType() {
+		return "aws:sns-outbound-channel-adapter";
+	}
+
+	@Override
+	protected boolean shouldCopyRequestHeaders() {
+		return false;
+	}
+
+	@Override
+	protected void onInit() {
+		super.onInit();
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		if (!this.headerMapperSet) {
+			setHeaderMapper(new SnsHeaderMapper());
+		}
+		TypeLocator typeLocator = this.evaluationContext.getTypeLocator();
+		if (typeLocator instanceof StandardTypeLocator standardTypeLocator) {
+			/*
+			 * Register the 'io.awspring.cloud.sns.integration' package you don't need a FQCN for the 'SnsBodyBuilder'.
+			 */
+			standardTypeLocator.registerImport("io.awspring.cloud.sns.integration");
+		}
+	}
+
+	@Override
+	protected void handleMessageInternal(Message<?> message) {
+		PublishRequest request = messageToAwsRequest(message);
+		CompletableFuture<?> resultFuture = this.amazonSns.publish(request)
+				.handle((response, ex) -> handleResponse(message, request, response, ex));
+
+		if (isAsync()) {
+			sendOutputs(resultFuture, message);
+			return;
+		}
+
+		Long sendTimeout = this.sendTimeoutExpression.getValue(this.evaluationContext, message, Long.class);
+		if (sendTimeout == null || sendTimeout < 0) {
+			try {
+				resultFuture.get();
+			}
+			catch (InterruptedException | ExecutionException ex) {
+				throw new IllegalStateException(ex);
+			}
+		}
+		else {
+			try {
+				resultFuture.get(sendTimeout, TimeUnit.MILLISECONDS);
+			}
+			catch (TimeoutException te) {
+				throw new MessageTimeoutException(message, "Timeout waiting for response from AmazonKinesis", te);
+			}
+			catch (InterruptedException | ExecutionException ex) {
+				throw new IllegalStateException(ex);
+			}
+		}
+	}
+
+	protected Message<?> handleResponse(Message<?> message, PublishRequest request, PublishResponse response,
+			Throwable cause) {
+
+		if (cause != null) {
+			throw new SnsRequestFailureException(message, request, cause);
+		}
+		return getMessageBuilderFactory().fromMessage(message)
+				.copyHeadersIfAbsent(additionalOnSuccessHeaders(request, response)).build();
+	}
+
+	private PublishRequest messageToAwsRequest(Message<?> message) {
+		Object payload = message.getPayload();
+
+		if (payload instanceof PublishRequest publishRequest) {
+			return publishRequest;
+		}
+		else {
+			Assert.state(this.topicArnExpression != null, "'topicArn' or 'topicArnExpression' must be specified.");
+			PublishRequest.Builder publishRequest = PublishRequest.builder();
+			String topic = this.topicArnExpression.getValue(this.evaluationContext, message, String.class);
+			String topicArn = this.topicArnResolver.resolveTopicArn(topic).toString();
+			publishRequest.topicArn(topicArn);
+
+			if (this.subjectExpression != null) {
+				String subject = this.subjectExpression.getValue(this.evaluationContext, message, String.class);
+				publishRequest.subject(subject);
+			}
+
+			if (topicArn.endsWith(".fifo")) {
+				String messageGroupId = null;
+				if (this.messageGroupIdExpression != null) {
+					messageGroupId = this.messageGroupIdExpression.getValue(this.evaluationContext, message,
+							String.class);
+				}
+				Assert.notNull(messageGroupId, () -> "The 'messageGroupIdExpression' [" + this.messageGroupIdExpression
+						+ "] " + "must not evaluate to null. The failed request message is " + message);
+
+				publishRequest.messageGroupId(messageGroupId);
+
+				String messageDeduplicationId = null;
+				if (this.messageDeduplicationIdExpression != null) {
+					messageDeduplicationId = this.messageDeduplicationIdExpression.getValue(this.evaluationContext,
+							message, String.class);
+				}
+				Assert.notNull(messageDeduplicationId,
+						() -> "The 'messageDeduplicationIdExpression' [" + this.messageDeduplicationIdExpression + "] "
+								+ "must not evaluate to null. The failed request message is " + message);
+
+				publishRequest.messageDeduplicationId(messageDeduplicationId);
+			}
+			else if (this.messageGroupIdExpression != null || this.messageDeduplicationIdExpression != null) {
+				logger.info("The 'messageGroupIdExpression' and 'messageDeduplicationIdExpression' properties "
+						+ "are ignored for non-FIFO topics.");
+			}
+
+			Object snsMessage = message.getPayload();
+
+			if (this.bodyExpression != null) {
+				snsMessage = this.bodyExpression.getValue(this.evaluationContext, message);
+			}
+
+			if (snsMessage instanceof SnsBodyBuilder) {
+				publishRequest.messageStructure("json").message(((SnsBodyBuilder) snsMessage).build());
+			}
+			else {
+				publishRequest.message(getConversionService().convert(snsMessage, String.class));
+			}
+
+			if (this.headerMapper != null) {
+				mapHeaders(message, publishRequest, this.headerMapper);
+			}
+			return publishRequest.build();
+		}
+	}
+
+	private void mapHeaders(Message<?> message, PublishRequest.Builder publishRequest,
+			HeaderMapper<Map<String, MessageAttributeValue>> headerMapper) {
+
+		HashMap<String, MessageAttributeValue> messageAttributes = new HashMap<>();
+		headerMapper.fromHeaders(message.getHeaders(), messageAttributes);
+		if (!messageAttributes.isEmpty()) {
+			publishRequest.messageAttributes(messageAttributes);
+		}
+	}
+
+	protected Map<String, ?> additionalOnSuccessHeaders(PublishRequest request, PublishResponse response) {
+		return Map.of(SnsHeaders.TOPIC_HEADER, request.topicArn(), SnsHeaders.MESSAGE_ID_HEADER, response.messageId());
+	}
+
+}

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/integration/SnsRequestFailureException.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/integration/SnsRequestFailureException.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sns.integration;
+
+import java.io.Serial;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+
+/**
+ * An exception that is the payload of an {@code ErrorMessage} when an SNS publish fails.
+ *
+ * @author Jacob Severson
+ * @author Artem Bilan
+ *
+ * @since 4.0
+ */
+public class SnsRequestFailureException extends MessagingException {
+
+	@Serial
+	private static final long serialVersionUID = 1L;
+
+	private final transient PublishRequest request;
+
+	public SnsRequestFailureException(Message<?> message, PublishRequest request, Throwable cause) {
+		super(message, cause);
+		this.request = request;
+	}
+
+	public PublishRequest getRequest() {
+		return this.request;
+	}
+
+	@Override
+	public String toString() {
+		return super.toString() + " [request=" + this.request + "]";
+	}
+
+}

--- a/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/integration/SnsBodyBuilderTests.java
+++ b/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/integration/SnsBodyBuilderTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sns.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 4.0
+ */
+class SnsBodyBuilderTests {
+
+	@Test
+	void snsBodyBuilder() {
+		assertThatIllegalArgumentException().isThrownBy(() -> SnsBodyBuilder.withDefault(""))
+				.withMessageContaining("defaultMessage must not be empty.");
+
+		String message = SnsBodyBuilder.withDefault("foo").build();
+		assertThat(message).isEqualTo("{\"default\":\"foo\"}");
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> SnsBodyBuilder.withDefault("foo").forProtocols("{\"foo\" : \"bar\"}").build())
+				.withMessageContaining("protocols must not be empty.");
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> SnsBodyBuilder.withDefault("foo").forProtocols("{\"foo\" : \"bar\"}", "").build())
+				.withMessageContaining("protocols must not contain empty elements.");
+
+		message = SnsBodyBuilder.withDefault("foo").forProtocols("{\"foo\" : \"bar\"}", "sms").build();
+
+		assertThat(message).isEqualTo("{\"default\":\"foo\",\"sms\":\"{\\\"foo\\\" : \\\"bar\\\"}\"}");
+	}
+
+}

--- a/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/integration/SnsInboundChannelAdapterTests.java
+++ b/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/integration/SnsInboundChannelAdapterTests.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sns.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.awspring.cloud.sns.core.SnsHeaders;
+import io.awspring.cloud.sns.handlers.NotificationStatus;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.HttpRequestHandler;
+import org.springframework.web.context.WebApplicationContext;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.ConfirmSubscriptionRequest;
+
+/**
+ * @author Artem Bilan
+ * @author Kamil Przerwa
+ *
+ * @since 4.0
+ */
+@SpringJUnitWebConfig
+@DirtiesContext
+class SnsInboundChannelAdapterTests {
+
+	@Autowired
+	private WebApplicationContext context;
+
+	@Autowired
+	private SnsClient amazonSns;
+
+	@Autowired
+	private PollableChannel inputChannel;
+
+	@Value("classpath:subscriptionConfirmation.json")
+	private Resource subscriptionConfirmation;
+
+	@Value("classpath:notificationMessage.json")
+	private Resource notificationMessage;
+
+	@Value("classpath:unsubscribeConfirmation.json")
+	private Resource unsubscribeConfirmation;
+
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp() {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(this.context).build();
+	}
+
+	@Test
+	void subscriptionConfirmation() throws Exception {
+		this.mockMvc
+				.perform(post("/mySampleTopic").header("x-amz-sns-message-type", "SubscriptionConfirmation")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(StreamUtils.copyToByteArray(this.subscriptionConfirmation.getInputStream())))
+				.andExpect(status().isNoContent());
+
+		Message<?> receive = this.inputChannel.receive(10000);
+		assertThat(receive).isNotNull();
+		assertThat(receive.getHeaders()).containsEntry(SnsHeaders.SNS_MESSAGE_TYPE_HEADER, "SubscriptionConfirmation")
+				.containsKey(SnsHeaders.NOTIFICATION_STATUS_HEADER);
+
+		NotificationStatus notificationStatus = (NotificationStatus) receive.getHeaders()
+				.get(SnsHeaders.NOTIFICATION_STATUS_HEADER);
+
+		notificationStatus.confirmSubscription();
+
+		verify(this.amazonSns).confirmSubscription(ConfirmSubscriptionRequest.builder()
+				.topicArn("arn:aws:sns:eu-west-1:111111111111:mySampleTopic")
+				.token("111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111")
+				.build());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void notification() throws Exception {
+		this.mockMvc
+				.perform(post("/mySampleTopic").header("x-amz-sns-message-type", "Notification")
+						.contentType(MediaType.TEXT_PLAIN)
+						.content(StreamUtils.copyToByteArray(this.notificationMessage.getInputStream())))
+				.andExpect(status().isNoContent());
+
+		Message<?> receive = this.inputChannel.receive(10000);
+		assertThat(receive).isNotNull();
+		Map<String, String> payload = (Map<String, String>) receive.getPayload();
+
+		assertThat(payload).containsEntry("Subject", "asdasd").containsEntry("Message", "asdasd");
+	}
+
+	@Test
+	void unsubscribe() throws Exception {
+		this.mockMvc
+				.perform(post("/mySampleTopic").header("x-amz-sns-message-type", "UnsubscribeConfirmation")
+						.contentType(MediaType.TEXT_PLAIN)
+						.content(StreamUtils.copyToByteArray(this.unsubscribeConfirmation.getInputStream())))
+				.andExpect(status().isNoContent());
+
+		Message<?> receive = this.inputChannel.receive(10000);
+		assertThat(receive).isNotNull();
+		assertThat(receive.getHeaders()).containsEntry(SnsHeaders.SNS_MESSAGE_TYPE_HEADER, "UnsubscribeConfirmation")
+				.containsKey(SnsHeaders.NOTIFICATION_STATUS_HEADER);
+		NotificationStatus notificationStatus = (NotificationStatus) receive.getHeaders()
+				.get(SnsHeaders.NOTIFICATION_STATUS_HEADER);
+
+		notificationStatus.confirmSubscription();
+
+		verify(this.amazonSns).confirmSubscription(ConfirmSubscriptionRequest.builder()
+				.topicArn("arn:aws:sns:eu-west-1:111111111111:mySampleTopic")
+				.token("2336412f37fb687f5d51e6e241d638b05824e9e2f6713b42abaeb8607743f5ba91d34edd2b9dabe2f1616ed77c0f8801ee79911d34dca3d210c228af87bd5d9597bf0d6093a1464e03af6650e992ecf54605e020f04ad3d47796045c9f24d902e72e811a1ad59852cad453f40bddfb45")
+				.build());
+	}
+
+	@Configuration
+	@EnableIntegration
+	public static class ContextConfiguration {
+
+		@Bean
+		public SnsClient amazonSns() {
+			return mock();
+		}
+
+		@Bean
+		public PollableChannel inputChannel() {
+			return new QueueChannel();
+		}
+
+		@Bean
+		public HttpRequestHandler snsInboundChannelAdapter() {
+			SnsInboundChannelAdapter adapter = new SnsInboundChannelAdapter(amazonSns(), "/mySampleTopic");
+			adapter.setRequestChannel(inputChannel());
+			adapter.setHandleNotificationStatus(true);
+			return adapter;
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/integration/SnsMessageHandlerTests.java
+++ b/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/integration/SnsMessageHandlerTests.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sns.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.awspring.cloud.sns.core.SnsHeaders;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import software.amazon.awssdk.services.sns.SnsAsyncClient;
+import software.amazon.awssdk.services.sns.model.CreateTopicResponse;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
+
+/**
+ * @author Artem Bilan
+ * @author Christopher Smith
+ *
+ * @since 4.0
+ */
+@SpringJUnitConfig
+@DirtiesContext
+class SnsMessageHandlerTests {
+
+	private static final SpelExpressionParser PARSER = new SpelExpressionParser();
+
+	@Autowired
+	private MessageChannel sendToSnsChannel;
+
+	@Autowired
+	private SnsAsyncClient amazonSNS;
+
+	@Autowired
+	private PollableChannel resultChannel;
+
+	@Test
+	void snsMessageHandler() {
+		SnsBodyBuilder payload = SnsBodyBuilder.withDefault("test data")
+				.forProtocols("{\"testAttribute\" : \"test data\"}", "sms");
+
+		Message<?> message = MessageBuilder.withPayload(payload).setHeader("topic", "topic")
+				.setHeader("subject", "subject").setHeader("testHeader", "testValue").build();
+
+		this.sendToSnsChannel.send(message);
+
+		Message<?> reply = this.resultChannel.receive(10000);
+		assertThat(reply).isNotNull();
+
+		ArgumentCaptor<PublishRequest> captor = ArgumentCaptor.forClass(PublishRequest.class);
+		verify(this.amazonSNS).publish(captor.capture());
+
+		PublishRequest publishRequest = captor.getValue();
+
+		assertThat(publishRequest.messageStructure()).isEqualTo("json");
+		assertThat(publishRequest.topicArn()).isEqualTo("arn:aws:sns:eu-west-1:111111111111:topic.fifo");
+		assertThat(publishRequest.subject()).isEqualTo("subject");
+		assertThat(publishRequest.messageGroupId()).isEqualTo("SUBJECT");
+		assertThat(publishRequest.messageDeduplicationId()).isEqualTo("TESTVALUE");
+		assertThat(publishRequest.message())
+				.isEqualTo("{\"default\":\"test data\",\"sms\":\"{\\\"testAttribute\\\" : \\\"test data\\\"}\"}");
+
+		Map<String, MessageAttributeValue> messageAttributes = publishRequest.messageAttributes();
+
+		assertThat(messageAttributes).doesNotContainKeys(MessageHeaders.ID, MessageHeaders.TIMESTAMP).containsEntry(
+				"testHeader", MessageAttributeValue.builder().dataType("String").stringValue("testValue").build());
+
+		assertThat(reply.getHeaders()).containsEntry(SnsHeaders.MESSAGE_ID_HEADER, "111")
+				.containsEntry(SnsHeaders.TOPIC_HEADER, "arn:aws:sns:eu-west-1:111111111111:topic.fifo");
+		assertThat(reply.getPayload()).isSameAs(payload);
+	}
+
+	@Configuration
+	@EnableIntegration
+	public static class ContextConfiguration {
+
+		@Bean
+		@SuppressWarnings("unchecked")
+		public SnsAsyncClient amazonSNS() {
+			SnsAsyncClient mock = mock();
+
+			willAnswer(invocation -> CompletableFuture.completedFuture(
+					CreateTopicResponse.builder().topicArn("arn:aws:sns:eu-west-1:111111111111:topic.fifo").build()))
+					.given(mock).createTopic(any(Consumer.class));
+
+			willAnswer(
+					invocation -> CompletableFuture.completedFuture(PublishResponse.builder().messageId("111").build()))
+					.given(mock).publish(any(PublishRequest.class));
+
+			return mock;
+		}
+
+		@Bean
+		public PollableChannel resultChannel() {
+			return new QueueChannel();
+		}
+
+		@Bean
+		@ServiceActivator(inputChannel = "sendToSnsChannel")
+		public MessageHandler snsMessageHandler() {
+			SnsMessageHandler snsMessageHandler = new SnsMessageHandler(amazonSNS());
+			snsMessageHandler.setTopicArnExpression(PARSER.parseExpression("headers.topic"));
+			snsMessageHandler.setMessageGroupIdExpression(PARSER.parseExpression("headers.subject.toUpperCase()"));
+			snsMessageHandler
+					.setMessageDeduplicationIdExpression(PARSER.parseExpression("headers.testHeader.toUpperCase()"));
+			snsMessageHandler.setSubjectExpression(PARSER.parseExpression("headers.subject"));
+			snsMessageHandler.setBodyExpression(PARSER.parseExpression("payload"));
+			snsMessageHandler.setAsync(true);
+			snsMessageHandler.setOutputChannel(resultChannel());
+			SnsHeaderMapper headerMapper = new SnsHeaderMapper();
+			headerMapper.setOutboundHeaderNames("testHeader");
+			snsMessageHandler.setHeaderMapper(headerMapper);
+			return snsMessageHandler;
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/integration/SnsMessageHandlerTests.java
+++ b/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/integration/SnsMessageHandlerTests.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.verify;
 import io.awspring.cloud.sns.core.SnsHeaders;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +42,7 @@ import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import software.amazon.awssdk.services.sns.SnsAsyncClient;
+import software.amazon.awssdk.services.sns.model.CreateTopicRequest;
 import software.amazon.awssdk.services.sns.model.CreateTopicResponse;
 import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
 import software.amazon.awssdk.services.sns.model.PublishRequest;
@@ -110,13 +110,12 @@ class SnsMessageHandlerTests {
 	public static class ContextConfiguration {
 
 		@Bean
-		@SuppressWarnings("unchecked")
 		public SnsAsyncClient amazonSNS() {
 			SnsAsyncClient mock = mock();
 
 			willAnswer(invocation -> CompletableFuture.completedFuture(
 					CreateTopicResponse.builder().topicArn("arn:aws:sns:eu-west-1:111111111111:topic.fifo").build()))
-					.given(mock).createTopic(any(Consumer.class));
+					.given(mock).createTopic(any(CreateTopicRequest.class));
 
 			willAnswer(
 					invocation -> CompletableFuture.completedFuture(PublishResponse.builder().messageId("111").build()))

--- a/spring-cloud-aws-starters/spring-cloud-aws-starter-integration-sns/pom.xml
+++ b/spring-cloud-aws-starters/spring-cloud-aws-starter-integration-sns/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>spring-cloud-aws</artifactId>
+		<groupId>io.awspring.cloud</groupId>
+		<version>4.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<name>Spring Cloud AWS Starter for Spring Integration with SNS</name>
+	<artifactId>spring-cloud-aws-starter-integration-sns</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.awspring.cloud</groupId>
+			<artifactId>spring-cloud-aws-starter-sns</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-http</artifactId>
+		</dependency>
+	</dependencies>
+
+</project>


### PR DESCRIPTION
* Add `spring-integration-http` as an optional dep into `spring-cloud-aws-sns`.
* Add `SnsInboundChannelAdapter` to consume SNS notification over HTTP(S)
* Add `SnsMessageHandler` to publish to an SNS topic.
* The `SnsHeaderMapper` and `SnsBodyBuilder` are supporting classes for various SNS publish scenarios
* The `SnsRequestFailureException` is a generic exception with a message a and request context to throw when publication fails
* Add extra useful `SnsHeaders` constant for some Spring Integration message headers
* Since `SnsMessageHandler` is based on the `SnsAsyncClient`, introduce an `SnsAsyncTopicArnResolver` for such an async use-case
* Add `spring-cloud-aws-starter-integration-sns`
* Document this new feature
* Add missed `spring-cloud-aws-starter-integration-sqs` module int the root pom

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
