### PR TITLE
Fix: Nondeterminism behavior in SqsListenerAnnotationBeanPostProcessorTests

### DIFF
--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessorTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessorTests.java
@@ -257,10 +257,8 @@ class SqsListenerAnnotationBeanPostProcessorTests {
 		assertThat(endpoint.getLogicalNames()).containsExactly("classLevelQueue");
 		assertThat(endpoint).isInstanceOfSatisfying(MultiMethodSqsEndpoint.class, multiMethodSqsEndpoint -> {
 			assertThat(multiMethodSqsEndpoint.getMethods()).hasSize(2);
-			assertThat(multiMethodSqsEndpoint.getMethods().get(0))
-					.isEqualTo(ClassLevelListener.class.getDeclaredMethods()[0]);
-			assertThat(multiMethodSqsEndpoint.getMethods().get(1))
-					.isEqualTo(ClassLevelListener.class.getDeclaredMethods()[1]);
+			assertThat(multiMethodSqsEndpoint.getMethods()).extracting(method -> method.getParameterTypes()[0])
+					.containsExactlyInAnyOrder(String.class, Integer.class);
 		});
 	}
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This pull request updates the test ```shouldRegisterClassLevelSqsListenerWithSqsHandlers``` in
```SqsListenerAnnotationBeanPostProcessorTests``` to avoid relying on the implicit method ordering returned by reflection.

Previously, the test compared methods using fixed index positions:
```
methods.get(0)
methods.get(1)
```
However, it does not guarantee a deterministic ordering of methods returned by [Class#getDeclaredMethods()](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredMethods--) or collections derived from it. As a result, the test becomes nondeterministic and fails under [NonDex tool](https://github.com/TestingResearchIllinois/NonDex) or repeated runs. The updated version checks only the presence of the two ```@SqsHandler``` overloads by validating their parameter types (```String.class``` and ```Integer.class```) in any order, making the test deterministic.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change ensures that the test remains stable under randomized iteration orders. When running with NonDex, the test failed intermittently because it assumed a fixed order for handler method discovery, even though this order is not guaranteed. By relaxing the assertion to be order-independent, we preserve the original intent of the test and eliminating nondeterministic behavior. This improves test reliability in continuous integration environments.

## :green_heart: How did you test it?
Run NonDex on ```spring-cloud-aws-sqs``` module using the following command:
```
mvn -pl spring-cloud-aws-sqs edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=io.awspring.cloud.sqs.annotation.SqsListenerAnnotationBeanPostProcessorTests#shouldRegisterClassLevelSqsListenerWithSqsHandlers
```

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
