### PR TITLE
Add flag which can be disabled to turn off  creation of  StsWebIdentityTokenFileCredentialsProvider

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProperties.java
@@ -63,7 +63,7 @@ public class CredentialsProperties {
 	 */
 	@NestedConfigurationProperty
 	@Nullable
-	private StsProperties sts;
+	private StsProperties sts = new StsProperties();
 
 	@Nullable
 	public String getAccessKey() {
@@ -100,7 +100,7 @@ public class CredentialsProperties {
 		this.profile = profile;
 	}
 
-	@Nullable
+
 	public StsProperties getSts() {
 		return sts;
 	}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/CredentialsProviderAutoConfiguration.java
@@ -103,7 +103,7 @@ public class CredentialsProviderAutoConfiguration {
 		}
 
 		StsProperties sts = properties.getSts();
-		if (ClassUtils.isPresent(STS_WEB_IDENTITY_TOKEN_FILE_CREDENTIALS_PROVIDER, null)) {
+		if (ClassUtils.isPresent(STS_WEB_IDENTITY_TOKEN_FILE_CREDENTIALS_PROVIDER, null) && sts.getEnableStsWebIdentityCredentialsProvider()) {
 			try {
 				providers.add(StsCredentialsProviderFactory.create(sts, regionProvider));
 			}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/StsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/core/StsProperties.java
@@ -53,6 +53,11 @@ public class StsProperties {
 	@Nullable
 	private String roleSessionName;
 
+	/**
+	 * Enables autoconfiguration for {@link software.amazon.awssdk.services.sts.auth.StsWebIdentityTokenFileCredentialsProvider}
+	 */
+	private Boolean enableStsWebIdentityCredentialsProvider = true;
+
 	public boolean isAsyncCredentialsUpdate() {
 		return asyncCredentialsUpdate;
 	}
@@ -86,5 +91,13 @@ public class StsProperties {
 
 	public void setRoleSessionName(@Nullable String roleSessionName) {
 		this.roleSessionName = roleSessionName;
+	}
+
+	public Boolean getEnableStsWebIdentityCredentialsProvider() {
+		return enableStsWebIdentityCredentialsProvider;
+	}
+
+	public void setEnableStsWebIdentityCredentialsProvider(Boolean enableStsWebIdentityCredentialsProvider) {
+		this.enableStsWebIdentityCredentialsProvider = enableStsWebIdentityCredentialsProvider;
 	}
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
#1517 
I only see adding flag as correct solution and letting user decide if they want StsWebIdentityTokenFileCredentialsProvider created or not.

AWS decided to lazy throw exception on resolve Credentials so user should take care of will Credentials provider fail or not. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
