### PR TITLE
feat(s3): add ParameterizedTypeReference support to S3Template

### DIFF
--- a/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/Jackson2JsonS3ObjectConverter.java
+++ b/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/Jackson2JsonS3ObjectConverter.java
@@ -17,6 +17,7 @@ package io.awspring.cloud.s3;
 
 import java.io.InputStream;
 import org.springframework.util.Assert;
+import org.springframework.core.ParametrizedTypeReference;
 import software.amazon.awssdk.core.sync.RequestBody;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
@@ -59,18 +60,12 @@ public class Jackson2JsonS3ObjectConverter implements S3ObjectConverter {
 		}
 	}
 
-	/**
-	 * Reads S3 object from the input stream into a Java object.
-	 * @param is - the input stream
-	 * @param valueTypeRef - the type reference
-	 * @param <T> - the the type of the object
-	 * @return deserialized object
-	 */
-	public <T> T read(InputStream is, TypeReference<T> valueTypeRef) {
+	@Override
+	public <T> T read(InputStream is, ParametrizedTypeReference<T> valueTypeRef) {
 		Assert.notNull(is, "InputStream is required");
-		Assert.notNull(valueTypeRef, "ValueTypeRef is required");
+		Assert.notNull(valueTypeRef, "valueTypeRef is required");
 		try {
-			return jsonMapper.readValue(is, valueTypeRef);
+			return jsonMapper.readValue(is, jsonMapper.constructType(valueTypeRef.getType()));
 		}
 		catch (IOException e) {
 			throw new S3Exception("Failed to deserialize object from JSON", e);

--- a/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/Jackson2JsonS3ObjectConverter.java
+++ b/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/Jackson2JsonS3ObjectConverter.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import org.springframework.util.Assert;
 import software.amazon.awssdk.core.sync.RequestBody;
 import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.json.JsonMapper;
 
 /**
@@ -57,6 +58,25 @@ public class Jackson2JsonS3ObjectConverter implements S3ObjectConverter {
 			throw new S3Exception("Failed to deserialize object from JSON", e);
 		}
 	}
+
+	/**
+	 * Reads S3 object from the input stream into a Java object.
+	 * @param is - the input stream
+	 * @param valueTypeRef - the type reference
+	 * @param <T> - the the type of the object
+	 * @return deserialized object
+	 */
+	public <T> T read(InputStream is, TypeReference<T> valueTypeRef) {
+		Assert.notNull(is, "InputStream is required");
+		Assert.notNull(valueTypeRef, "ValueTypeRef is required");
+		try {
+			return jsonMapper.readValue(is, valueTypeRef);
+		}
+		catch (IOException e) {
+			throw new S3Exception("Failed to deserialize object from JSON", e);
+		}
+	}
+
 
 	@Override
 	public String contentType() {

--- a/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/Jackson2JsonS3ObjectConverter.java
+++ b/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/Jackson2JsonS3ObjectConverter.java
@@ -20,7 +20,6 @@ import org.springframework.util.Assert;
 import org.springframework.core.ParametrizedTypeReference;
 import software.amazon.awssdk.core.sync.RequestBody;
 import tools.jackson.core.JacksonException;
-import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.json.JsonMapper;
 
 /**

--- a/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/LegacyJackson2JsonS3ObjectConverter.java
+++ b/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/LegacyJackson2JsonS3ObjectConverter.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.s3;
 
 import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core..type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
@@ -54,6 +55,24 @@ public class LegacyJackson2JsonS3ObjectConverter implements S3ObjectConverter {
 		Assert.notNull(clazz, "Clazz is required");
 		try {
 			return objectMapper.readValue(is, clazz);
+		}
+		catch (IOException e) {
+			throw new S3Exception("Failed to deserialize object from JSON", e);
+		}
+	}
+
+	/**
+	 * Reads S3 object from the input stream into a Java object.
+	 * @param is - the input stream
+	 * @param valueTypeRef - the type reference
+	 * @param <T> - the the type of the object
+	 * @return deserialized object
+	 */
+	public <T> T read(InputStream is, TypeReference<T> valueTypeRef) {
+		Assert.notNull(is, "InputStream is required");
+		Assert.notNull(valueTypeRef, "ValueTypeRef is required");
+		try {
+			return objectMapper.readValue(is, valueTypeRef);
 		}
 		catch (IOException e) {
 			throw new S3Exception("Failed to deserialize object from JSON", e);

--- a/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/LegacyJackson2JsonS3ObjectConverter.java
+++ b/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/LegacyJackson2JsonS3ObjectConverter.java
@@ -16,11 +16,11 @@
 package io.awspring.cloud.s3;
 
 import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core..type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import org.springframework.util.Assert;
+import org.springframework.core.ParameterizedTypeReference;
 import software.amazon.awssdk.core.sync.RequestBody;
 
 /**
@@ -61,18 +61,12 @@ public class LegacyJackson2JsonS3ObjectConverter implements S3ObjectConverter {
 		}
 	}
 
-	/**
-	 * Reads S3 object from the input stream into a Java object.
-	 * @param is - the input stream
-	 * @param valueTypeRef - the type reference
-	 * @param <T> - the the type of the object
-	 * @return deserialized object
-	 */
-	public <T> T read(InputStream is, TypeReference<T> valueTypeRef) {
+	@Override
+	public <T> T read(InputStream is, ParametrizedTypeReference<T> valueTypeRef) {
 		Assert.notNull(is, "InputStream is required");
-		Assert.notNull(valueTypeRef, "ValueTypeRef is required");
+		Assert.notNull(valueTypeRef, "valueTypeRef is required");
 		try {
-			return objectMapper.readValue(is, valueTypeRef);
+			return objectMapper.readValue(is, objectMapper.constructType(valueTypeRef.getType()));
 		}
 		catch (IOException e) {
 			throw new S3Exception("Failed to deserialize object from JSON", e);

--- a/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3ObjectConverter.java
+++ b/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3ObjectConverter.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.s3;
 
 import java.io.InputStream;
+import org.springframework.core.ParameterizedTypeReference;
 import software.amazon.awssdk.core.sync.RequestBody;
 
 /**
@@ -43,6 +44,15 @@ public interface S3ObjectConverter {
 	 */
 	<T> T read(InputStream is, Class<T> clazz);
 
+	/**
+	 * Reads S3 object from the input stream into a Java object.
+	 * @param is - the input stream
+	 * @param valueTypeRef - the type reference of the object
+	 * @param <T> - the the type of the object
+	 * @return deserialized object
+	 */
+	<T> T read(InputStream is, ParameterizedTypeReference<T> valueTypeRef);
+	
 	/**
 	 * Supported content type.
 	 *

--- a/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Operations.java
+++ b/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Operations.java
@@ -133,6 +133,17 @@ public interface S3Operations {
 	<T> T read(String bucketName, String key, Class<T> clazz);
 
 	/**
+	 * Reads a Java object from a S3 bucket. Uses {@link S3ObjectConverter} for deserialization.
+	 *
+	 * @param bucketName - the bucket name
+	 * @param key - the object key
+	 * @param valueTypeRef - the parameterized type reference of the read object
+	 * @param <T> - the type of the read object
+	 * @return an object
+	 */
+	<T> T read(String bucketName, String key, ParameterizedTypeReference<T> valueTypeRef);
+
+	/**
 	 * Uploads data from an input stream to a S3 bucket.
 	 *
 	 * @param bucketName - the bucket name

--- a/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Operations.java
+++ b/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Operations.java
@@ -20,6 +20,7 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
+import org.springframework.core.ParameterizedTypeReference;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
 

--- a/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Template.java
+++ b/spring-cloud-aws-s3/src/main/java/io/awspring/cloud/s3/S3Template.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -158,6 +159,21 @@ public class S3Template implements S3Operations {
 
 		try (InputStream is = s3Client.getObject(r -> r.bucket(bucketName).key(key))) {
 			return s3ObjectConverter.read(is, clazz);
+		}
+		catch (Exception e) {
+			throw new S3Exception(
+					String.format("Failed to read object with a key '%s' from bucket '%s'", key, bucketName), e);
+		}
+	}
+
+	@Override
+	public <T> T read(String bucketName, String key, ParameterizedTypeReference<T> valueTypeRef) {
+		Assert.notNull(bucketName, "bucketName is required");
+		Assert.notNull(key, "key is required");
+		Assert.notNull(valueTypeRef, "valueTypeRef is required");
+
+		try (InputStream is = s3Client.getObject(r -> r.bucket(bucketName).key(key))) {
+			return s3ObjectConverter.read(is, valueTypeRef);
 		}
 		catch (Exception e) {
 			throw new S3Exception(

--- a/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
+++ b/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.util.StreamUtils;
+import org.springframework.core.ParameterizedTypeReference;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.HttpStatusCode;

--- a/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
+++ b/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/S3TemplateIntegrationTests.java
@@ -233,6 +233,20 @@ class S3TemplateIntegrationTests implements LocalstackContainerTest {
 	}
 
 	@Test
+	void readsParameterizedTypeObject() {
+		client.putObject(r -> r.bucket(BUCKET_NAME).key("persons.json"),
+				RequestBody.fromString("[{\"firstName\":\"John\",\"lastName\":\"Doe\"}]"));
+
+		List<Person> persons = s3Template.read(BUCKET_NAME, "persons.json", new ParamaterizedTypeReference<List<Person>>(){});
+
+		assertThat(persons.size()).isEqualTo(1);
+
+		Person person = persons.get(0);
+		assertThat(person.firstName).isEqualTo("John");
+		assertThat(person.lastName).isEqualTo("Doe");
+	}
+
+	@Test
 	void uploadsFile() throws IOException {
 		try (InputStream is = new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8))) {
 			S3Resource uploadedResource = s3Template.upload(BUCKET_NAME, "file.txt", is,


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Overloads the `S3Template` `read` method with one that accepts a `ParameterizedTypeReference`


## :bulb: Motivation and Context
These changes allow developers to use s3Template.read() with typed classes such as collections 


## :green_heart: How did you test it?
Added `readsParameterizedTypeObject()` test to `S3TemplateIntegrationTests`

## :pencil: Checklist
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes