### PR TITLE
Add SemaphoreBackPressureHandler as an optional fallback

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/backpressure/BackPressureHandler.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/backpressure/BackPressureHandler.java
@@ -58,6 +58,18 @@ public interface BackPressureHandler {
 	void release(int amount, ReleaseReason reason);
 
 	/**
+	 * Release the specified amount of permits. Each message that has been processed should release one permit, whether
+	 * processing was successful or not.
+	 * @param amount the amount of permits to release.
+	 *
+	 * @deprecated This method is deprecated and will not be called by the Spring Cloud AWS SQS listener anymore.
+	 * Implement {@link #release(int, ReleaseReason)} instead.
+	 */
+	@Deprecated
+	default void release(int amount) {
+	}
+
+	/**
 	 * Attempts to acquire all permits up to the specified timeout. If successful, means all permits were returned and
 	 * thus no activity is left in the {@link io.awspring.cloud.sqs.listener.source.MessageSource}.
 	 * @param timeout the maximum amount of time to wait for all permits to be released.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/backpressure/BackPressureHandlerFactories.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/backpressure/BackPressureHandlerFactories.java
@@ -184,4 +184,17 @@ public class BackPressureHandlerFactories {
 	public static BackPressureHandlerFactory fullBatchBackPressureHandler() {
 		return options -> FullBatchBackPressureHandler.builder().batchSize(options.getMaxMessagesPerPoll()).build();
 	}
+
+	/**
+	 * Creates a new {@link SemaphoreBackPressureHandler} instance based on the provided {@link ContainerOptions}.
+	 *
+	 * @return the created SemaphoreBackPressureHandler.
+	 */
+	@Deprecated
+	public static BackPressureHandlerFactory semaphoreBackPressureHandler() {
+		return options -> SemaphoreBackPressureHandler.builder().batchSize(options.getMaxMessagesPerPoll())
+			.totalPermits(options.getMaxConcurrentMessages()).acquireTimeout(options.getMaxDelayBetweenPolls())
+			.throughputConfiguration(options.getBackPressureMode()).build();
+	}
+
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/backpressure/BatchAwareBackPressureHandler.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/backpressure/BatchAwareBackPressureHandler.java
@@ -31,4 +31,37 @@ public interface BatchAwareBackPressureHandler extends BackPressureHandler {
 	 */
 	int requestBatch() throws InterruptedException;
 
+	/**
+	 * Release a batch of permits. This has the semantics of letting the {@link BackPressureHandler} know that all
+	 * permits from a batch are being released, in opposition to {@link #release(int)} in which any number of permits
+	 * can be specified.
+	 *
+	 * @deprecated This method is deprecated and will not be called by the Spring Cloud AWS SQS listener anymore.
+	 * Implement {@link BackPressureHandler#release(int, ReleaseReason)} instead.
+	 */
+	@Deprecated
+	default void releaseBatch() {
+	}
+
+	@Override
+	default void release(int amount, ReleaseReason reason) {
+		if (amount == getBatchSize() && reason == ReleaseReason.NONE_FETCHED) {
+			releaseBatch();
+		}
+		else {
+			release(amount);
+		}
+	}
+
+	/**
+	 * Return the configured batch size for this handler.
+	 * @return the batch size.
+	 *
+	 * @deprecated This method is deprecated and will not be used by the Spring Cloud AWS SQS listener anymore.
+	 */
+	@Deprecated
+	default int getBatchSize() {
+		return 0;
+	}
+
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/backpressure/SemaphoreBackPressureHandler.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/backpressure/SemaphoreBackPressureHandler.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.backpressure;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.awspring.cloud.sqs.listener.BackPressureMode;
+import io.awspring.cloud.sqs.listener.IdentifiableContainerComponent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.Assert;
+
+/**
+ * {@link BackPressureHandler} implementation that uses a {@link Semaphore} for handling backpressure.
+ *
+ * @author Tomaz Fernandes
+ * @since 3.0
+ * @see io.awspring.cloud.sqs.listener.source.PollingMessageSource
+ */
+@Deprecated
+public class SemaphoreBackPressureHandler
+		implements BatchAwareBackPressureHandler, IdentifiableContainerComponent {
+
+	private static final Logger logger = LoggerFactory.getLogger(SemaphoreBackPressureHandler.class);
+
+	private final Semaphore semaphore;
+
+	private final int batchSize;
+
+	private final int totalPermits;
+
+	private final Duration acquireTimeout;
+
+	private final BackPressureMode backPressureConfiguration;
+
+	private volatile CurrentThroughputMode currentThroughputMode;
+
+	private final AtomicBoolean hasAcquiredFullPermits = new AtomicBoolean(false);
+
+	private String id;
+
+	private SemaphoreBackPressureHandler(Builder builder) {
+		this.batchSize = builder.batchSize;
+		this.totalPermits = builder.totalPermits;
+		this.acquireTimeout = builder.acquireTimeout;
+		this.backPressureConfiguration = builder.backPressureMode;
+		this.semaphore = new Semaphore(totalPermits);
+		this.currentThroughputMode = BackPressureMode.FIXED_HIGH_THROUGHPUT.equals(backPressureConfiguration)
+				? CurrentThroughputMode.HIGH
+				: CurrentThroughputMode.LOW;
+		logger.debug("SemaphoreBackPressureHandler created with configuration {} and {} total permits",
+				backPressureConfiguration, totalPermits);
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	@Override
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	@Override
+	public String getId() {
+		return this.id;
+	}
+
+	@Override
+	public int request(int amount) throws InterruptedException {
+		return tryAcquire(amount, this.currentThroughputMode) ? amount : 0;
+	}
+
+	// @formatter:off
+	@Override
+	public int requestBatch() throws InterruptedException {
+		return CurrentThroughputMode.LOW.equals(this.currentThroughputMode)
+			? requestInLowThroughputMode()
+			: requestInHighThroughputMode();
+	}
+
+	private int requestInHighThroughputMode() throws InterruptedException {
+		return tryAcquire(this.batchSize, CurrentThroughputMode.HIGH)
+			? this.batchSize
+			: tryAcquirePartial();
+	}
+	// @formatter:on
+
+	private int tryAcquirePartial() throws InterruptedException {
+		int availablePermits = this.semaphore.availablePermits();
+		if (availablePermits == 0 || BackPressureMode.ALWAYS_POLL_MAX_MESSAGES.equals(this.backPressureConfiguration)) {
+			return 0;
+		}
+		int permitsToRequest = Math.min(availablePermits, this.batchSize);
+		CurrentThroughputMode currentThroughputModeNow = this.currentThroughputMode;
+		logger.trace("Trying to acquire partial batch of {} permits from {} available for {} in TM {}",
+				permitsToRequest, availablePermits, this.id, currentThroughputModeNow);
+		boolean hasAcquiredPartial = tryAcquire(permitsToRequest, currentThroughputModeNow);
+		return hasAcquiredPartial ? permitsToRequest : 0;
+	}
+
+	private int requestInLowThroughputMode() throws InterruptedException {
+		// Although LTM can be set / unset by many processes, only the MessageSource thread gets here,
+		// so no actual concurrency
+		logger.debug("Trying to acquire full permits for {}. Permits left: {}", this.id,
+				this.semaphore.availablePermits());
+		boolean hasAcquired = tryAcquire(this.totalPermits, CurrentThroughputMode.LOW);
+		if (hasAcquired) {
+			logger.debug("Acquired full permits for {}. Permits left: {}", this.id, this.semaphore.availablePermits());
+			// We've acquired all permits - there's no other process currently processing messages
+			if (!this.hasAcquiredFullPermits.compareAndSet(false, true)) {
+				logger.warn("hasAcquiredFullPermits was already true. Permits left: {}",
+						this.semaphore.availablePermits());
+			}
+			return this.batchSize;
+		}
+		else {
+			return 0;
+		}
+	}
+
+	private boolean tryAcquire(int amount, CurrentThroughputMode currentThroughputModeNow) throws InterruptedException {
+		logger.trace("Acquiring {} permits for {} in TM {}", amount, this.id, this.currentThroughputMode);
+		boolean hasAcquired = this.semaphore.tryAcquire(amount, this.acquireTimeout.toMillis(), TimeUnit.MILLISECONDS);
+		if (hasAcquired) {
+			logger.trace("{} permits acquired for {} in TM {}. Permits left: {}", amount, this.id,
+					currentThroughputModeNow, this.semaphore.availablePermits());
+		}
+		else {
+			logger.trace("Not able to acquire {} permits in {} milliseconds for {} in TM {}. Permits left: {}", amount,
+					this.acquireTimeout.toMillis(), this.id, currentThroughputModeNow,
+					this.semaphore.availablePermits());
+		}
+		return hasAcquired;
+	}
+
+	@Override
+	public void releaseBatch() {
+		maybeSwitchToLowThroughputMode();
+		int permitsToRelease = getPermitsToRelease(this.batchSize);
+		this.semaphore.release(permitsToRelease);
+		logger.trace("Released {} permits for {}. Permits left: {}", permitsToRelease, this.id,
+				this.semaphore.availablePermits());
+	}
+
+	@Override
+	public int getBatchSize() {
+		return this.batchSize;
+	}
+
+	private void maybeSwitchToLowThroughputMode() {
+		if (!BackPressureMode.FIXED_HIGH_THROUGHPUT.equals(this.backPressureConfiguration)
+				&& CurrentThroughputMode.HIGH.equals(this.currentThroughputMode)) {
+			logger.debug("Entire batch of permits released for {}, setting TM LOW. Permits left: {}", this.id,
+					this.semaphore.availablePermits());
+			this.currentThroughputMode = CurrentThroughputMode.LOW;
+		}
+	}
+
+	@Override
+	public void release(int amount) {
+		logger.trace("Releasing {} permits for {}. Permits left: {}", amount, this.id,
+				this.semaphore.availablePermits());
+		maybeSwitchToHighThroughputMode(amount);
+		int permitsToRelease = getPermitsToRelease(amount);
+		this.semaphore.release(permitsToRelease);
+		logger.trace("Released {} permits for {}. Permits left: {}", permitsToRelease, this.id,
+				this.semaphore.availablePermits());
+	}
+
+	private int getPermitsToRelease(int amount) {
+		return this.hasAcquiredFullPermits.compareAndSet(true, false)
+				// The first process that gets here should release all permits except for inflight messages
+				// We can have only one batch of messages at this point since we have all permits
+				? this.totalPermits - (this.batchSize - amount)
+				: amount;
+	}
+
+	private void maybeSwitchToHighThroughputMode(int amount) {
+		if (CurrentThroughputMode.LOW.equals(this.currentThroughputMode)) {
+			logger.debug("{} unused permit(s), setting TM HIGH for {}. Permits left: {}", amount, this.id,
+					this.semaphore.availablePermits());
+			this.currentThroughputMode = CurrentThroughputMode.HIGH;
+		}
+	}
+
+	@Override
+	public boolean drain(Duration timeout) {
+		logger.debug("Waiting for up to {} seconds for approx. {} permits to be released for {}", timeout.getSeconds(),
+				this.totalPermits - this.semaphore.availablePermits(), this.id);
+		try {
+			return this.semaphore.tryAcquire(this.totalPermits, (int) timeout.getSeconds(), TimeUnit.SECONDS);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException("Interrupted while waiting to acquire permits", e);
+		}
+	}
+
+	private enum CurrentThroughputMode {
+
+		HIGH,
+
+		LOW;
+
+	}
+
+	public static class Builder {
+
+		private int batchSize;
+
+		private int totalPermits;
+
+		private Duration acquireTimeout;
+
+		private BackPressureMode backPressureMode;
+
+		public Builder batchSize(int batchSize) {
+			this.batchSize = batchSize;
+			return this;
+		}
+
+		public Builder totalPermits(int totalPermits) {
+			this.totalPermits = totalPermits;
+			return this;
+		}
+
+		public Builder acquireTimeout(Duration acquireTimeout) {
+			this.acquireTimeout = acquireTimeout;
+			return this;
+		}
+
+		public Builder throughputConfiguration(BackPressureMode backPressureConfiguration) {
+			this.backPressureMode = backPressureConfiguration;
+			return this;
+		}
+
+		public SemaphoreBackPressureHandler build() {
+			Assert.noNullElements(
+					Arrays.asList(this.batchSize, this.totalPermits, this.acquireTimeout, this.backPressureMode),
+					"Missing configuration");
+			return new SemaphoreBackPressureHandler(this);
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/SemaphoreBackPressureHandlerAbstractPollingMessageSourceTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/SemaphoreBackPressureHandlerAbstractPollingMessageSourceTests.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import io.awspring.cloud.sqs.MessageExecutionThreadFactory;
+import io.awspring.cloud.sqs.listener.*;
+import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementCallback;
+import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementProcessor;
+import io.awspring.cloud.sqs.listener.backpressure.BackPressureHandler;
+import io.awspring.cloud.sqs.listener.backpressure.BackPressureHandlerFactories;
+import io.awspring.cloud.sqs.support.converter.MessageConversionContext;
+import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.lang.Nullable;
+import org.springframework.retry.backoff.BackOffContext;
+import org.springframework.retry.backoff.BackOffPolicy;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+/**
+ * @author Tomaz Fernandes
+ * @author Loïc Rouchon
+ */
+class SemaphoreBackPressureHandlerAbstractPollingMessageSourceTests {
+
+	private static final Logger logger = LoggerFactory.getLogger(AbstractPollingMessageSourceTests.class);
+
+	@Test
+	void shouldAcquireAndReleaseFullPermits() {
+		String testName = "shouldAcquireAndReleaseFullPermits";
+		BackPressureHandler backPressureHandler = BackPressureHandlerFactories
+				.semaphoreBackPressureHandler().createBackPressureHandler(SqsContainerOptions.builder().maxMessagesPerPoll(10)
+						.maxConcurrentMessages(10).backPressureMode(BackPressureMode.ALWAYS_POLL_MAX_MESSAGES)
+						.maxDelayBetweenPolls(Duration.ofMillis(200)).build());
+
+		ExecutorService threadPool = Executors.newCachedThreadPool();
+		CountDownLatch pollingCounter = new CountDownLatch(3);
+		CountDownLatch processingCounter = new CountDownLatch(1);
+
+		AbstractPollingMessageSource<Object, Message> source = new AbstractPollingMessageSource<>() {
+
+			private final AtomicBoolean hasReceived = new AtomicBoolean(false);
+
+			private final AtomicBoolean hasMadeSecondPoll = new AtomicBoolean(false);
+
+			@Override
+			protected CompletableFuture<Collection<Message>> doPollForMessages(int messagesToRequest) {
+				return CompletableFuture.supplyAsync(() -> {
+					try {
+						// Since BackPressureMode.ALWAYS_POLL_MAX_MESSAGES, should always be 10.
+						assertThat(messagesToRequest).isEqualTo(10);
+						assertAvailablePermits(backPressureHandler, 0);
+						boolean firstPoll = hasReceived.compareAndSet(false, true);
+						if (firstPoll) {
+							logger.debug("First poll");
+							// No permits released yet, should be TM low
+							assertThroughputMode(backPressureHandler, "low");
+						}
+						else if (hasMadeSecondPoll.compareAndSet(false, true)) {
+							logger.debug("Second poll");
+							// Permits returned, should be high
+							assertThroughputMode(backPressureHandler, "high");
+						}
+						else {
+							logger.debug("Third poll");
+							// Already returned full permits, should be low
+							assertThroughputMode(backPressureHandler, "low");
+						}
+						return firstPoll
+								? (Collection<Message>) List.of(Message.builder()
+										.messageId(UUID.randomUUID().toString()).body("message").build())
+								: Collections.<Message> emptyList();
+					}
+					catch (Throwable t) {
+						logger.error("Error", t);
+						throw new RuntimeException(t);
+					}
+				}, threadPool).whenComplete((v, t) -> {
+					if (t == null) {
+						pollingCounter.countDown();
+					}
+				});
+			}
+		};
+
+		source.setBackPressureHandler(backPressureHandler);
+		source.setMessageSink((msgs, context) -> {
+			assertAvailablePermits(backPressureHandler, 9);
+			msgs.forEach(msg -> context.runBackPressureReleaseCallback());
+			return CompletableFuture.runAsync(processingCounter::countDown);
+		});
+
+		source.setId(testName + " source");
+		source.configure(SqsContainerOptions.builder().build());
+		source.setTaskExecutor(createTaskExecutor(testName));
+		source.setAcknowledgementProcessor(getNoOpsAcknowledgementProcessor());
+		source.start();
+		assertThat(doAwait(pollingCounter)).isTrue();
+		assertThat(doAwait(processingCounter)).isTrue();
+	}
+
+	private static final AtomicInteger testCounter = new AtomicInteger();
+
+	@Test
+	void shouldAcquireAndReleasePartialPermits() {
+		String testName = "shouldAcquireAndReleasePartialPermits";
+		BackPressureHandler backPressureHandler = BackPressureHandlerFactories.semaphoreBackPressureHandler().createBackPressureHandler(
+				SqsContainerOptions.builder().maxMessagesPerPoll(10).maxConcurrentMessages(10)
+						.backPressureMode(BackPressureMode.AUTO).maxDelayBetweenPolls(Duration.ofMillis(150)).build());
+
+		ExecutorService threadPool = Executors
+				.newCachedThreadPool(new MessageExecutionThreadFactory("test " + testCounter.incrementAndGet()));
+		CountDownLatch pollingCounter = new CountDownLatch(4);
+		CountDownLatch processingCounter = new CountDownLatch(1);
+		CountDownLatch processingLatch = new CountDownLatch(1);
+		AtomicBoolean hasThrownError = new AtomicBoolean(false);
+
+		AbstractPollingMessageSource<Object, Message> source = new AbstractPollingMessageSource<>() {
+
+			private final AtomicBoolean hasReceived = new AtomicBoolean(false);
+
+			private final AtomicBoolean hasAcquired9 = new AtomicBoolean(false);
+
+			private final AtomicBoolean hasMadeThirdPoll = new AtomicBoolean(false);
+
+			@Override
+			protected CompletableFuture<Collection<Message>> doPollForMessages(int messagesToRequest) {
+				return CompletableFuture.supplyAsync(() -> {
+					try {
+						// Give it some time between returning empty and polling again
+						// doSleep(100);
+
+						// Will only be true the first time it sets hasReceived to true
+						boolean shouldReturnMessage = hasReceived.compareAndSet(false, true);
+						if (shouldReturnMessage) {
+							// First poll, should have 10
+							logger.debug("First poll - should request 10 messages");
+							assertThat(messagesToRequest).isEqualTo(10);
+							assertAvailablePermits(backPressureHandler, 0);
+							// No permits have been released yet
+							assertThroughputMode(backPressureHandler, "low");
+						}
+						else if (hasAcquired9.compareAndSet(false, true)) {
+							// Second poll, should have 9
+							logger.debug("Second poll - should request 9 messages");
+							assertThat(messagesToRequest).isEqualTo(9);
+							assertAvailablePermitsLessThanOrEqualTo(backPressureHandler, 1);
+							// Has released 9 permits, should be TM HIGH
+							assertThroughputMode(backPressureHandler, "high");
+							processingLatch.countDown(); // Release processing now
+						}
+						else {
+							boolean thirdPoll = hasMadeThirdPoll.compareAndSet(false, true);
+							// Third poll or later, should have 10 again
+							logger.debug("Third poll - should request 10 messages");
+							assertThat(messagesToRequest).isEqualTo(10);
+							assertAvailablePermits(backPressureHandler, 0);
+							if (thirdPoll) {
+								// Hasn't yet returned a full batch, should be TM High
+								assertThroughputMode(backPressureHandler, "high");
+							}
+							else {
+								// Has returned all permits in third poll
+								assertThroughputMode(backPressureHandler, "low");
+							}
+						}
+						if (shouldReturnMessage) {
+							logger.debug("shouldReturnMessage, returning one message");
+							return (Collection<Message>) List.of(
+									Message.builder().messageId(UUID.randomUUID().toString()).body("message").build());
+						}
+						logger.debug("should not return message, returning empty list");
+						return Collections.<Message> emptyList();
+					}
+					catch (Error e) {
+						hasThrownError.set(true);
+						throw new RuntimeException("Error polling for messages", e);
+					}
+				}, threadPool).whenComplete((v, t) -> pollingCounter.countDown());
+			}
+		};
+
+		source.setBackPressureHandler(backPressureHandler);
+		source.setMessageSink((msgs, context) -> {
+			logger.debug("Processing {} messages", msgs.size());
+			assertAvailablePermits(backPressureHandler, 9);
+			assertThat(doAwait(processingLatch)).isTrue();
+			logger.debug("Finished processing {} messages", msgs.size());
+			msgs.forEach(msg -> context.runBackPressureReleaseCallback());
+			return CompletableFuture.completedFuture(null).thenRun(processingCounter::countDown);
+		});
+		source.setId(testName + " source");
+		source.configure(SqsContainerOptions.builder().build());
+		source.setTaskExecutor(createTaskExecutor(testName));
+		source.setAcknowledgementProcessor(getNoOpsAcknowledgementProcessor());
+		source.start();
+		assertThat(doAwait(processingCounter)).isTrue();
+		assertThat(doAwait(pollingCounter)).isTrue();
+		source.stop();
+		assertThat(hasThrownError.get()).isFalse();
+	}
+
+	@Test
+	void shouldReleasePermitsOnConversionErrors() {
+		String testName = "shouldReleasePermitsOnConversionErrors";
+		BackPressureHandler backPressureHandler = BackPressureHandlerFactories.semaphoreBackPressureHandler().createBackPressureHandler(
+				SqsContainerOptions.builder().maxMessagesPerPoll(10).maxConcurrentMessages(10)
+						.backPressureMode(BackPressureMode.AUTO).maxDelayBetweenPolls(Duration.ofMillis(150)).build());
+
+		AtomicInteger convertedMessages = new AtomicInteger(0);
+		AtomicInteger messagesInSink = new AtomicInteger(0);
+		AtomicBoolean hasFailed = new AtomicBoolean(false);
+
+		var converter = new SqsMessagingMessageConverter() {
+			@Override
+			public org.springframework.messaging.Message<?> toMessagingMessage(Message source,
+					@Nullable MessageConversionContext context) {
+				var converted = convertedMessages.incrementAndGet();
+				logger.trace("Messages converted: {}", converted);
+				if (converted % 9 == 0) {
+					throw new RuntimeException("Expected error");
+				}
+				return super.toMessagingMessage(source, context);
+			}
+		};
+
+		AbstractPollingMessageSource<Object, Message> source = new AbstractPollingMessageSource<>() {
+
+			@Override
+			protected CompletableFuture<Collection<Message>> doPollForMessages(int messagesToRequest) {
+				if (messagesToRequest != 10) {
+					logger.error("Expected 10 messages to requesst, received {}", messagesToRequest);
+					hasFailed.set(true);
+				}
+				return convertedMessages.get() < 30 ? CompletableFuture.completedFuture(create10Messages())
+						: CompletableFuture.completedFuture(List.of());
+			}
+
+			private Collection<Message> create10Messages() {
+				return IntStream.range(0, 10).mapToObj(
+						index -> Message.builder().messageId(UUID.randomUUID().toString()).body("test-message").build())
+						.toList();
+			}
+		};
+
+		source.setBackPressureHandler(backPressureHandler);
+		source.setMessageSink((msgs, context) -> {
+			msgs.forEach(message -> messagesInSink.incrementAndGet());
+			msgs.forEach(msg -> context.runBackPressureReleaseCallback());
+			return CompletableFuture.completedFuture(null);
+		});
+		source.setId(testName + " source");
+		source.configure(SqsContainerOptions.builder().messageConverter(converter).build());
+		source.setPollingEndpointName("shouldReleasePermitsOnConversionErrors-queue");
+		source.setTaskExecutor(createTaskExecutor(testName));
+		source.setAcknowledgementProcessor(getNoOpsAcknowledgementProcessor());
+		source.start();
+		Awaitility.waitAtMost(Duration.ofSeconds(10)).until(() -> convertedMessages.get() == 30);
+		assertThat(hasFailed).isFalse();
+		assertThat(messagesInSink).hasValue(27);
+		source.stop();
+	}
+
+	@Test
+	void shouldBackOffIfPollingThrowsAnError() {
+		var testName = "shouldBackOffIfPollingThrowsAnError";
+		BackPressureHandler backPressureHandler = BackPressureHandlerFactories
+				.semaphoreBackPressureHandler().createBackPressureHandler(SqsContainerOptions.builder().maxMessagesPerPoll(10)
+						.maxConcurrentMessages(40).backPressureMode(BackPressureMode.ALWAYS_POLL_MAX_MESSAGES)
+						.maxDelayBetweenPolls(Duration.ofMillis(200)).build());
+
+		var currentPoll = new AtomicInteger(0);
+		var waitThirdPollLatch = new CountDownLatch(4);
+
+		AbstractPollingMessageSource<Object, Message> source = new AbstractPollingMessageSource<>() {
+			@Override
+			protected CompletableFuture<Collection<Message>> doPollForMessages(int messagesToRequest) {
+				waitThirdPollLatch.countDown();
+				if (currentPoll.compareAndSet(0, 1)) {
+					logger.debug("First poll - returning empty list");
+					return CompletableFuture.completedFuture(List.of());
+				}
+				else if (currentPoll.compareAndSet(1, 2)) {
+					logger.debug("Second poll - returning error");
+					return CompletableFuture.failedFuture(new RuntimeException("Expected exception on second poll"));
+				}
+				else if (currentPoll.compareAndSet(2, 3)) {
+					logger.debug("Third poll - returning error");
+					return CompletableFuture.failedFuture(new RuntimeException("Expected exception on third poll"));
+				}
+				else {
+					logger.debug("Fourth poll - returning empty list");
+					return CompletableFuture.completedFuture(List.of());
+				}
+			}
+		};
+
+		var policy = mock(BackOffPolicy.class);
+		var backOffContext = mock(BackOffContext.class);
+		given(policy.start(null)).willReturn(backOffContext);
+
+		source.setBackPressureHandler(backPressureHandler);
+		source.setMessageSink((msgs, context) -> CompletableFuture.completedFuture(null));
+		source.setId(testName + " source");
+		source.configure(SqsContainerOptions.builder().pollBackOffPolicy(policy).build());
+
+		source.setTaskExecutor(createTaskExecutor(testName));
+		source.setAcknowledgementProcessor(getNoOpsAcknowledgementProcessor());
+		source.start();
+
+		doAwait(waitThirdPollLatch);
+
+		then(policy).should().start(null);
+		then(policy).should(times(2)).backOff(backOffContext);
+
+	}
+
+	private static boolean doAwait(CountDownLatch processingLatch) {
+		try {
+			return processingLatch.await(4, TimeUnit.SECONDS);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("Interrupted while waiting for latch", e);
+		}
+	}
+
+	private void assertThroughputMode(BackPressureHandler backPressureHandler, String expectedThroughputMode) {
+		assertThat(ReflectionTestUtils.getField(backPressureHandler, "currentThroughputMode"))
+				.extracting(Object::toString).extracting(String::toLowerCase)
+				.isEqualTo(expectedThroughputMode.toLowerCase());
+	}
+
+	private void assertAvailablePermits(BackPressureHandler backPressureHandler, int expectedPermits) {
+		assertThat(ReflectionTestUtils.getField(backPressureHandler, "semaphore")).asInstanceOf(type(Semaphore.class))
+				.extracting(Semaphore::availablePermits).isEqualTo(expectedPermits);
+	}
+
+	private void assertAvailablePermitsLessThanOrEqualTo(BackPressureHandler backPressureHandler,
+			int maxExpectedPermits) {
+		assertThat(ReflectionTestUtils.getField(backPressureHandler, "semaphore")).asInstanceOf(type(Semaphore.class))
+				.extracting(Semaphore::availablePermits).asInstanceOf(InstanceOfAssertFactories.INTEGER)
+				.isLessThanOrEqualTo(maxExpectedPermits);
+	}
+
+	// Used to slow down tests while developing
+	private void doSleep(int time) {
+		try {
+			Thread.sleep(time);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected TaskExecutor createTaskExecutor(String testName) {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		int poolSize = 10;
+		executor.setMaxPoolSize(poolSize);
+		executor.setCorePoolSize(10);
+		executor.setQueueCapacity(poolSize);
+		executor.setAllowCoreThreadTimeOut(true);
+		executor.setThreadFactory(createThreadFactory(testName));
+		executor.afterPropertiesSet();
+		return executor;
+	}
+
+	protected ThreadFactory createThreadFactory(String testName) {
+		MessageExecutionThreadFactory threadFactory = new MessageExecutionThreadFactory();
+		threadFactory.setThreadNamePrefix(testName + "-thread" + "-");
+		return threadFactory;
+	}
+
+	private AcknowledgementProcessor<Object> getNoOpsAcknowledgementProcessor() {
+		return new AcknowledgementProcessor<>() {
+			@Override
+			public AcknowledgementCallback<Object> getAcknowledgementCallback() {
+				return new AcknowledgementCallback<>() {
+				};
+			}
+
+			@Override
+			public void setId(String id) {
+			}
+
+			@Override
+			public String getId() {
+				return "test processor";
+			}
+
+			@Override
+			public void start() {
+			}
+
+			@Override
+			public void stop() {
+			}
+
+			@Override
+			public boolean isRunning() {
+				return false;
+			}
+		};
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/resources/logback.xml
+++ b/spring-cloud-aws-sqs/src/test/resources/logback.xml
@@ -25,7 +25,7 @@
 	<logger name="io.awspring.cloud.sqs" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.listener.SqsMessageListenerContainer" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.listener.AsyncComponentAdapters" level="INFO"/>
-	<logger name="io.awspring.cloud.sqs.listener.SemaphoreBackPressureHandler" level="INFO"/>
+	<logger name="io.awspring.cloud.sqs.listener.backpressure.SemaphoreBackPressureHandler" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.QueueAttributesResolver" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.listener.source" level="INFO"/>
 	<logger name="io.awspring.cloud.sqs.listener.sink" level="INFO"/>


### PR DESCRIPTION
@loicrouchon, the new structure remains the default, just adding back SBPH as an optional fallback as we iterate on community feedback.

M1 should be released in the next few days, and we can clean up the deprecated parts before GA.