### PR TITLE
Fix `maxMessagesPerPoll` validation message in `AbstractContainerOptions`

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractContainerOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractContainerOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@ public abstract class AbstractContainerOptions<O extends ContainerOptions<O, B>,
 		this.observationRegistry = builder.observationRegistry;
 		this.observationConvention = builder.observationConvention;
 		Assert.isTrue(this.maxMessagesPerPoll <= this.maxConcurrentMessages, String.format(
-				"messagesPerPoll should be less than or equal to maxConcurrentMessages. Values provided: %s and %s respectively",
+				"maxMessagesPerPoll should be less than or equal to maxConcurrentMessages. Values provided: %s and %s respectively",
 				this.maxMessagesPerPoll, this.maxConcurrentMessages));
 	}
 


### PR DESCRIPTION
The message is used when validating `maxMessagesPerPoll`, but incorrectly refers to `messagesPerPoll`.

Fixes gh-1466

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description

The validation message in the `AbstractContainerOptions` constructor refers to `messagesPerPoll`, but should say `maxMessagesPerPoll`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Validation message is incorrect and doesn't identify the parameter that needs correcting if a validation exception is thrown.


## :green_heart: How did you test it?

Tested with unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
