### PR TITLE
Resolve listener payload type during container setup

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -660,6 +660,18 @@ public class MyListener {
 
 The `isDefault = true` parameter designates a method as the fallback handler for messages that don't match any other handler's parameter type.
 
+To determine which handler method to invoke, the framework needs to know the payload type before deserialization.
+A custom `PayloadTypeMapper` should be configured to map incoming messages to their concrete types.
+See <<Custom Payload Type Mapping>> for an example.
+
+[NOTE]
+====
+Since 4.0.0, the default type header sent by `SqsTemplate` is deprecated and is no longer used to deserialize the payload.
+A custom mapper is necessary to disambiguate between different payload types in multi-handler listeners.
+Alternatively, automatic inference can be disabled to restore header-based type resolution.
+See <<Automatic Payload Type Inference>> for more information.
+====
+
 ===== SNS Messages
 
 Since 3.1.1, when receiving SNS messages through the `@SqsListener`, the message includes all attributes of the `SnsNotification`. To only receive need the `Message` part of the payload, you can utilize the `@SnsNotificationMessage` annotation.
@@ -1609,16 +1621,55 @@ NOTE: When using Spring Boot's auto-configuration, if there's a single `ObjectMa
 This includes the one provided by Spring Boot's auto-configuration itself.
 For configuring a different `ObjectMapper`, see <<Global Configuration for @SqsListeners>>.
 
-For manually created `MessageListeners`, `MessageInterceptor` and `ErrorHandler` components, or more fine-grained conversion such as using `interfaces` or `inheritance` in listener methods, type mapping is required for payload deserialization.
+==== Automatic Payload Type Inference
 
-By default, the framework looks for a `MessageHeader` named `Sqs_MA_JavaType` containing the fully qualified class name (`FQCN`) for which the payload should be deserialized to.
-If such header is found, the message is automatically deserialized to the provided class.
+Since 4.0.0, by default, the framework automatically infers the payload type from the `@SqsListener` method signature at the `MessageSource` level.
+This allows payloads to be deserialized early in the message processing flow without requiring type information in message headers.
 
-Further configuration can be achieved by providing a configured `MessagingMessageConverter` instance in the `SqsContainerOptions`.
+This enables accessing the deserialized payload in components such as `MessageInterceptor`, `ErrorHandler`, and `AcknowledgementResultCallback` without type headers.
 
-NOTE: If type mapping is setup or type information is added to the headers, payloads are deserialized right after the message is polled.
-Otherwise, for `@SqsListener` annotated methods, payloads are deserialized right before the message is sent to the listener.
-For providing custom `MessageConverter` instances to be used by `@SqsListener` methods, see <<Global Configuration for @SqsListeners>>
+The inference supports simple types, generic types like `List<MyEvent>`, `Message<MyEvent>`, and `List<Message<MyEvent>>`.
+Parameters annotated with `@Payload` are explicitly recognized as the payload parameter.
+
+For polymorphic types (interfaces, `Object`, or `@SqsHandler` methods), a custom mapper is required.
+See <<Custom Payload Type Mapping>>.
+
+[NOTE]
+====
+The `JavaType` header automatically set by `SqsTemplate` is deprecated since 4.0.0 and will be removed in a future version.
+When automatic payload type inference is enabled, the `JavaType` header is ignored by default.
+For backward compatibility, `SqsTemplate` still sends this header, allowing applications to roll back if needed.
+====
+
+==== Customizing Type Resolution
+
+Type resolution can be customized at two levels:
+
+*Per-converter:* Configure `setPayloadTypeMapper` or `setPayloadTypeHeader` on a `MessagingMessageConverter`.
+Any custom type mapper takes precedence over automatic inference for that converter.
+Note that, by default, all containers share the same SqsMessagingMessageConverter instance.
+
+*Framework-wide:* Provide a custom `MethodPayloadTypeInferrer` implementation via a `SqsListenerConfigurer`.
+See <<Global Configuration for @SqsListeners>>.
+
+==== Disabling Automatic Inference
+
+*Per-converter:* To restore header-based type mapping for specific converters, call `setPayloadTypeHeader` on the converter:
+
+[source, java]
+----
+converter.setPayloadTypeHeader(SqsHeaders.SQS_DEFAULT_TYPE_HEADER);
+----
+
+*Framework-wide:* To disable automatic inference globally, set `methodPayloadTypeInferrer` to `null` via a `SqsListenerConfigurer`:
+
+[source, java]
+----
+@Bean
+SqsListenerConfigurer sqsListenerConfigurer() {
+    return registrar -> registrar.setMethodPayloadTypeInferrer(null);
+}
+----
 
 ==== Configuring a MessagingMessageConverter
 
@@ -1677,41 +1728,72 @@ messageConverter.setPayloadMessageConverter(payloadConverter);
 factory.configure(options -> options.messageConverter(messageConverter));
 ----
 
-==== Interfaces and Subclasses in Listener Methods
+==== Custom Payload Type Mapping
 
-Interfaces and subclasses can be used in `@SqsListener` annotated methods by configuring a `type mapper`:
-
-[source, java]
-----
-messageConverter.setPayloadTypeMapper(message -> {
-    String eventTypeHeader = message.getHeaders().get("myEventTypeHeader", String.class);
-    return "eventTypeA".equals(eventTypeHeader)
-        ? MyTypeA.class
-        : MyTypeB.class;
-});
-----
-
-And then, in the listener method:
+When determining the payload type based on message content is necessary, a custom `payloadTypeMapper` can be configured:
 
 [source, java]
 ----
-@SpringBootApplication
-public class SqsApplication {
+@Bean
+SqsMessagingMessageConverter messageConverter() {
+    var converter = new SqsMessagingMessageConverter();
+    converter.setPayloadTypeMapper(message -> {
+        String payload = (String) message.getPayload();
+        if (payload.contains("\"type\":\"OrderEvent\"")) {
+            return OrderEvent.class;
+        }
+        if (payload.contains("\"type\":\"PaymentEvent\"")) {
+            return PaymentEvent.class;
+        }
+        return null;
+    });
+    return converter;
+}
+----
 
-    public static void main(String[] args) {
-        SpringApplication.run(SqsApplication.class, args);
+This enables using interfaces or subclasses in listener methods:
+
+[source, java]
+----
+public interface DomainEvent {}
+public record OrderEvent(String orderId, String status) implements DomainEvent {}
+public record PaymentEvent(String paymentId, BigDecimal amount) implements DomainEvent {}
+
+@SqsListener("events-queue")
+void handleEvent(DomainEvent event) {
+    // event will be the correct concrete type based on the mapper
+}
+----
+
+The same configuration enables routing to different `@SqsHandler` methods:
+
+[source, java]
+----
+@SqsListener("events-queue")
+public class EventListener {
+
+    @SqsHandler
+    void handle(OrderEvent event) {
+        // handles OrderEvent
     }
 
-    // Retrieve the converted payload
-    @SqsListener("myQueue")
-    public void listen(MyInterface message) {
-        System.out.println(message);
+    @SqsHandler
+    void handle(PaymentEvent event) {
+        // handles PaymentEvent
     }
+}
+----
 
-    // Or retrieve a Message with the converted payload
-    @SqsListener("myOtherQueue")
-    public void listen(Message<MyInterface> message) {
-        System.out.println(message);
+Or when using `Object` as the parameter type:
+
+[source, java]
+----
+@SqsListener("events-queue")
+void handleEvent(Object event) {
+    if (event instanceof OrderEvent orderEvent) {
+        // handle order
+    } else if (event instanceof PaymentEvent paymentEvent) {
+        // handle payment
     }
 }
 ----
@@ -1933,6 +2015,9 @@ By default, `StringMessageConverter`, `SimpleMessageConverter` and `MappingJacks
 
 - `manageArgumentResolvers` - gives access to the list of argument resolvers that will be used to resolve the listener method arguments.
 The order of resolvers is important - `PayloadMethodArgumentResolver` should generally be last since it's used as default.
+- `setMethodPayloadTypeInferrer` - set the `MethodPayloadTypeInferrer` instance to be used for automatic payload type inference.
+Set to `null` to disable automatic inference and rely on header-based type mapping.
+See <<Automatic Payload Type Inference>> for more information.
 
 A simple example would be:
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/ConfigUtils.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/ConfigUtils.java
@@ -92,4 +92,12 @@ public class ConfigUtils {
 		return this;
 	}
 
+	public <T, V> ConfigUtils acceptManyIfNotNullAndInstance(@Nullable T value, Collection<?> values, Class<V> clazz,
+			BiConsumer<T, V> consumer) {
+		if (value != null) {
+			values.forEach(v -> acceptIfInstance(v, clazz, instance -> consumer.accept(value, instance)));
+		}
+		return this;
+	}
+
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/AbstractListenerAnnotationBeanPostProcessor.java
@@ -99,6 +99,8 @@ public abstract class AbstractListenerAnnotationBeanPostProcessor<A extends Anno
 	@Nullable
 	private BeanExpressionContext expressionContext;
 
+	private final List<HandlerMethodArgumentResolver> argumentResolvers = new ArrayList<>();
+
 	@Override
 	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
 		Class<?> targetClass = AopUtils.getTargetClass(bean);
@@ -155,6 +157,7 @@ public abstract class AbstractListenerAnnotationBeanPostProcessor<A extends Anno
 			hme.setBean(bean);
 			hme.setMethod(method);
 			hme.setHandlerMethodFactory(this.delegatingHandlerMethodFactory);
+			hme.setArgumentResolvers(this.argumentResolvers);
 		});
 		return endpoint;
 	}
@@ -320,6 +323,7 @@ public abstract class AbstractListenerAnnotationBeanPostProcessor<A extends Anno
 		this.endpointRegistrar.getMethodArgumentResolversConsumer().accept(methodArgumentResolvers);
 		handlerMethodFactory.setArgumentResolvers(methodArgumentResolvers);
 		handlerMethodFactory.afterPropertiesSet();
+		this.argumentResolvers.addAll(methodArgumentResolvers);
 	}
 
 	protected Collection<HandlerMethodArgumentResolver> createAdditionalArgumentResolvers(

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/DefaultMethodPayloadTypeInferrer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/DefaultMethodPayloadTypeInferrer.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.config;
+
+import io.awspring.cloud.sqs.support.resolver.BatchPayloadMethodArgumentResolver;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.support.MessageMethodArgumentResolver;
+import org.springframework.messaging.handler.annotation.support.PayloadMethodArgumentResolver;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+
+/**
+ * Default implementation of {@link MethodPayloadTypeInferrer} that infers the payload type by analyzing method
+ * parameters and their associated argument resolvers.
+ * <p>
+ * The inference strategy:
+ * <ol>
+ * <li>If a parameter is explicitly annotated with {@link Payload}, it is considered the payload</li>
+ * <li>Otherwise, the first parameter that is not supported by any non-payload resolver is considered the payload</li>
+ * </ol>
+ * <p>
+ * Non-payload resolvers are those that handle framework-specific types like acknowledgements, headers, visibility, or
+ * user-provided resolvers for custom types. Payload resolvers handle the actual message payload.
+ *
+ * @author Tomaz Fernandes
+ * @since 3.4.3
+ */
+public class DefaultMethodPayloadTypeInferrer implements MethodPayloadTypeInferrer {
+
+	@Override
+	@Nullable
+	public Class<?> inferPayloadType(Method method, List<HandlerMethodArgumentResolver> argumentResolvers) {
+		if (argumentResolvers == null || argumentResolvers.isEmpty()) {
+			return null;
+		}
+
+		List<HandlerMethodArgumentResolver> nonPayloadResolvers = argumentResolvers.stream()
+				.filter(resolver -> !isPayloadResolver(resolver)).toList();
+
+		for (int i = 0; i < method.getParameterCount(); i++) {
+			MethodParameter parameter = new MethodParameter(method, i);
+
+			if (parameter.hasParameterAnnotation(Payload.class)) {
+				return extractClass(parameter.getGenericParameterType());
+			}
+
+			boolean supportedByNonPayloadResolver = nonPayloadResolvers.stream()
+					.anyMatch(resolver -> resolver.supportsParameter(parameter));
+
+			if (!supportedByNonPayloadResolver) {
+				return extractClass(parameter.getGenericParameterType());
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Extract the target class for payload conversion from the inferred type. Handles generic types like
+	 * {@code List<CustomEvent>} by extracting the element type.
+	 * @param type the inferred payload type
+	 * @return the class to be used for payload conversion, or null if cannot be determined
+	 */
+	@Nullable
+	private Class<?> extractClass(Type type) {
+		ResolvableType resolvableType = ResolvableType.forType(type);
+		Class<?> rawClass = resolvableType.toClass();
+
+		// If it's a Collection (e.g., List<CustomEvent>), extract the element type
+		if (Collection.class.isAssignableFrom(rawClass)) {
+			Class<?> elementClass = resolvableType.getNested(2).toClass();
+			// If it's a Collection of Messages (e.g., List<Message<CustomEvent>>), go one level deeper
+			if (Message.class.isAssignableFrom(elementClass)) {
+				return resolvableType.getNested(3).toClass();
+			}
+			return elementClass;
+		}
+
+		// If it's a Message<T>, unwrap to get T
+		if (Message.class.isAssignableFrom(rawClass)) {
+			return resolvableType.getNested(2).toClass();
+		}
+
+		// For simple types, return as-is
+		return rawClass;
+	}
+
+	private boolean isPayloadResolver(HandlerMethodArgumentResolver resolver) {
+		return resolver instanceof PayloadMethodArgumentResolver
+				|| resolver instanceof BatchPayloadMethodArgumentResolver
+				|| resolver instanceof MessageMethodArgumentResolver;
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/HandlerMethodEndpoint.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/HandlerMethodEndpoint.java
@@ -17,8 +17,11 @@ package io.awspring.cloud.sqs.config;
 
 import io.awspring.cloud.sqs.listener.ListenerMode;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.function.Consumer;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 
 /**
  * {@link Endpoint} specialization that indicates that {@link org.springframework.messaging.Message} instances coming
@@ -47,6 +50,18 @@ public interface HandlerMethodEndpoint extends Endpoint {
 	 * @param handlerMethodFactory the factory.
 	 */
 	void setHandlerMethodFactory(MessageHandlerMethodFactory handlerMethodFactory);
+
+	/**
+	 * Set the {@link MethodPayloadTypeInferrer} to be used for inferring payload types from method signatures.
+	 * @param inferrer the inferrer instance, or null to disable inference.
+	 */
+	void setMethodPayloadTypeInferrer(@Nullable MethodPayloadTypeInferrer inferrer);
+
+	/**
+	 * Set the argument resolvers to be used for inferring payload types.
+	 * @param argumentResolvers the argument resolvers, may be null.
+	 */
+	void setArgumentResolvers(@Nullable List<HandlerMethodArgumentResolver> argumentResolvers);
 
 	/**
 	 * Allows configuring the {@link ListenerMode} for this endpoint.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/MethodPayloadTypeInferrer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/MethodPayloadTypeInferrer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.config;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+
+/**
+ * Strategy interface for inferring the payload type from a listener method signature. Implementations analyze the
+ * method parameters and argument resolvers to dynamically determine which parameter represents the message payload and
+ * what its type is.
+ *
+ * @author Tomaz Fernandes
+ * @since 3.4.3
+ */
+@FunctionalInterface
+public interface MethodPayloadTypeInferrer {
+
+	/**
+	 * Infer the payload class from the given method and its argument resolvers.
+	 * @param method the listener method
+	 * @param argumentResolvers the argument resolvers available for this method, may be null or empty
+	 * @return the inferred payload class, or null if it cannot be determined
+	 */
+	@Nullable
+	Class<?> inferPayloadType(Method method, @Nullable List<HandlerMethodArgumentResolver> argumentResolvers);
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
@@ -71,6 +71,9 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 
 	private int phase = DEFAULT_PHASE;
 
+	@Nullable
+	private Class<?> payloadDeserializationType;
+
 	/**
 	 * Create an instance with the provided {@link ContainerOptions}
 	 * @param containerOptions the options instance.
@@ -173,6 +176,23 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 	}
 
 	/**
+	 * Set the target type for payload deserialization. When set, messages will be deserialized to this type at the
+	 * {@link org.springframework.context.MessageSource} before being passed to the listener.
+	 * <p>
+	 * Since 4.0.0, this type is typically inferred automatically from the {@code @SqsListener} method signature when
+	 * using @SqsListener annotations, but can also be set manually for programmatic container configuration.
+	 * <p>
+	 * <b>Note on precedence:</b> Payload type mappers on the converter take precedence over the type manually set by
+	 * this method.
+	 * <p>
+	 * @param payloadDeserializationType the target type for deserialization
+	 * @see io.awspring.cloud.sqs.support.converter.AbstractMessagingMessageConverter
+	 */
+	public void setPayloadDeserializationType(@Nullable Class<?> payloadDeserializationType) {
+		this.payloadDeserializationType = payloadDeserializationType;
+	}
+
+	/**
 	 * Returns the {@link ContainerOptions} instance for this container. Changed options will take effect on container
 	 * restart.
 	 */
@@ -225,6 +245,15 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 	 */
 	public AsyncAcknowledgementResultCallback<T> getAcknowledgementResultCallback() {
 		return this.acknowledgementResultCallback;
+	}
+
+	/**
+	 * Return the target type for payload deserialization, or null if not set.
+	 * @return the payload deserialization type.
+	 */
+	@Nullable
+	public Class<?> getPayloadDeserializationType() {
+		return this.payloadDeserializationType;
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractPipelineMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractPipelineMessageListenerContainer.java
@@ -34,6 +34,7 @@ import io.awspring.cloud.sqs.listener.pipeline.MessageProcessingPipeline;
 import io.awspring.cloud.sqs.listener.pipeline.MessageProcessingPipelineBuilder;
 import io.awspring.cloud.sqs.listener.sink.MessageProcessingPipelineSink;
 import io.awspring.cloud.sqs.listener.sink.MessageSink;
+import io.awspring.cloud.sqs.listener.source.AbstractMessageConvertingMessageSource;
 import io.awspring.cloud.sqs.listener.source.AcknowledgementProcessingMessageSource;
 import io.awspring.cloud.sqs.listener.source.MessageSource;
 import io.awspring.cloud.sqs.listener.source.PollingMessageSource;
@@ -163,7 +164,11 @@ public abstract class AbstractPipelineMessageListenerContainer<T, O extends Cont
 				.acceptManyIfInstance(this.messageSources, AcknowledgementProcessingMessageSource.class,
 						ams -> ams.setAcknowledgementResultCallback(getAcknowledgementResultCallback()))
 				.acceptManyIfInstance(this.messageSources, TaskExecutorAware.class,
-						teac -> teac.setTaskExecutor(taskExecutor));
+						teac -> teac.setTaskExecutor(taskExecutor))
+				.acceptManyIfNotNullAndInstance(getPayloadDeserializationType(), this.messageSources,
+						AbstractMessageConvertingMessageSource.class,
+						(type, source) -> source.setPayloadDeserializationType(type));
+
 		doConfigureMessageSources(this.messageSources);
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractMessageConvertingMessageSource.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractMessageConvertingMessageSource.java
@@ -78,6 +78,25 @@ public abstract class AbstractMessageConvertingMessageSource<T, S> implements Me
 		}
 	}
 
+	/**
+	 * Set the payload deserialization type. This will be used by the message converter to deserialize messages to the
+	 * target type. Note that type mappers in MessagingMessageConverters take precedence over this type.
+	 * @param payloadDeserializationType the target class
+	 */
+	public void setPayloadDeserializationType(@Nullable Class<?> payloadDeserializationType) {
+		ConfigUtils.INSTANCE.acceptBothIfNoneNull(payloadDeserializationType, this.messageConversionContext,
+				this::doConfigurePayloadTypeOnContext);
+	}
+
+	/**
+	 * Hook method for subclasses to configure the payload type on their specific MessageConversionContext
+	 * implementation.
+	 * @param payloadType the payload type to configure
+	 * @param context the message conversion context
+	 */
+	protected void doConfigurePayloadTypeOnContext(Class<?> payloadType, MessageConversionContext context) {
+	}
+
 	@Nullable
 	private MessageConversionContext maybeCreateConversionContext() {
 		return this.messagingMessageConverter instanceof ContextAwareMessagingMessageConverter

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSource.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSource.java
@@ -26,6 +26,8 @@ import io.awspring.cloud.sqs.listener.SqsContainerOptions;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementExecutor;
 import io.awspring.cloud.sqs.listener.acknowledgement.ExecutingAcknowledgementProcessor;
 import io.awspring.cloud.sqs.listener.acknowledgement.SqsAcknowledgementExecutor;
+import io.awspring.cloud.sqs.support.converter.MessageConversionContext;
+import io.awspring.cloud.sqs.support.converter.SqsMessageConversionContext;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -127,6 +129,12 @@ public abstract class AbstractSqsMessageSource<T> extends AbstractPollingMessage
 						qaa -> qaa.setQueueAttributes(this.queueAttributes))
 				.acceptIfInstance(getAcknowledgmentProcessor(), ExecutingAcknowledgementProcessor.class, eap -> eap
 						.setAcknowledgementExecutor(createAndConfigureAcknowledgementExecutor(this.queueAttributes)));
+	}
+
+	@Override
+	protected void doConfigurePayloadTypeOnContext(Class<?> payloadType, MessageConversionContext context) {
+		ConfigUtils.INSTANCE.acceptIfInstance(context, SqsMessageConversionContext.class,
+				ctx -> ctx.setPayloadClass(payloadType));
 	}
 
 	// @formatter:off

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
@@ -55,7 +55,10 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 
 	private HeaderMapper<S> headerMapper;
 
-	private Function<Message<?>, Class<?>> payloadTypeMapper;
+	private static final Function<Message<?>, Class<?>> DEFAULT_PAYLOAD_TYPE_MAPPER = msg -> headerTypeMapping(msg,
+			SqsHeaders.SQS_DEFAULT_TYPE_HEADER);
+
+	private Function<Message<?>, Class<?>> payloadTypeMapper = DEFAULT_PAYLOAD_TYPE_MAPPER;
 
 	private Function<Message<?>, String> payloadTypeHeaderFunction = message -> message.getPayload().getClass()
 			.getName();
@@ -63,12 +66,19 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 	protected AbstractMessagingMessageConverter() {
 		this.payloadMessageConverter = createDefaultCompositeMessageConverter();
 		this.headerMapper = createDefaultHeaderMapper();
-		this.payloadTypeMapper = this::defaultHeaderTypeMapping;
+	}
+
+	/**
+	 * Check if this converter is using the default payload type mapper (header-based).
+	 * @return true if using the default mapper, false if a custom mapper has been configured
+	 */
+	public boolean isUsingDefaultPayloadTypeMapper() {
+		return this.payloadTypeMapper == DEFAULT_PAYLOAD_TYPE_MAPPER;
 	}
 
 	/**
 	 * Set the payload type mapper to be used by this converter. {@link Message} payloads will be converted to the
-	 * {@link Class} returned by this function. The {@link #defaultHeaderTypeMapping} uses the {@link #typeHeader}
+	 * {@link Class} returned by this function. The default header-based type mapping uses the {@link #typeHeader}
 	 * property to retrieve the payload class' FQCN. This method replaces the default type mapping for this converter
 	 * instance.
 	 * @param payloadTypeMapper the type mapping function.
@@ -119,13 +129,14 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 	}
 
 	/**
-	 * Set the name of the header to be looked up in a {@link Message} instance by the
-	 * {@link #defaultHeaderTypeMapping(Message)}.
+	 * Set the name of the header to be looked up in a {@link Message} instance for payload type mapping. When used,
+	 * type header mapping takes precedence over automatic type inferrence.
 	 * @param typeHeader the header name.
 	 */
 	public void setPayloadTypeHeader(String typeHeader) {
 		Assert.notNull(typeHeader, "typeHeader cannot be null");
 		this.typeHeader = typeHeader;
+		this.payloadTypeMapper = msg -> headerTypeMapping(msg, typeHeader);
 	}
 
 	/**
@@ -195,8 +206,8 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 	protected abstract Object getPayloadToDeserialize(S message);
 
 	@Nullable
-	private Class<?> defaultHeaderTypeMapping(Message<?> message) {
-		String header = message.getHeaders().get(this.typeHeader, String.class);
+	private static Class<?> headerTypeMapping(Message<?> message, String typeHeader) {
+		String header = message.getHeaders().get(typeHeader, String.class);
 		if (header == null) {
 			return null;
 		}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/config/AbstractEndpointTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/config/AbstractEndpointTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.config;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.awspring.cloud.sqs.listener.AbstractMessageListenerContainer;
+import io.awspring.cloud.sqs.listener.ContainerOptions;
+import io.awspring.cloud.sqs.support.converter.AbstractMessagingMessageConverter;
+import io.awspring.cloud.sqs.support.converter.MessagingMessageConverter;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+
+/**
+ * Tests for {@link AbstractEndpoint} focusing on payload type mapper configuration.
+ *
+ * @author Tomaz Fernandes
+ */
+@SuppressWarnings("rawtypes")
+class AbstractEndpointTest {
+
+	private SqsEndpoint endpoint;
+
+	private AbstractMessageListenerContainer<?, ?, ?> container;
+
+	private ContainerOptions<?, ?> containerOptions;
+
+	private AbstractMessagingMessageConverter<?> converter;
+
+	private MethodPayloadTypeInferrer inferrer;
+
+	private MessageHandlerMethodFactory handlerMethodFactory;
+
+	private InvocableHandlerMethod invocableHandlerMethod;
+
+	@BeforeEach
+	@SuppressWarnings("unchecked")
+	void setup() {
+		endpoint = SqsEndpoint.builder().queueNames(Collections.singletonList("test-queue")).id("test-id").build();
+
+		container = (AbstractMessageListenerContainer<?, ?, ?>) mock(AbstractMessageListenerContainer.class);
+		containerOptions = (ContainerOptions<?, ?>) mock(ContainerOptions.class);
+		converter = (AbstractMessagingMessageConverter<?>) mock(AbstractMessagingMessageConverter.class);
+		inferrer = mock(MethodPayloadTypeInferrer.class);
+		handlerMethodFactory = mock(MessageHandlerMethodFactory.class);
+		invocableHandlerMethod = mock(InvocableHandlerMethod.class);
+
+		when(container.getContainerOptions()).thenReturn((ContainerOptions) containerOptions);
+		when(containerOptions.getMessageConverter()).thenReturn((MessagingMessageConverter) converter);
+		when(handlerMethodFactory.createInvocableHandlerMethod(any(), any(Method.class)))
+				.thenReturn(invocableHandlerMethod);
+
+		// Mock the return type to be a non-CompletionStage
+		MethodParameter returnType = mock(MethodParameter.class);
+		when(invocableHandlerMethod.getReturnType()).thenReturn(returnType);
+		when(returnType.getParameterType()).thenReturn((Class) String.class);
+
+		endpoint.setBean(new TestListener());
+		endpoint.setHandlerMethodFactory(handlerMethodFactory);
+	}
+
+	@Test
+	void shouldNotConfigureMapperWhenInferrerIsNull() throws Exception {
+		Method method = TestListener.class.getMethod("handleMessage", String.class);
+		endpoint.setMethod(method);
+		endpoint.setMethodPayloadTypeInferrer(null);
+
+		endpoint.setupContainer(container);
+
+		verify(converter, never()).setPayloadTypeMapper(any());
+	}
+
+	@Test
+	void shouldNotConfigureMapperWhenInferredTypeIsNull() throws Exception {
+		Method method = TestListener.class.getMethod("handleMessage", String.class);
+		endpoint.setMethod(method);
+		endpoint.setMethodPayloadTypeInferrer(inferrer);
+
+		when(inferrer.inferPayloadType(any(Method.class), any())).thenReturn(null);
+
+		endpoint.setupContainer(container);
+
+		verify(converter, never()).setPayloadTypeMapper(any());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void shouldConfigureMapperWhenUsingDefaultMapper() throws Exception {
+		Method method = TestListener.class.getMethod("handleMessage", String.class);
+		endpoint.setMethod(method);
+		endpoint.setMethodPayloadTypeInferrer(inferrer);
+
+		when(inferrer.inferPayloadType(any(Method.class), any())).thenReturn((Class) String.class);
+		when(converter.isUsingDefaultPayloadTypeMapper()).thenReturn(true);
+
+		endpoint.setupContainer(container);
+
+		verify(converter).setPayloadTypeMapper(any(Function.class));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void shouldNotOverrideCustomMapper() throws Exception {
+		Method method = TestListener.class.getMethod("handleMessage", String.class);
+		endpoint.setMethod(method);
+		endpoint.setMethodPayloadTypeInferrer(inferrer);
+
+		when(inferrer.inferPayloadType(any(Method.class), any())).thenReturn((Class) String.class);
+		when(converter.isUsingDefaultPayloadTypeMapper()).thenReturn(false);
+
+		endpoint.setupContainer(container);
+
+		verify(converter, never()).setPayloadTypeMapper(any());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void shouldNotConfigureWhenConverterIsNotAbstractMessagingMessageConverter() throws Exception {
+		MessagingMessageConverter<?> nonAbstractConverter = (MessagingMessageConverter<?>) mock(
+				MessagingMessageConverter.class);
+		when(containerOptions.getMessageConverter()).thenReturn((MessagingMessageConverter) nonAbstractConverter);
+
+		Method method = TestListener.class.getMethod("handleMessage", String.class);
+		endpoint.setMethod(method);
+		endpoint.setMethodPayloadTypeInferrer(inferrer);
+
+		when(inferrer.inferPayloadType(any(Method.class), any())).thenReturn((Class) String.class);
+
+		endpoint.setupContainer(container);
+
+		verify(converter, never()).setPayloadTypeMapper(any());
+	}
+
+	static class TestListener {
+		public void handleMessage(String message) {
+			// test method
+		}
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/config/DefaultMethodPayloadTypeInferrerTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/config/DefaultMethodPayloadTypeInferrerTest.java
@@ -1,0 +1,629 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement;
+import io.awspring.cloud.sqs.support.resolver.BatchPayloadMethodArgumentResolver;
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.support.MessageMethodArgumentResolver;
+import org.springframework.messaging.handler.annotation.support.PayloadMethodArgumentResolver;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+
+/**
+ * Comprehensive tests for {@link DefaultMethodPayloadTypeInferrer}.
+ *
+ * @author Tomaz Fernandes
+ */
+class DefaultMethodPayloadTypeInferrerTest {
+
+	private final DefaultMethodPayloadTypeInferrer inferrer = new DefaultMethodPayloadTypeInferrer();
+
+	// ========== Null and Empty Input Tests ==========
+
+	@Test
+	void shouldReturnNullWhenArgumentResolversIsNull() throws Exception {
+		Method method = TestMethods.class.getMethod("simpleStringPayload", String.class);
+
+		Class<?> result = inferrer.inferPayloadType(method, null);
+
+		assertThat(result).isNull();
+	}
+
+	@Test
+	void shouldReturnNullWhenArgumentResolversIsEmpty() throws Exception {
+		Method method = TestMethods.class.getMethod("simpleStringPayload", String.class);
+		List<HandlerMethodArgumentResolver> emptyResolvers = Collections.emptyList();
+
+		Class<?> result = inferrer.inferPayloadType(method, emptyResolvers);
+
+		assertThat(result).isNull();
+	}
+
+	@Test
+	void shouldReturnNullWhenMethodHasNoParameters() throws Exception {
+		Method method = TestMethods.class.getMethod("noParameters");
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isNull();
+	}
+
+	// ========== @Payload Annotation Tests ==========
+
+	@Test
+	void shouldInferFromPayloadAnnotationOnFirstParameter() throws Exception {
+		Method method = TestMethods.class.getMethod("payloadAnnotationFirst", String.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(String.class);
+	}
+
+	@Test
+	void shouldInferFromPayloadAnnotationOnSecondParameter() throws Exception {
+		Method method = TestMethods.class.getMethod("payloadAnnotationSecond", String.class, CustomEvent.class);
+		List<HandlerMethodArgumentResolver> resolvers = createMixedResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldInferFromPayloadAnnotationWithList() throws Exception {
+		Method method = TestMethods.class.getMethod("payloadAnnotationList", List.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldInferFromPayloadAnnotationWithMessage() throws Exception {
+		Method method = TestMethods.class.getMethod("payloadAnnotationMessage", Message.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldInferFromPayloadAnnotationWithListOfMessages() throws Exception {
+		Method method = TestMethods.class.getMethod("payloadAnnotationListOfMessages", List.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	// ========== Inference Without @Payload Annotation Tests ==========
+
+	@Test
+	void shouldInferSimpleTypeAsFirstParameter() throws Exception {
+		Method method = TestMethods.class.getMethod("simpleStringPayload", String.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(String.class);
+	}
+
+	@Test
+	void shouldInferCustomTypeAsFirstParameter() throws Exception {
+		Method method = TestMethods.class.getMethod("customEventPayload", CustomEvent.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldInferPayloadAsSecondParameterWhenFirstIsSupportedByNonPayloadResolver() throws Exception {
+		Method method = TestMethods.class.getMethod("headerThenPayload", String.class, CustomEvent.class);
+		List<HandlerMethodArgumentResolver> resolvers = createMixedResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldInferPayloadAfterMultipleNonPayloadParameters() throws Exception {
+		Method method = TestMethods.class.getMethod("multipleNonPayloadThenPayload", String.class, String.class,
+				CustomEvent.class);
+		List<HandlerMethodArgumentResolver> resolvers = createMixedResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldInferPayloadWithAcknowledgementParameter() throws Exception {
+		Method method = TestMethods.class.getMethod("payloadWithAcknowledgement", CustomEvent.class,
+				Acknowledgement.class);
+		List<HandlerMethodArgumentResolver> resolvers = createResolversWithAcknowledgement();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	// ========== Generic Type Extraction Tests ==========
+
+	@Test
+	void shouldExtractElementTypeFromList() throws Exception {
+		Method method = TestMethods.class.getMethod("listOfCustomEvents", List.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldExtractElementTypeFromSet() throws Exception {
+		Method method = TestMethods.class.getMethod("setOfCustomEvents", Set.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldExtractElementTypeFromCollection() throws Exception {
+		Method method = TestMethods.class.getMethod("collectionOfCustomEvents", Collection.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldExtractElementTypeFromQueue() throws Exception {
+		Method method = TestMethods.class.getMethod("queueOfCustomEvents", Queue.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldUnwrapMessageGeneric() throws Exception {
+		Method method = TestMethods.class.getMethod("messageOfCustomEvent", Message.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldUnwrapListOfMessages() throws Exception {
+		Method method = TestMethods.class.getMethod("listOfMessageOfCustomEvent", List.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldHandleComplexNestedGenerics() throws Exception {
+		Method method = TestMethods.class.getMethod("collectionOfMessageOfCustomEvent", Collection.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	// ========== Various Payload Type Tests ==========
+
+	@Test
+	void shouldInferStringPayloadType() throws Exception {
+		Method method = TestMethods.class.getMethod("simpleStringPayload", String.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(String.class);
+	}
+
+	@Test
+	void shouldInferIntegerPayloadType() throws Exception {
+		Method method = TestMethods.class.getMethod("integerPayload", Integer.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(Integer.class);
+	}
+
+	@Test
+	void shouldInferComplexCustomType() throws Exception {
+		Method method = TestMethods.class.getMethod("complexEventPayload", ComplexEvent.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(ComplexEvent.class);
+	}
+
+	// ========== Edge Cases and Special Scenarios ==========
+
+	@Test
+	void shouldReturnNullWhenAllParametersSupportedByNonPayloadResolvers() throws Exception {
+		Method method = TestMethods.class.getMethod("onlyNonPayloadParameters", String.class, String.class);
+		List<HandlerMethodArgumentResolver> resolvers = createMixedResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isNull();
+	}
+
+	@Test
+	void shouldReturnNullWhenOnlyPayloadResolverParametersPresent() throws Exception {
+		// This tests the case where all parameters would be handled by payload resolvers
+		// but we filter them out, so nothing is left
+		Method method = TestMethods.class.getMethod("messageParameter", Message.class);
+		List<HandlerMethodArgumentResolver> resolvers = createOnlyPayloadResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		// Since MessageMethodArgumentResolver is filtered out as a payload resolver,
+		// and there are no non-payload resolvers, the Message parameter should be inferred
+		assertThat(result).isEqualTo(Object.class);
+	}
+
+	@Test
+	void shouldHandleMethodWithOnlyPayloadParameter() throws Exception {
+		Method method = TestMethods.class.getMethod("onlyPayload", CustomEvent.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldPreferPayloadAnnotationOverInference() throws Exception {
+		Method method = TestMethods.class.getMethod("payloadAnnotationOverridesInference", String.class, String.class);
+		List<HandlerMethodArgumentResolver> resolvers = createMixedResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		// Second parameter has @Payload, so it should be inferred even though first param is supported by header
+		// resolver
+		assertThat(result).isEqualTo(String.class);
+	}
+
+	@Test
+	void shouldHandlePrimitiveTypes() throws Exception {
+		Method method = TestMethods.class.getMethod("primitiveIntPayload", int.class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(int.class);
+	}
+
+	@Test
+	void shouldHandleArrayTypes() throws Exception {
+		Method method = TestMethods.class.getMethod("arrayPayload", String[].class);
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(String[].class);
+	}
+
+	// ========== Resolver Behavior Tests ==========
+
+	@Test
+	void shouldWorkWithOnlyPayloadMethodArgumentResolver() throws Exception {
+		Method method = TestMethods.class.getMethod("simpleStringPayload", String.class);
+		List<HandlerMethodArgumentResolver> resolvers = new ArrayList<>();
+		resolvers.add(mock(PayloadMethodArgumentResolver.class));
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(String.class);
+	}
+
+	@Test
+	void shouldWorkWithOnlyBatchPayloadMethodArgumentResolver() throws Exception {
+		Method method = TestMethods.class.getMethod("listOfCustomEvents", List.class);
+		List<HandlerMethodArgumentResolver> resolvers = new ArrayList<>();
+		resolvers.add(mock(BatchPayloadMethodArgumentResolver.class));
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldWorkWithOnlyMessageMethodArgumentResolver() throws Exception {
+		Method method = TestMethods.class.getMethod("messageOfCustomEvent", Message.class);
+		List<HandlerMethodArgumentResolver> resolvers = new ArrayList<>();
+		resolvers.add(mock(MessageMethodArgumentResolver.class));
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldFilterOutAllPayloadResolvers() throws Exception {
+		Method method = TestMethods.class.getMethod("customEventPayload", CustomEvent.class);
+		List<HandlerMethodArgumentResolver> resolvers = createOnlyPayloadResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		// All resolvers are payload resolvers, so they're filtered out
+		// CustomEvent parameter is not supported by any non-payload resolver, so it's the payload
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	@Test
+	void shouldHandleMixOfPayloadAndNonPayloadResolvers() throws Exception {
+		Method method = TestMethods.class.getMethod("headerThenPayload", String.class, CustomEvent.class);
+		List<HandlerMethodArgumentResolver> resolvers = createMixedResolvers();
+
+		Class<?> result = inferrer.inferPayloadType(method, resolvers);
+
+		assertThat(result).isEqualTo(CustomEvent.class);
+	}
+
+	// ========== Helper Methods ==========
+
+	private List<HandlerMethodArgumentResolver> createStandardResolvers() {
+		List<HandlerMethodArgumentResolver> resolvers = new ArrayList<>();
+
+		// Mock PayloadMethodArgumentResolver
+		PayloadMethodArgumentResolver payloadResolver = mock(PayloadMethodArgumentResolver.class);
+		resolvers.add(payloadResolver);
+
+		// Mock BatchPayloadMethodArgumentResolver
+		BatchPayloadMethodArgumentResolver batchResolver = mock(BatchPayloadMethodArgumentResolver.class);
+		resolvers.add(batchResolver);
+
+		// Mock MessageMethodArgumentResolver
+		MessageMethodArgumentResolver messageResolver = mock(MessageMethodArgumentResolver.class);
+		resolvers.add(messageResolver);
+
+		return resolvers;
+	}
+
+	private List<HandlerMethodArgumentResolver> createOnlyPayloadResolvers() {
+		return createStandardResolvers();
+	}
+
+	private List<HandlerMethodArgumentResolver> createMixedResolvers() {
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		// Add a mock resolver that supports String parameters with @Header annotation
+		HandlerMethodArgumentResolver headerResolver = mock(HandlerMethodArgumentResolver.class);
+		when(headerResolver.supportsParameter(any(MethodParameter.class))).thenAnswer(invocation -> {
+			MethodParameter param = invocation.getArgument(0);
+			return param.getParameterType().equals(String.class) && param.hasParameterAnnotation(Header.class);
+		});
+		resolvers.add(headerResolver);
+
+		return resolvers;
+	}
+
+	private List<HandlerMethodArgumentResolver> createResolversWithAcknowledgement() {
+		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
+
+		// Add a mock resolver that supports Acknowledgement parameters
+		HandlerMethodArgumentResolver ackResolver = mock(HandlerMethodArgumentResolver.class);
+		when(ackResolver.supportsParameter(any(MethodParameter.class))).thenAnswer(invocation -> {
+			MethodParameter param = invocation.getArgument(0);
+			return Acknowledgement.class.isAssignableFrom(param.getParameterType());
+		});
+		resolvers.add(ackResolver);
+
+		return resolvers;
+	}
+
+	// ========== Test Method Signatures ==========
+
+	static class TestMethods {
+
+		// No parameters
+		public void noParameters() {
+		}
+
+		// Simple types
+		public void simpleStringPayload(String payload) {
+		}
+
+		public void integerPayload(Integer payload) {
+		}
+
+		public void primitiveIntPayload(int payload) {
+		}
+
+		public void arrayPayload(String[] payload) {
+		}
+
+		// Custom types
+		public void customEventPayload(CustomEvent payload) {
+		}
+
+		public void complexEventPayload(ComplexEvent payload) {
+		}
+
+		// With @Payload annotation
+		public void payloadAnnotationFirst(@Payload String payload) {
+		}
+
+		public void payloadAnnotationSecond(@Header String header, @Payload CustomEvent payload) {
+		}
+
+		public void payloadAnnotationList(@Payload List<CustomEvent> events) {
+		}
+
+		public void payloadAnnotationMessage(@Payload Message<CustomEvent> message) {
+		}
+
+		public void payloadAnnotationListOfMessages(@Payload List<Message<CustomEvent>> messages) {
+		}
+
+		public void payloadAnnotationOverridesInference(@Header String header, @Payload String payload) {
+		}
+
+		// Multiple parameters
+		public void headerThenPayload(@Header String header, CustomEvent payload) {
+		}
+
+		public void multipleNonPayloadThenPayload(@Header String header1, @Header String header2, CustomEvent payload) {
+		}
+
+		public void onlyNonPayloadParameters(@Header String header1, @Header String header2) {
+		}
+
+		public void payloadWithAcknowledgement(CustomEvent payload, Acknowledgement ack) {
+		}
+
+		// Generic types
+		public void listOfCustomEvents(List<CustomEvent> events) {
+		}
+
+		public void setOfCustomEvents(Set<CustomEvent> events) {
+		}
+
+		public void collectionOfCustomEvents(Collection<CustomEvent> events) {
+		}
+
+		public void queueOfCustomEvents(Queue<CustomEvent> events) {
+		}
+
+		public void messageOfCustomEvent(Message<CustomEvent> message) {
+		}
+
+		public void listOfMessageOfCustomEvent(List<Message<CustomEvent>> messages) {
+		}
+
+		public void collectionOfMessageOfCustomEvent(Collection<Message<CustomEvent>> messages) {
+		}
+
+		// Message parameter
+		public void messageParameter(Message<?> message) {
+		}
+
+		// Only payload
+		public void onlyPayload(CustomEvent payload) {
+		}
+
+	}
+
+	static class CustomEvent {
+
+		private String id;
+
+		private String data;
+
+		private LocalDateTime timestamp;
+
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public String getData() {
+			return data;
+		}
+
+		public void setData(String data) {
+			this.data = data;
+		}
+
+		public LocalDateTime getTimestamp() {
+			return timestamp;
+		}
+
+		public void setTimestamp(LocalDateTime timestamp) {
+			this.timestamp = timestamp;
+		}
+
+	}
+
+	static class ComplexEvent {
+
+		private String eventType;
+
+		private CustomEvent details;
+
+		private List<String> tags;
+
+		public String getEventType() {
+			return eventType;
+		}
+
+		public void setEventType(String eventType) {
+			this.eventType = eventType;
+		}
+
+		public CustomEvent getDetails() {
+			return details;
+		}
+
+		public void setDetails(CustomEvent details) {
+			this.details = details;
+		}
+
+		public List<String> getTags() {
+			return tags;
+		}
+
+		public void setTags(List<String> tags) {
+			this.tags = tags;
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
@@ -28,6 +28,7 @@ import io.awspring.cloud.sqs.listener.SqsHeaders;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import io.awspring.cloud.sqs.support.converter.MessagingMessageHeaders;
+import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -348,7 +349,11 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 		@Bean
 		public SqsMessageListenerContainerFactory<MyInterface> myPojoListenerContainerFactory() {
 			SqsMessageListenerContainerFactory<MyInterface> factory = new SqsMessageListenerContainerFactory<>();
+			// Configure converter to use header-based type resolution, which takes precedence over type inference
+			SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+			converter.setPayloadTypeHeader(SqsHeaders.SQS_DEFAULT_TYPE_HEADER);
 			factory.configure(options -> options
+					.messageConverter(converter)
 					.queueAttributeNames(Collections.singletonList(QueueAttributeName.VISIBILITY_TIMEOUT))
 					.maxDelayBetweenPolls(Duration.ofSeconds(1))
 					.pollTimeout(Duration.ofSeconds(1)));

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsPayloadTypeInferenceIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsPayloadTypeInferenceIntegrationTests.java
@@ -1,0 +1,1042 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration;
+import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
+import io.awspring.cloud.sqs.listener.QueueAttributes;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.listener.Visibility;
+import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement;
+import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementResultCallback;
+import io.awspring.cloud.sqs.listener.acknowledgement.BatchAcknowledgement;
+import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementMode;
+import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
+import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import io.awspring.cloud.sqs.support.converter.AbstractMessagingMessageConverter;
+import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.support.MessageBuilder;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
+
+/**
+ * Integration tests for SQS payload type inference without type headers.
+ *
+ * @author Tomaz Fernandes
+ */
+@SpringBootTest
+class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
+
+	private static final Logger logger = LoggerFactory.getLogger(SqsPayloadTypeInferenceIntegrationTests.class);
+
+	static final String INFERS_SIMPLE_POJO_QUEUE = "infers_simple_pojo_queue";
+
+	static final String INFERS_POJO_WITH_MANY_PARAMETERS_QUEUE = "infers_pojo_with_many_parameters_queue";
+
+	static final String INFERS_BATCH_POJO_QUEUE = "infers_batch_pojo_queue";
+
+	static final String INFERS_NESTED_GENERIC_POJO_QUEUE = "infers_nested_generic_pojo_queue";
+
+	static final String ASYNC_LISTENER_QUEUE = "async_listener_type_inference_queue";
+
+	static final String BATCH_MESSAGE_WRAPPER_QUEUE = "batch_message_wrapper_queue";
+
+	static final String IGNORES_TYPE_HEADER_QUEUE = "ignores_type_header_queue";
+
+	static final String EXPLICIT_PAYLOAD_ANNOTATION_QUEUE = "explicit_payload_annotation_queue";
+
+	static final String STRING_PAYLOAD_QUEUE = "string_payload_queue";
+
+	static final String CUSTOM_CONVERTER_QUEUE = "custom_converter_type_inference_queue";
+
+	static final String ERROR_HANDLER_TEST_QUEUE = "error_handler_type_inference_queue";
+
+	static final String MANUAL_ACK_FACTORY = "manualAckFactory";
+
+	static final String CUSTOM_CONVERTER_FACTORY = "customConverterFactory";
+
+	@BeforeAll
+	static void beforeTests() {
+		SqsAsyncClient client = createAsyncClient();
+		CompletableFuture.allOf(createQueue(client, INFERS_SIMPLE_POJO_QUEUE),
+				createQueue(client, INFERS_POJO_WITH_MANY_PARAMETERS_QUEUE),
+				createQueue(client, INFERS_BATCH_POJO_QUEUE), createQueue(client, INFERS_NESTED_GENERIC_POJO_QUEUE),
+				createQueue(client, ASYNC_LISTENER_QUEUE), createQueue(client, BATCH_MESSAGE_WRAPPER_QUEUE),
+				createQueue(client, IGNORES_TYPE_HEADER_QUEUE), createQueue(client, EXPLICIT_PAYLOAD_ANNOTATION_QUEUE),
+				createQueue(client, STRING_PAYLOAD_QUEUE), createQueue(client, CUSTOM_CONVERTER_QUEUE),
+				createQueue(client, ERROR_HANDLER_TEST_QUEUE)).join();
+	}
+
+	@Autowired
+	LatchContainer latchContainer;
+
+	@Autowired
+	SqsTemplate sqsTemplate;
+
+	@Autowired
+	PojoCollector pojoCollector;
+
+	@Autowired
+	InterceptorPayloadTypeCollector interceptorPayloadTypeCollector;
+
+	@Autowired
+	ErrorHandlerPayloadTypeCollector errorHandlerPayloadTypeCollector;
+
+	@Autowired
+	AckCallbackPayloadTypeCollector ackCallbackPayloadTypeCollector;
+
+	@Test
+	void shouldInferSimplePojoType() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(1);
+		ackCallbackPayloadTypeCollector.registerLatch(INFERS_SIMPLE_POJO_QUEUE, ackLatch);
+
+		TestEvent event = new TestEvent("test-id", "test-payload");
+		sqsTemplate.send(INFERS_SIMPLE_POJO_QUEUE, event);
+		logger.debug("Sent event to queue {}: {}", INFERS_SIMPLE_POJO_QUEUE, event);
+
+		assertThat(latchContainer.infersSimplePojoLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedSimplePojos).hasSize(1);
+		assertThat(pojoCollector.receivedSimplePojos.get(0)).isEqualTo(event);
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_SIMPLE_POJO_QUEUE, event);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_SIMPLE_POJO_QUEUE, event);
+	}
+
+	@Test
+	void shouldInferPojoWithManyParameterTypes() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(1);
+		ackCallbackPayloadTypeCollector.registerLatch(INFERS_POJO_WITH_MANY_PARAMETERS_QUEUE, ackLatch);
+
+		TestEvent event = new TestEvent("test-id-2", "test-payload-2");
+		sqsTemplate.send(INFERS_POJO_WITH_MANY_PARAMETERS_QUEUE, event);
+		logger.debug("Sent event to queue {}: {}", INFERS_POJO_WITH_MANY_PARAMETERS_QUEUE, event);
+
+		assertThat(latchContainer.infersPojoWithManyParametersLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedPojoWithManyParams).hasSize(1);
+		assertThat(pojoCollector.receivedPojoWithManyParams.get(0)).isEqualTo(event);
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_POJO_WITH_MANY_PARAMETERS_QUEUE, event);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_POJO_WITH_MANY_PARAMETERS_QUEUE, event);
+	}
+
+	@Test
+	void shouldInferBatchPojoType() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(3);
+		ackCallbackPayloadTypeCollector.registerLatch(INFERS_BATCH_POJO_QUEUE, ackLatch);
+
+		List<TestEvent> events = List.of(new TestEvent("batch-1", "payload-1"), new TestEvent("batch-2", "payload-2"),
+				new TestEvent("batch-3", "payload-3"));
+
+		sqsTemplate.sendMany(INFERS_BATCH_POJO_QUEUE,
+				events.stream().map(e -> MessageBuilder.withPayload(e).build()).toList());
+		logger.debug("Sent {} events to queue {}", events.size(), INFERS_BATCH_POJO_QUEUE);
+
+		assertThat(latchContainer.infersBatchPojoLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedBatchPojos).containsExactlyInAnyOrderElementsOf(events);
+		// Interceptor runs before the listener, so payloads are already recorded by now
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContainsAll(INFERS_BATCH_POJO_QUEUE, events);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContainsAll(INFERS_BATCH_POJO_QUEUE, events);
+	}
+
+	@Test
+	void shouldInferNestedGenericType() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(1);
+		ackCallbackPayloadTypeCollector.registerLatch(INFERS_NESTED_GENERIC_POJO_QUEUE, ackLatch);
+
+		NestedGenericEvent event = new NestedGenericEvent(new TestEvent("nested-id", "nested-payload"), 42);
+		sqsTemplate.send(INFERS_NESTED_GENERIC_POJO_QUEUE, event);
+		logger.debug("Sent nested generic event to queue {}: {}", INFERS_NESTED_GENERIC_POJO_QUEUE, event);
+
+		assertThat(latchContainer.infersNestedGenericLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedNestedGeneric).hasSize(1);
+		assertThat(pojoCollector.receivedNestedGeneric.get(0)).isEqualTo(event);
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_NESTED_GENERIC_POJO_QUEUE, event);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_NESTED_GENERIC_POJO_QUEUE, event);
+	}
+
+	@Test
+	void shouldInferTypeWithAsyncListener() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(1);
+		ackCallbackPayloadTypeCollector.registerLatch(ASYNC_LISTENER_QUEUE, ackLatch);
+
+		TestEvent event = new TestEvent("async-id", "async-payload");
+		sqsTemplate.send(ASYNC_LISTENER_QUEUE, event);
+		logger.debug("Sent event to async listener queue {}: {}", ASYNC_LISTENER_QUEUE, event);
+
+		assertThat(latchContainer.asyncListenerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedAsyncPojos).hasSize(1);
+		assertThat(pojoCollector.receivedAsyncPojos.get(0)).isEqualTo(event);
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(ASYNC_LISTENER_QUEUE, event);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(ASYNC_LISTENER_QUEUE, event);
+	}
+
+	@Test
+	void shouldInferTypeFromListOfMessages() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(3);
+		ackCallbackPayloadTypeCollector.registerLatch(BATCH_MESSAGE_WRAPPER_QUEUE, ackLatch);
+
+		List<TestEvent> events = List.of(new TestEvent("batch-msg-1", "payload-1"),
+				new TestEvent("batch-msg-2", "payload-2"), new TestEvent("batch-msg-3", "payload-3"));
+
+		sqsTemplate.sendMany(BATCH_MESSAGE_WRAPPER_QUEUE,
+				events.stream().map(e -> MessageBuilder.withPayload(e).build()).toList());
+		logger.debug("Sent {} events to queue {}", events.size(), BATCH_MESSAGE_WRAPPER_QUEUE);
+
+		assertThat(latchContainer.batchMessageWrapperLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedBatchMessageWrapperPojos).containsExactlyInAnyOrderElementsOf(events);
+		// Interceptor runs before the listener, so payloads are already recorded by now
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContainsAll(BATCH_MESSAGE_WRAPPER_QUEUE, events);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContainsAll(BATCH_MESSAGE_WRAPPER_QUEUE, events);
+	}
+
+	@Test
+	void shouldIgnoreTypeHeaderWhenInferenceActive() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(1);
+		ackCallbackPayloadTypeCollector.registerLatch(IGNORES_TYPE_HEADER_QUEUE, ackLatch);
+
+		TestEvent event = new TestEvent("header-test-id", "header-test-payload");
+		// Send with __TypeId__ header pointing to a WRONG class - inference should ignore it
+		sqsTemplate.send(to -> to.queue(IGNORES_TYPE_HEADER_QUEUE).payload(event)
+				.header(SqsHeaders.SQS_DEFAULT_TYPE_HEADER, "com.example.NonExistentClass"));
+		logger.debug("Sent event with wrong type header to queue {}: {}", IGNORES_TYPE_HEADER_QUEUE, event);
+
+		assertThat(latchContainer.ignoresTypeHeaderLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedIgnoresTypeHeaderPojos).hasSize(1);
+		assertThat(pojoCollector.receivedIgnoresTypeHeaderPojos.get(0)).isEqualTo(event);
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(IGNORES_TYPE_HEADER_QUEUE, event);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(IGNORES_TYPE_HEADER_QUEUE, event);
+	}
+
+	@Test
+	void shouldInferTypeWithExplicitPayloadAnnotation() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(1);
+		ackCallbackPayloadTypeCollector.registerLatch(EXPLICIT_PAYLOAD_ANNOTATION_QUEUE, ackLatch);
+
+		TestEvent event = new TestEvent("explicit-payload-id", "explicit-payload-data");
+		sqsTemplate.send(EXPLICIT_PAYLOAD_ANNOTATION_QUEUE, event);
+		logger.debug("Sent event to explicit payload annotation queue {}: {}", EXPLICIT_PAYLOAD_ANNOTATION_QUEUE,
+				event);
+
+		assertThat(latchContainer.explicitPayloadAnnotationLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedExplicitPayloadPojos).hasSize(1);
+		assertThat(pojoCollector.receivedExplicitPayloadPojos.get(0)).isEqualTo(event);
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(EXPLICIT_PAYLOAD_ANNOTATION_QUEUE, event);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(EXPLICIT_PAYLOAD_ANNOTATION_QUEUE, event);
+	}
+
+	@Test
+	void shouldHandleStringPayloadWithoutDeserialization() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(1);
+		ackCallbackPayloadTypeCollector.registerLatch(STRING_PAYLOAD_QUEUE, ackLatch);
+
+		String rawJson = "{\"id\":\"raw-json-id\",\"payload\":\"raw-json-payload\"}";
+		// Send raw string directly without type header
+		sqsTemplate.send(to -> to.queue(STRING_PAYLOAD_QUEUE).payload(rawJson));
+		logger.debug("Sent raw JSON string to queue {}: {}", STRING_PAYLOAD_QUEUE, rawJson);
+
+		assertThat(latchContainer.stringPayloadLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedStringPayloads).hasSize(1);
+		assertThat(pojoCollector.receivedStringPayloads.get(0)).isEqualTo(rawJson);
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(STRING_PAYLOAD_QUEUE, rawJson);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(STRING_PAYLOAD_QUEUE, rawJson);
+	}
+
+	@Test
+	void shouldUseCustomConverterWithTypeInference() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(1);
+		ackCallbackPayloadTypeCollector.registerLatch(CUSTOM_CONVERTER_QUEUE, ackLatch);
+
+		// Send snake_case JSON - only a custom ObjectMapper with SNAKE_CASE naming will parse this correctly
+		String snakeCaseJson = "{\"event_id\":\"custom-converter-id\",\"event_payload\":\"custom-converter-data\"}";
+		sqsTemplate.send(to -> to.queue(CUSTOM_CONVERTER_QUEUE).payload(snakeCaseJson));
+		logger.debug("Sent snake_case JSON to custom converter queue {}: {}", CUSTOM_CONVERTER_QUEUE, snakeCaseJson);
+
+		assertThat(latchContainer.customConverterLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedCustomConverterPojos).hasSize(1);
+		SnakeCaseEvent received = pojoCollector.receivedCustomConverterPojos.get(0);
+		SnakeCaseEvent expectedEvent = new SnakeCaseEvent("custom-converter-id", "custom-converter-data");
+		assertThat(received.getEventId()).isEqualTo("custom-converter-id");
+		assertThat(received.getEventPayload()).isEqualTo("custom-converter-data");
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(CUSTOM_CONVERTER_QUEUE, expectedEvent);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(CUSTOM_CONVERTER_QUEUE, expectedEvent);
+	}
+
+	@Test
+	void errorHandlerShouldReceiveDeserializedPojo() throws Exception {
+		// Register a latch for the error handler to signal when it processes the message
+		CountDownLatch errorHandlerLatch = new CountDownLatch(1);
+		errorHandlerPayloadTypeCollector.registerLatch(ERROR_HANDLER_TEST_QUEUE, errorHandlerLatch);
+
+		TestEvent event = new TestEvent("error-handler-test-id", "error-handler-test-payload");
+		sqsTemplate.send(ERROR_HANDLER_TEST_QUEUE, event);
+		logger.debug("Sent event to error handler test queue {}: {}", ERROR_HANDLER_TEST_QUEUE, event);
+
+		// Wait for the error handler to process the message
+		assertThat(errorHandlerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		// Verify the error handler received the deserialized payload with correct field values
+		errorHandlerPayloadTypeCollector.assertPayloadsForQueueContains(ERROR_HANDLER_TEST_QUEUE, event);
+	}
+
+	static class InfersSimplePojoListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = INFERS_SIMPLE_POJO_QUEUE, id = "infers-simple-pojo")
+		void listen(TestEvent event) {
+			logger.debug("Received TestEvent: {}", event);
+			pojoCollector.receivedSimplePojos.add(event);
+			latchContainer.infersSimplePojoLatch.countDown();
+		}
+
+	}
+
+	static class InfersPojoWithManyParametersListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = INFERS_POJO_WITH_MANY_PARAMETERS_QUEUE, factory = MANUAL_ACK_FACTORY, id = "infers-pojo-with-many-params")
+		void listen(TestEvent event, @Header(SqsHeaders.SQS_QUEUE_NAME_HEADER) String queueName, MessageHeaders headers,
+				Acknowledgement ack, Visibility visibility, QueueAttributes queueAttributes) {
+			logger.debug("Received TestEvent: {} from queue: {}", event, queueName);
+			assertThat(headers).isNotNull();
+			assertThat(ack).isNotNull();
+			assertThat(visibility).isNotNull();
+			assertThat(queueAttributes).isNotNull();
+			assertThat(queueName).isEqualTo(INFERS_POJO_WITH_MANY_PARAMETERS_QUEUE);
+
+			pojoCollector.receivedPojoWithManyParams.add(event);
+			ack.acknowledge();
+			latchContainer.infersPojoWithManyParametersLatch.countDown();
+		}
+
+	}
+
+	static class InfersBatchPojoListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = INFERS_BATCH_POJO_QUEUE, factory = MANUAL_ACK_FACTORY, id = "infers-batch-pojo")
+		void listen(List<TestEvent> events, BatchAcknowledgement<TestEvent> ack) {
+			logger.debug("Received {} TestEvents", events.size());
+			pojoCollector.receivedBatchPojos.addAll(events);
+			ack.acknowledge();
+			// Count down per event to handle multiple batch deliveries
+			events.forEach(e -> latchContainer.infersBatchPojoLatch.countDown());
+		}
+
+	}
+
+	static class InfersNestedGenericListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = INFERS_NESTED_GENERIC_POJO_QUEUE, id = "infers-nested-generic")
+		void listen(Message<NestedGenericEvent> message) {
+			logger.debug("Received NestedGenericEvent: {}", message.getPayload());
+			pojoCollector.receivedNestedGeneric.add(message.getPayload());
+			latchContainer.infersNestedGenericLatch.countDown();
+		}
+
+	}
+
+	static class AsyncListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = ASYNC_LISTENER_QUEUE, id = "async-listener")
+		CompletableFuture<Void> listen(TestEvent event) {
+			logger.debug("Received TestEvent in async listener: {}", event);
+			pojoCollector.receivedAsyncPojos.add(event);
+			latchContainer.asyncListenerLatch.countDown();
+			return CompletableFuture.completedFuture(null);
+		}
+
+	}
+
+	static class BatchMessageWrapperListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = BATCH_MESSAGE_WRAPPER_QUEUE, factory = MANUAL_ACK_FACTORY, id = "batch-message-wrapper")
+		void listen(List<Message<TestEvent>> messages, BatchAcknowledgement<TestEvent> ack) {
+			logger.debug("Received {} messages with Message wrapper", messages.size());
+			messages.forEach(msg -> {
+				pojoCollector.receivedBatchMessageWrapperPojos.add(msg.getPayload());
+				latchContainer.batchMessageWrapperLatch.countDown();
+			});
+			ack.acknowledge();
+		}
+
+	}
+
+	static class IgnoresTypeHeaderListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = IGNORES_TYPE_HEADER_QUEUE, id = "ignores-type-header")
+		void listen(TestEvent event) {
+			logger.debug("Received TestEvent (type header should have been ignored): {}", event);
+			pojoCollector.receivedIgnoresTypeHeaderPojos.add(event);
+			latchContainer.ignoresTypeHeaderLatch.countDown();
+		}
+
+	}
+
+	static class ExplicitPayloadAnnotationListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = EXPLICIT_PAYLOAD_ANNOTATION_QUEUE, id = "explicit-payload-annotation")
+		void listen(@Header(SqsHeaders.SQS_QUEUE_NAME_HEADER) String queueName, @Payload TestEvent event) {
+			logger.debug("Received TestEvent with explicit @Payload from queue {}: {}", queueName, event);
+			assertThat(queueName).isEqualTo(EXPLICIT_PAYLOAD_ANNOTATION_QUEUE);
+			pojoCollector.receivedExplicitPayloadPojos.add(event);
+			latchContainer.explicitPayloadAnnotationLatch.countDown();
+		}
+
+	}
+
+	static class StringPayloadListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = STRING_PAYLOAD_QUEUE, id = "string-payload")
+		void listen(String rawPayload) {
+			logger.debug("Received raw string payload: {}", rawPayload);
+			pojoCollector.receivedStringPayloads.add(rawPayload);
+			latchContainer.stringPayloadLatch.countDown();
+		}
+
+	}
+
+	static class CustomConverterListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = CUSTOM_CONVERTER_QUEUE, factory = CUSTOM_CONVERTER_FACTORY, id = "custom-converter")
+		void listen(SnakeCaseEvent event) {
+			logger.debug("Received SnakeCaseEvent: {}", event);
+			pojoCollector.receivedCustomConverterPojos.add(event);
+			latchContainer.customConverterLatch.countDown();
+		}
+
+	}
+
+	static class ErrorHandlerTestListener {
+
+		@SqsListener(queueNames = ERROR_HANDLER_TEST_QUEUE, id = "error-handler-test")
+		void listen(TestEvent event) {
+			logger.debug("Received TestEvent in error handler test listener (will throw): {}", event);
+			throw new RuntimeException("Expected exception to trigger error handler");
+		}
+
+	}
+
+	static class PojoCollector {
+
+		final List<TestEvent> receivedSimplePojos = Collections.synchronizedList(new ArrayList<>());
+
+		final List<TestEvent> receivedPojoWithManyParams = Collections.synchronizedList(new ArrayList<>());
+
+		final List<TestEvent> receivedBatchPojos = Collections.synchronizedList(new ArrayList<>());
+
+		final List<NestedGenericEvent> receivedNestedGeneric = Collections.synchronizedList(new ArrayList<>());
+
+		final List<TestEvent> receivedAsyncPojos = Collections.synchronizedList(new ArrayList<>());
+
+		final List<TestEvent> receivedBatchMessageWrapperPojos = Collections.synchronizedList(new ArrayList<>());
+
+		final List<TestEvent> receivedIgnoresTypeHeaderPojos = Collections.synchronizedList(new ArrayList<>());
+
+		final List<TestEvent> receivedExplicitPayloadPojos = Collections.synchronizedList(new ArrayList<>());
+
+		final List<String> receivedStringPayloads = Collections.synchronizedList(new ArrayList<>());
+
+		final List<SnakeCaseEvent> receivedCustomConverterPojos = Collections.synchronizedList(new ArrayList<>());
+
+	}
+
+	/**
+	 * Collects payloads received by the interceptor, keyed by queue name. Used to verify that deserialization happens
+	 * at MessageSource level (early) rather than at argument resolver level (late).
+	 */
+	static class InterceptorPayloadTypeCollector {
+
+		final java.util.Map<String, List<Object>> payloadsByQueue = new java.util.concurrent.ConcurrentHashMap<>();
+
+		void recordPayload(String queueName, Object payload) {
+			payloadsByQueue.computeIfAbsent(queueName, k -> Collections.synchronizedList(new ArrayList<>()))
+					.add(payload);
+		}
+
+		void assertPayloadsForQueueContains(String queueName, Object expectedPayload) {
+			List<Object> payloads = payloadsByQueue.get(queueName);
+			assertThat(payloads).isNotNull().isNotEmpty().contains(expectedPayload);
+		}
+
+		void assertPayloadsForQueueContainsAll(String queueName, List<?> expectedPayloads) {
+			List<Object> payloads = payloadsByQueue.get(queueName);
+			assertThat(payloads).isNotNull().isNotEmpty().containsAll(expectedPayloads);
+		}
+
+	}
+
+	/**
+	 * Collects payloads received by the error handler, keyed by queue name. Used to verify that deserialization happens
+	 * at MessageSource level (early) rather than at argument resolver level (late).
+	 */
+	static class ErrorHandlerPayloadTypeCollector {
+
+		final java.util.Map<String, List<Object>> payloadsByQueue = new java.util.concurrent.ConcurrentHashMap<>();
+
+		final java.util.Map<String, CountDownLatch> latches = new java.util.concurrent.ConcurrentHashMap<>();
+
+		void registerLatch(String queueName, CountDownLatch latch) {
+			latches.put(queueName, latch);
+		}
+
+		void recordPayload(String queueName, Object payload) {
+			payloadsByQueue.computeIfAbsent(queueName, k -> Collections.synchronizedList(new ArrayList<>()))
+					.add(payload);
+			CountDownLatch latch = latches.get(queueName);
+			if (latch != null) {
+				latch.countDown();
+			}
+		}
+
+		void assertPayloadsForQueueContains(String queueName, Object expectedPayload) {
+			List<Object> payloads = payloadsByQueue.get(queueName);
+			assertThat(payloads).isNotNull().isNotEmpty().contains(expectedPayload);
+		}
+
+	}
+
+	/**
+	 * Collects payloads received by the acknowledgement callback, keyed by queue name. Used to verify that
+	 * deserialization happens at MessageSource level (early) rather than at argument resolver level (late).
+	 */
+	static class AckCallbackPayloadTypeCollector {
+
+		final java.util.Map<String, List<Object>> payloadsByQueue = new java.util.concurrent.ConcurrentHashMap<>();
+
+		final java.util.Map<String, CountDownLatch> latches = new java.util.concurrent.ConcurrentHashMap<>();
+
+		void registerLatch(String queueName, CountDownLatch latch) {
+			latches.put(queueName, latch);
+		}
+
+		void recordPayload(String queueName, Object payload) {
+			payloadsByQueue.computeIfAbsent(queueName, k -> Collections.synchronizedList(new ArrayList<>()))
+					.add(payload);
+			CountDownLatch latch = latches.get(queueName);
+			if (latch != null) {
+				latch.countDown();
+			}
+		}
+
+		void assertPayloadsForQueueContains(String queueName, Object expectedPayload) {
+			List<Object> payloads = payloadsByQueue.get(queueName);
+			assertThat(payloads).isNotNull().isNotEmpty().contains(expectedPayload);
+		}
+
+		void assertPayloadsForQueueContainsAll(String queueName, List<?> expectedPayloads) {
+			List<Object> payloads = payloadsByQueue.get(queueName);
+			assertThat(payloads).isNotNull().isNotEmpty().containsAll(expectedPayloads);
+		}
+
+	}
+
+	static class LatchContainer {
+
+		final CountDownLatch infersSimplePojoLatch = new CountDownLatch(1);
+
+		final CountDownLatch infersPojoWithManyParametersLatch = new CountDownLatch(1);
+
+		final CountDownLatch infersBatchPojoLatch = new CountDownLatch(3);
+
+		final CountDownLatch infersNestedGenericLatch = new CountDownLatch(1);
+
+		final CountDownLatch asyncListenerLatch = new CountDownLatch(1);
+
+		final CountDownLatch batchMessageWrapperLatch = new CountDownLatch(3);
+
+		final CountDownLatch ignoresTypeHeaderLatch = new CountDownLatch(1);
+
+		final CountDownLatch explicitPayloadAnnotationLatch = new CountDownLatch(1);
+
+		final CountDownLatch stringPayloadLatch = new CountDownLatch(1);
+
+		final CountDownLatch customConverterLatch = new CountDownLatch(1);
+
+	}
+
+	@Import(SqsBootstrapConfiguration.class)
+	@Configuration
+	static class SQSConfiguration {
+
+		@Bean
+		public SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFactory(
+				InterceptorPayloadTypeCollector interceptorPayloadTypeCollector,
+				ErrorHandlerPayloadTypeCollector errorHandlerPayloadTypeCollector,
+				AckCallbackPayloadTypeCollector ackCallbackPayloadTypeCollector) {
+			return SqsMessageListenerContainerFactory.builder()
+					.sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
+					.configure(options -> options.maxDelayBetweenPolls(Duration.ofSeconds(1))
+							.pollTimeout(Duration.ofSeconds(3)))
+					.messageInterceptor(createPayloadTypeRecordingInterceptor(interceptorPayloadTypeCollector))
+					.errorHandler(createErrorHandler(errorHandlerPayloadTypeCollector))
+					.acknowledgementResultCallback(createAckCallback(ackCallbackPayloadTypeCollector)).build();
+		}
+
+		@Bean(name = MANUAL_ACK_FACTORY)
+		public SqsMessageListenerContainerFactory<Object> manualAckFactory(
+				InterceptorPayloadTypeCollector interceptorPayloadTypeCollector,
+				ErrorHandlerPayloadTypeCollector errorHandlerPayloadTypeCollector,
+				AckCallbackPayloadTypeCollector ackCallbackPayloadTypeCollector) {
+			return SqsMessageListenerContainerFactory.builder()
+					.sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
+					.configure(options -> options.acknowledgementMode(AcknowledgementMode.MANUAL)
+							.maxDelayBetweenPolls(Duration.ofSeconds(1)).pollTimeout(Duration.ofSeconds(3))
+							.queueAttributeNames(Collections.singletonList(QueueAttributeName.QUEUE_ARN)))
+					.messageInterceptor(createPayloadTypeRecordingInterceptor(interceptorPayloadTypeCollector))
+					.errorHandler(createErrorHandler(errorHandlerPayloadTypeCollector))
+					.acknowledgementResultCallback(createAckCallback(ackCallbackPayloadTypeCollector)).build();
+		}
+
+		@Bean(name = CUSTOM_CONVERTER_FACTORY)
+		public SqsMessageListenerContainerFactory<Object> customConverterFactory(
+				InterceptorPayloadTypeCollector interceptorPayloadTypeCollector,
+				ErrorHandlerPayloadTypeCollector errorHandlerPayloadTypeCollector,
+				AckCallbackPayloadTypeCollector ackCallbackPayloadTypeCollector) {
+			// Create a custom ObjectMapper that uses SNAKE_CASE naming strategy
+			ObjectMapper snakeCaseMapper = new ObjectMapper();
+			snakeCaseMapper
+					.setPropertyNamingStrategy(com.fasterxml.jackson.databind.PropertyNamingStrategies.SNAKE_CASE);
+
+			// Create custom converter with the snake_case ObjectMapper
+			SqsMessagingMessageConverter customConverter = new SqsMessagingMessageConverter();
+			customConverter.setPayloadMessageConverter(new MappingJackson2MessageConverter() {
+				{
+					setObjectMapper(snakeCaseMapper);
+					setSerializedPayloadClass(String.class);
+					setStrictContentTypeMatch(false);
+				}
+			});
+
+			return SqsMessageListenerContainerFactory.builder()
+					.sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
+					.configure(options -> options.maxDelayBetweenPolls(Duration.ofSeconds(1))
+							.pollTimeout(Duration.ofSeconds(3)).messageConverter(customConverter))
+					.messageInterceptor(createPayloadTypeRecordingInterceptor(interceptorPayloadTypeCollector))
+					.errorHandler(createErrorHandler(errorHandlerPayloadTypeCollector))
+					.acknowledgementResultCallback(createAckCallback(ackCallbackPayloadTypeCollector)).build();
+		}
+
+		private AsyncMessageInterceptor<Object> createPayloadTypeRecordingInterceptor(
+				InterceptorPayloadTypeCollector collector) {
+			return new AsyncMessageInterceptor<>() {
+				@Override
+				public CompletableFuture<Message<Object>> intercept(Message<Object> message) {
+					String queueName = (String) message.getHeaders().get(SqsHeaders.SQS_QUEUE_NAME_HEADER);
+					logger.debug("Interceptor received message from queue {} with payload type: {}", queueName,
+							message.getPayload().getClass().getName());
+					collector.recordPayload(queueName, message.getPayload());
+					return CompletableFuture.completedFuture(message);
+				}
+
+				@Override
+				public CompletableFuture<Collection<Message<Object>>> intercept(Collection<Message<Object>> messages) {
+					messages.forEach(message -> {
+						String queueName = (String) message.getHeaders().get(SqsHeaders.SQS_QUEUE_NAME_HEADER);
+						logger.debug("Interceptor received batch message from queue {} with payload type: {}",
+								queueName, message.getPayload().getClass().getName());
+						collector.recordPayload(queueName, message.getPayload());
+					});
+					return CompletableFuture.completedFuture(messages);
+				}
+			};
+		}
+
+		private AsyncErrorHandler<Object> createErrorHandler(ErrorHandlerPayloadTypeCollector collector) {
+			return new AsyncErrorHandler<>() {
+				@Override
+				public CompletableFuture<Void> handle(Message<Object> message, Throwable t) {
+					String queueName = (String) message.getHeaders().get(SqsHeaders.SQS_QUEUE_NAME_HEADER);
+					logger.debug("Error handler received message from queue {} with payload type: {}", queueName,
+							message.getPayload().getClass().getName());
+					collector.recordPayload(queueName, message.getPayload());
+					return CompletableFuture.completedFuture(null);
+				}
+
+				@Override
+				public CompletableFuture<Void> handle(Collection<Message<Object>> messages, Throwable t) {
+					messages.forEach(message -> {
+						String queueName = (String) message.getHeaders().get(SqsHeaders.SQS_QUEUE_NAME_HEADER);
+						logger.debug("Error handler received batch message from queue {} with payload type: {}",
+								queueName, message.getPayload().getClass().getName());
+						collector.recordPayload(queueName, message.getPayload());
+					});
+					return CompletableFuture.completedFuture(null);
+				}
+			};
+		}
+
+		private AcknowledgementResultCallback<Object> createAckCallback(AckCallbackPayloadTypeCollector collector) {
+			return new AcknowledgementResultCallback<>() {
+				@Override
+				public void onSuccess(Collection<Message<Object>> messages) {
+					messages.forEach(message -> {
+						String queueName = (String) message.getHeaders().get(SqsHeaders.SQS_QUEUE_NAME_HEADER);
+						logger.debug("Ack callback received message from queue {} with payload type: {}", queueName,
+								message.getPayload().getClass().getName());
+						collector.recordPayload(queueName, message.getPayload());
+					});
+				}
+
+				@Override
+				public void onFailure(Collection<Message<Object>> messages, Throwable t) {
+					// No need to record failures
+				}
+			};
+		}
+
+		@Bean
+		InfersSimplePojoListener infersSimplePojoListener() {
+			return new InfersSimplePojoListener();
+		}
+
+		@Bean
+		InfersPojoWithManyParametersListener infersPojoWithManyParametersListener() {
+			return new InfersPojoWithManyParametersListener();
+		}
+
+		@Bean
+		InfersBatchPojoListener infersBatchPojoListener() {
+			return new InfersBatchPojoListener();
+		}
+
+		@Bean
+		InfersNestedGenericListener infersNestedGenericListener() {
+			return new InfersNestedGenericListener();
+		}
+
+		@Bean
+		AsyncListener asyncListener() {
+			return new AsyncListener();
+		}
+
+		@Bean
+		BatchMessageWrapperListener batchMessageWrapperListener() {
+			return new BatchMessageWrapperListener();
+		}
+
+		@Bean
+		IgnoresTypeHeaderListener ignoresTypeHeaderListener() {
+			return new IgnoresTypeHeaderListener();
+		}
+
+		@Bean
+		ExplicitPayloadAnnotationListener explicitPayloadAnnotationListener() {
+			return new ExplicitPayloadAnnotationListener();
+		}
+
+		@Bean
+		StringPayloadListener stringPayloadListener() {
+			return new StringPayloadListener();
+		}
+
+		@Bean
+		CustomConverterListener customConverterListener() {
+			return new CustomConverterListener();
+		}
+
+		@Bean
+		ErrorHandlerTestListener errorHandlerTestListener() {
+			return new ErrorHandlerTestListener();
+		}
+
+		@Bean
+		PojoCollector pojoCollector() {
+			return new PojoCollector();
+		}
+
+		@Bean
+		InterceptorPayloadTypeCollector interceptorPayloadTypeCollector() {
+			return new InterceptorPayloadTypeCollector();
+		}
+
+		@Bean
+		ErrorHandlerPayloadTypeCollector errorHandlerPayloadTypeCollector() {
+			return new ErrorHandlerPayloadTypeCollector();
+		}
+
+		@Bean
+		AckCallbackPayloadTypeCollector ackCallbackPayloadTypeCollector() {
+			return new AckCallbackPayloadTypeCollector();
+		}
+
+		@Bean
+		LatchContainer latchContainer() {
+			return new LatchContainer();
+		}
+
+		@Bean
+		ObjectMapper objectMapper() {
+			return new ObjectMapper();
+		}
+
+		@Bean
+		SqsTemplate sqsTemplate() {
+			return SqsTemplate.builder().sqsAsyncClient(BaseSqsIntegrationTest.createAsyncClient())
+					.configureDefaultConverter(AbstractMessagingMessageConverter::doNotSendPayloadTypeHeader).build();
+		}
+
+	}
+
+	static class TestEvent {
+
+		private String id;
+
+		private String payload;
+
+		public TestEvent() {
+		}
+
+		public TestEvent(String id, String payload) {
+			this.id = id;
+			this.payload = payload;
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public String getPayload() {
+			return payload;
+		}
+
+		public void setPayload(String payload) {
+			this.payload = payload;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (o == null || getClass() != o.getClass())
+				return false;
+			TestEvent testEvent = (TestEvent) o;
+			return Objects.equals(id, testEvent.id) && Objects.equals(payload, testEvent.payload);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(id, payload);
+		}
+
+		@Override
+		public String toString() {
+			return "TestEvent{" + "id='" + id + '\'' + ", payload='" + payload + '\'' + '}';
+		}
+
+	}
+
+	static class NestedGenericEvent {
+
+		private TestEvent nestedEvent;
+
+		private int count;
+
+		public NestedGenericEvent() {
+		}
+
+		public NestedGenericEvent(TestEvent nestedEvent, int count) {
+			this.nestedEvent = nestedEvent;
+			this.count = count;
+		}
+
+		public TestEvent getNestedEvent() {
+			return nestedEvent;
+		}
+
+		public void setNestedEvent(TestEvent nestedEvent) {
+			this.nestedEvent = nestedEvent;
+		}
+
+		public int getCount() {
+			return count;
+		}
+
+		public void setCount(int count) {
+			this.count = count;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (o == null || getClass() != o.getClass())
+				return false;
+			NestedGenericEvent that = (NestedGenericEvent) o;
+			return count == that.count && Objects.equals(nestedEvent, that.nestedEvent);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(nestedEvent, count);
+		}
+
+		@Override
+		public String toString() {
+			return "NestedGenericEvent{" + "nestedEvent=" + nestedEvent + ", count=" + count + '}';
+		}
+
+	}
+
+	static class SnakeCaseEvent {
+
+		private String eventId;
+
+		private String eventPayload;
+
+		public SnakeCaseEvent() {
+		}
+
+		public SnakeCaseEvent(String eventId, String eventPayload) {
+			this.eventId = eventId;
+			this.eventPayload = eventPayload;
+		}
+
+		public String getEventId() {
+			return eventId;
+		}
+
+		public void setEventId(String eventId) {
+			this.eventId = eventId;
+		}
+
+		public String getEventPayload() {
+			return eventPayload;
+		}
+
+		public void setEventPayload(String eventPayload) {
+			this.eventPayload = eventPayload;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (o == null || getClass() != o.getClass())
+				return false;
+			SnakeCaseEvent that = (SnakeCaseEvent) o;
+			return Objects.equals(eventId, that.eventId) && Objects.equals(eventPayload, that.eventPayload);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(eventId, eventPayload);
+		}
+
+		@Override
+		public String toString() {
+			return "SnakeCaseEvent{" + "eventId='" + eventId + '\'' + ", eventPayload='" + eventPayload + '\'' + '}';
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverterTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverterTests.java
@@ -135,6 +135,26 @@ class SqsMessagingMessageConverterTests {
 				MessageAttributeValue.builder().stringValue("application/json").dataType("String").build());
 	}
 
+	@Test
+	void shouldReturnTrueForDefaultPayloadTypeMapper() {
+		SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+		assertThat(converter.isUsingDefaultPayloadTypeMapper()).isTrue();
+	}
+
+	@Test
+	void shouldReturnFalseAfterSettingCustomPayloadTypeMapper() {
+		SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+		converter.setPayloadTypeMapper(msg -> MyPojo.class);
+		assertThat(converter.isUsingDefaultPayloadTypeMapper()).isFalse();
+	}
+
+	@Test
+	void shouldReturnFalseAfterSettingPayloadTypeHeader() {
+		SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+		converter.setPayloadTypeHeader("myTypeHeader");
+		assertThat(converter.isUsingDefaultPayloadTypeMapper()).isFalse();
+	}
+
 	static class MyPojo {
 
 		private String myProperty = "myValue";


### PR DESCRIPTION
Resolve payload types during container initialization by analyzing `@SqsListener` method signatures, removing the need for type headers by default.

With this change, the resolved payload type is available earlier in the flow, and components such as `MessageInterceptors`, `ErrorHandlers`, and `AcknowledgementResultCallback` receive the deserialized payload even when no type header is present.

This removes coupling to producer-specific type names (which often differ across services) and reduces the risk of trusting type headers.

Supported patterns:
	•	Simple types: `MyEvent`
	•	Generic types: `List<MyEvent>`, `Message<MyEvent>`, `List<Message<MyEvent>>`
	•	Explicit `@Payload` annotations

The `SqsTemplate` `JavaType` header is deprecated and ignored by default, with documented options to restore the previous behavior.

Polymorphic payloads (interfaces, Object, @SqsHandler) require configuring a custom `payloadTypeMapper` in `SqsMessagingMessageConverter` for type resolution.

Fixes this recent issue about the converter set in the factory being ignored: #1546

Also addresses long-standing requests to avoid relying on the JavaType header, ensuring downstream components consistently receive a deserialized payload:
	•	https://github.com/awspring/spring-cloud-aws/issues/1165
	•	https://github.com/awspring/spring-cloud-aws/issues/1000
	•	https://github.com/awspring/spring-cloud-aws/issues/999
	•	https://github.com/awspring/spring-cloud-aws/discussions/1036

Release / backport notes:
	•	4.0.0-RC1: opt-out
	•	3.4.3: opt-in (will cherry-pick to the 3.4.x branch)