### PR TITLE
Fix: add missing 'spring-cloud-aws-starter-imds' module in the project's BOM (#1484)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
 		<module>spring-cloud-aws-starters/spring-cloud-aws-starter-integration-sns</module>
 		<module>spring-cloud-aws-starters/spring-cloud-aws-starter-sqs</module>
 		<module>spring-cloud-aws-starters/spring-cloud-aws-starter-integration-sqs</module>
+		<module>spring-cloud-aws-starters/spring-cloud-aws-starter-imds</module>
 		<module>spring-cloud-aws-samples</module>
 		<module>spring-cloud-aws-test</module>
 		<module>spring-cloud-aws-modulith</module>


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Adds missing 'spring-cloud-aws-starter-imds' module in the project's BOM (see #1484).


## :bulb: Motivation and Context

Without this change, the 'spring-cloud-aws-starter-imds' library is not published together with the other libraries from the project when a new version of is released.


## :green_heart: How did you test it?

I didn't.

## :pencil: Checklist

- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
