### PR TITLE
Fix format of sqs.adoc

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -2093,7 +2093,6 @@ By default, `StringMessageConverter`, `SimpleMessageConverter` and `JacksonJsonM
 Set to `null` to disable automatic inference and rely on header-based type mapping.
 See <<Automatic Payload Type Inference>> for more information.
 
-----
 
 NOTE: Any number of `SqsListenerConfigurer` beans can be registered in the context.
 All instances will be looked up at application startup and iterated through.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fix format of https://docs.awspring.io/spring-cloud-aws/docs/4.0.0/reference/html/index.html#global-configuration-for-sqslisteners

## :bulb: Motivation and Context
Documentation can be used properly again.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
