### PR TITLE
Add cost warning and filtering example to CloudWatch documentation

### DIFF
--- a/docs/src/main/asciidoc/cloudwatch.adoc
+++ b/docs/src/main/asciidoc/cloudwatch.adoc
@@ -41,6 +41,31 @@ Following configuration properties are available to configure CloudWatch integra
 |The specific region for CloudWatch integration.
 |===
 
+[WARNING]
+====
+Enabling CloudWatch metrics integration can lead to unexpected costs. By default, Spring Boot captures a large number of metrics (e.g., JVM, CPU, memory, disk usage), and each unique metric (name + dimensions) published to CloudWatch is billed as a custom metric.
+
+AWS CloudWatch Free Tier includes only a limited number of metrics. Please review the https://aws.amazon.com/cloudwatch/pricing/[CloudWatch pricing page] for more details.
+
+To limit costs, it is highly recommended to use a `MeterFilter` to publish only the metrics that are relevant to your application.
+====
+
+=== Filtering Metrics
+
+To filter which metrics are sent to CloudWatch, you can define a `MeterFilter` bean. For example, to only allow a specific set of metrics:
+
+[source,java]
+----
+@Bean
+public MeterFilter cloudWatchMeterFilter() {
+    Set<String> allowed = Set.of(
+        "jvm.memory.used",
+        "jvm.memory.committed"
+    );
+    return MeterFilter.denyUnless(id -> allowed.contains(id.getName()));
+}
+----
+
 === Client Customization
 
 `CloudWatchAsyncClient` can be further customized by providing a bean of type `CloudWatchAsyncClientCustomizer`:


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This PR enhances the CloudWatch metrics documentation by adding guidance about potential cost implications and metric filtering.

Specifically, it adds:
- A warning that enabling CloudWatch metrics can lead to unexpected costs
- An explanation that CloudWatch charges per metric name + dimensions
- A recommendation to use Micrometer MeterFilter to limit exported metrics
- A concrete example showing how to allow only a selected set of metrics
- This change is documentation-only and does not alter any existing behavior.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When CloudWatch metrics integration is enabled, Spring Boot Actuator and Micrometer publish a large number of default metrics.
Without explicit filtering, this may result in unintended CloudWatch costs.

Currently, the documentation does not clearly explain:
- The cost model of CloudWatch custom metrics
- How to control which metrics are exported

This PR addresses that gap by making the cost implications explicit and documenting a recommended way to restrict exported metrics.

While this PR does not change the default behavior, it helps clarify and mitigate the concerns raised in #873 by documenting the cost implications and recommended configuration.

The example code included in this documentation is based on the snippet originally shared by the issue author

## :green_heart: How did you test it?
- Verified locally that a MeterFilter.denyUnless configuration allows only the specified metric names to pass through
- Confirmed that non-whitelisted metrics are filtered out at the Micrometer level
- No changes to runtime behavior were introduced

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
