### PR TITLE
fix: Fix three nondeterministic tests caused by shard processing and JSON key ordering

### DIFF
--- a/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KinesisMessageDrivenChannelAdapterTests.java
+++ b/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KinesisMessageDrivenChannelAdapterTests.java
@@ -252,8 +252,9 @@ class KinesisMessageDrivenChannelAdapterTests {
 
 		KinesisShardEndedEvent kinesisShardEndedEvent = this.config.shardEndedEventReference.get();
 
-		assertThat(kinesisShardEndedEvent).isNotNull().extracting(KinesisShardEndedEvent::getShardKey)
-				.isEqualTo("SpringIntegration:streamForResharding:closedEmptyShard5");
+		assertThat(kinesisShardEndedEvent).isNotNull().extracting(KinesisShardEndedEvent::getShardKey).isIn(
+				"SpringIntegration:" + STREAM_FOR_RESHARDING + ":closedEmptyShard5",
+				"SpringIntegration:" + STREAM_FOR_RESHARDING + ":closedShard4");
 	}
 
 	@Configuration

--- a/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/integration/SnsBodyBuilderTests.java
+++ b/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/integration/SnsBodyBuilderTests.java
@@ -45,7 +45,8 @@ class SnsBodyBuilderTests {
 
 		message = SnsBodyBuilder.withDefault("foo").forProtocols("{\"foo\" : \"bar\"}", "sms").build();
 
-		assertThat(message).isEqualTo("{\"default\":\"foo\",\"sms\":\"{\\\"foo\\\" : \\\"bar\\\"}\"}");
+		assertThat(message).startsWith("{").endsWith("}").contains("\"default\":\"foo\"")
+				.contains("\"sms\":\"{\\\"foo\\\" : \\\"bar\\\"}\"");
 	}
 
 }

--- a/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/integration/SnsMessageHandlerTests.java
+++ b/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/integration/SnsMessageHandlerTests.java
@@ -92,8 +92,8 @@ class SnsMessageHandlerTests {
 		assertThat(publishRequest.subject()).isEqualTo("subject");
 		assertThat(publishRequest.messageGroupId()).isEqualTo("SUBJECT");
 		assertThat(publishRequest.messageDeduplicationId()).isEqualTo("TESTVALUE");
-		assertThat(publishRequest.message())
-				.isEqualTo("{\"default\":\"test data\",\"sms\":\"{\\\"testAttribute\\\" : \\\"test data\\\"}\"}");
+		assertThat(publishRequest.message()).startsWith("{").endsWith("}").contains("\"default\":\"test data\"")
+				.contains("\"sms\":\"{\\\"testAttribute\\\" : \\\"test data\\\"}\"");
 
 		Map<String, MessageAttributeValue> messageAttributes = publishRequest.messageAttributes();
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This pull request updates three tests that were failing under [NonDex](https://github.com/TestingResearchIllinois/NonDex) due to relying on ordering that is not guaranteed:

1. ```KinesisMessageDrivenChannelAdapterTests.resharding```: The test previously assumed a specific shard key, which depended on the order in which shards were processed. Under NonDex, this ordering can change. The assertion is updated to accept either of the two expected shard keys (```closedEmptyShard5```, ```closedShard4```).
2. ```SnsBodyBuilderTests.snsBodyBuilder```: The test previously asserted equality against a concrete JSON string. When the JSON object fields are emitted in a different order (e.g., ```"sms"``` before ```"default"```), the string changes. The assertion is updated to check structure and required fields without enforcing key order.
3. ```SnsMessageHandlerTests.snsMessageHandler```: Similar to ```SnsBodyBuilderTests.snsBodyBuilder```, this test previously asserted exact string equality on the JSON body. The assertion is updated to verify content while allowing either key order.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These three tests were relying on ordering that is not guaranteed by the underlying platform, which NonDex exposes as non-deterministic behavior.

- In `KinesisMessageDrivenChannelAdapterTests.resharding`, the test assumed a single shard key, even though the resharding logic can legitimately end with either of two closed shards depending on iteration order. This caused intermittent failures under NonDex despite both outcomes being correct.

- In `SnsBodyBuilderTests.snsBodyBuilder` and `SnsMessageHandlerTests.snsMessageHandler`, the assertions compared JSON payloads using exact string equality. Since JSON object key order is not guaranteed, the tests failed when `"sms"` appeared before `"default"`, even though the message content was identical.

By:
- Accepting either valid shard key in the Kinesis test, and  
- Asserting that the SNS JSON payloads are well-formed and contain the expected `"default"` and `"sms"` fields (without enforcing key order),

this PR removes hidden ordering assumptions and makes the tests deterministic while still validating the intended behavior.

## :green_heart: How did you test it?
Run NonDex on ```<ModulePath>``` using the following commands:
```
mvn -pl <ModulePath> edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=packageName.ClassName#methodName
```
Replace ```<ModulePath>``` with the corresponding ```packageName.ClassName#methodName```:
```
ModulePath: spring-cloud-aws-kinesis
io.awspring.cloud.kinesis.integration.KinesisMessageDrivenChannelAdapterTests#resharding
```
```
ModulePath: spring-cloud-aws-sns
io.awspring.cloud.sns.integration.SnsBodyBuilderTests#snsBodyBuilder
io.awspring.cloud.sns.integration.SnsMessageHandlerTests#snsMessageHandler 
```

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
