### PR TITLE
Fix JsonMapper wiring in autoconfiguration for SqsMessagingMessageConverter

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -330,6 +330,8 @@ Message conversion by default is handled by a `SqsMessagingMessageConverter` ins
 NOTE: `SqsMessagingMessageConverter` is using Jackson 3 under the hood. If you are interested in using Jackson 2 you should be configuring `LegacyJackson2SqsMessagingMessageConverter`.
 When `LegacyJackson2SqsMessagingMessageConverter` is used you have to configure `MappingJackson2MessageConverter`.
 
+NOTE: When using Spring Boot's auto-configuration, providing a `JsonMapper` bean will automatically configure it for message conversion.
+
 A custom `MessagingMessageConverter` implementation can be provided in the `SqsTemplate.builder()`:
 
 ```java
@@ -354,7 +356,22 @@ SqsOperations template = SqsTemplate
     .buildSyncTemplate();
 ```
 
-The Jackson 2 specific  `LegacyJackson2SqsMessagingMessageConverter` instance can also be configured in the builder:
+To use a custom `JsonMapper` with `SqsTemplate`, create a `SqsMessagingMessageConverter` with the desired `JsonMapper` and provide it via `messageConverter()`:
+
+```java
+JsonMapper customMapper = JsonMapper.builder()
+    .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    .build();
+SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter(customMapper);
+
+SqsOperations template = SqsTemplate
+    .builder()
+    .sqsAsyncClient(sqsAsyncClient)
+    .messageConverter(converter)
+    .buildSyncTemplate();
+```
+
+The Jackson 2 specific `LegacyJackson2SqsMessagingMessageConverter` instance can also be configured in the builder:
 
 ```java
 SqsOperations template = SqsTemplate
@@ -1722,7 +1739,13 @@ An example of such configuration follows:
 
 [source, java]
 ----
-// Create converter instance
+// Create converter instance with custom JsonMapper
+JsonMapper customMapper = JsonMapper.builder()
+    .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    .build();
+SqsMessagingMessageConverter messageConverter = new SqsMessagingMessageConverter(customMapper);
+
+// Or create with defaults
 SqsMessagingMessageConverter messageConverter = new SqsMessagingMessageConverter();
 
 // Configure Type Header
@@ -1739,8 +1762,8 @@ headerMapper.setAdditionalHeadersFunction(((sqsMessage, accessor) -> {
 }));
 messageConverter.setHeaderMapper(headerMapper);
 
-// Configure Payload Converter
-JacksonJsonMessageConverter payloadConverter = new JacksonJsonMessageConverter();
+// Alternatively, configure a custom Payload Converter directly
+JacksonJsonMessageConverter payloadConverter = new JacksonJsonMessageConverter(customMapper);
 payloadConverter.setPrettyPrint(true);
 messageConverter.setPayloadMessageConverter(payloadConverter);
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -159,8 +159,10 @@ public class SqsAutoConfiguration {
 	static class SqsJacksonConfiguration {
 		@ConditionalOnMissingBean
 		@Bean
-		public MessagingMessageConverter<Message> messageConverter() {
-			return new SqsMessagingMessageConverter();
+		public MessagingMessageConverter<Message> messageConverter(ObjectProvider<JsonMapper> jsonMapperProvider) {
+			JsonMapper jsonMapper = jsonMapperProvider.getIfAvailable();
+			return jsonMapper != null ? new SqsMessagingMessageConverter(jsonMapper)
+					: new SqsMessagingMessageConverter();
 		}
 
 		@Bean

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverter.java
@@ -15,18 +15,22 @@
  */
 package io.awspring.cloud.sqs.support.converter;
 
-import static io.awspring.cloud.sqs.config.MessageConverterFactory.createDefaultMappingJacksonMessageConverter;
+import static io.awspring.cloud.sqs.config.MessageConverterFactory.createJacksonJsonMessageConverter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import org.springframework.messaging.converter.CompositeMessageConverter;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.converter.StringMessageConverter;
 import org.springframework.util.Assert;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * {@link MessagingMessageConverter} implementation for converting SQS
- * {@link software.amazon.awssdk.services.sqs.model.Message} instances to Spring Messaging {@link Message} instances.
+ * {@link software.amazon.awssdk.services.sqs.model.Message} instances to Spring Messaging
+ * {@link org.springframework.messaging.Message} instances.
  *
  * @author Tomaz Fernandes
  * @author Dongha kim
@@ -38,15 +42,23 @@ import org.springframework.util.Assert;
 public class SqsMessagingMessageConverter
 		extends AbstractMessagingMessageConverter<software.amazon.awssdk.services.sqs.model.Message> {
 
+	public SqsMessagingMessageConverter(JsonMapper jsonMapper) {
+		super(createDefaultCompositeMessageConverter(Objects.requireNonNull(jsonMapper, "jsonMapper cannot be null")));
+	}
+
 	public SqsMessagingMessageConverter() {
 		super(createDefaultCompositeMessageConverter());
 	}
 
 	private static CompositeMessageConverter createDefaultCompositeMessageConverter() {
+		return createDefaultCompositeMessageConverter(null);
+	}
+
+	private static CompositeMessageConverter createDefaultCompositeMessageConverter(@Nullable JsonMapper jsonMapper) {
 		List<MessageConverter> messageConverters = new ArrayList<>();
 		messageConverters.add(createClassMatchingMessageConverter());
 		messageConverters.add(createStringMessageConverter());
-		messageConverters.add(createDefaultMappingJacksonMessageConverter());
+		messageConverters.add(createJacksonJsonMessageConverter(jsonMapper));
 		return new CompositeMessageConverter(messageConverters);
 	}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverterTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverterTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.support.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+
+import java.util.Objects;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.converter.CompositeMessageConverter;
+import org.springframework.messaging.converter.JacksonJsonMessageConverter;
+import software.amazon.awssdk.services.sqs.model.Message;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Tests for {@link SqsMessagingMessageConverter}.
+ *
+ * @author Tomaz Fernandes
+ */
+class SqsMessagingMessageConverterTests {
+
+	@Test
+	void shouldCreateConverterWithDefaultJsonMapper() {
+		SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+
+		assertThat(converter).extracting("payloadMessageConverter").asInstanceOf(type(CompositeMessageConverter.class))
+				.extracting(CompositeMessageConverter::getConverters).asList()
+				.filteredOn(c -> c instanceof JacksonJsonMessageConverter).hasSize(1).first().extracting("mapper")
+				.isNotNull();
+	}
+
+	@Test
+	void shouldCreateConverterWithProvidedJsonMapper() {
+		JsonMapper customMapper = JsonMapper.builder().build();
+
+		SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter(customMapper);
+
+		assertThat(converter).extracting("payloadMessageConverter").asInstanceOf(type(CompositeMessageConverter.class))
+				.extracting(CompositeMessageConverter::getConverters).asList()
+				.filteredOn(c -> c instanceof JacksonJsonMessageConverter).hasSize(1).first().extracting("mapper")
+				.isSameAs(customMapper);
+	}
+
+	@Test
+	void shouldThrowWhenJsonMapperIsNull() {
+		assertThatThrownBy(() -> new SqsMessagingMessageConverter(null)).isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("jsonMapper cannot be null");
+	}
+
+	@Test
+	void shouldConvertMessageWithCustomJsonMapper() throws Exception {
+		JsonMapper customMapper = JsonMapper.builder().build();
+		MyPojo myPojo = new MyPojo();
+		String payload = customMapper.writeValueAsString(myPojo);
+		Message message = Message.builder().body(payload).messageId(UUID.randomUUID().toString()).build();
+
+		SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter(customMapper);
+		converter.setPayloadTypeMapper(msg -> MyPojo.class);
+
+		org.springframework.messaging.Message<?> resultMessage = converter.toMessagingMessage(message);
+
+		assertThat(resultMessage.getPayload()).isEqualTo(myPojo);
+	}
+
+	static class MyPojo {
+
+		private String myProperty = "myValue";
+
+		public String getMyProperty() {
+			return this.myProperty;
+		}
+
+		public void setMyProperty(String myProperty) {
+			this.myProperty = myProperty;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (o == null || getClass() != o.getClass())
+				return false;
+			MyPojo myPojo = (MyPojo) o;
+			return Objects.equals(myProperty, myPojo.myProperty);
+		}
+
+		@Override
+		public int hashCode() {
+			return myProperty != null ? myProperty.hashCode() : 0;
+		}
+	}
+
+}


### PR DESCRIPTION
JsonMapper provided as a bean wasn't properly being wired to `SqsMessagingMessageConverter` in SQS auto configuration.

- Add JsonMapper as a constructor parameter
- Wire user-provided JsonMapper to the autoconfigured SqsMessagingMessageConverter
- Add tests

Fixes #1553
