### PR TITLE
Fail docs build on AsciiDoc warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,19 @@ jobs:
           cache: maven
       - name: Build with Maven
         run: ./mvnw -V -B verify -Pspring
+  docs:
+    name: Validate Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17.0.12
+          cache: maven
+      - name: Validate AsciiDoc
+        run: ./mvnw -V -B verify -Pdocs-classic -DskipTests
   sonar:
     name: Run Sonar Analysis
     runs-on: ubuntu-latest

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -14,6 +14,7 @@
 	<properties>
 		<docs.main>spring-cloud-aws</docs.main>
 		<main.basedir>${basedir}/..</main.basedir>
+		<generate-docs.phase>prepare-package</generate-docs.phase>
 		<configprops.path>${project.basedir}/src/main/asciidoc/_configprops.adoc</configprops.path>
 		<configprops.inclusionPattern>spring.cloud.aws.*</configprops.inclusionPattern>
 		<upload-docs-zip.phase>deploy</upload-docs-zip.phase>
@@ -257,7 +258,7 @@
 										<logHandler>
 											<outputToConsole>true</outputToConsole>
 											<failIf>
-												<!--												<severity>DEBUG</severity>-->
+												<severity>WARN</severity>
 											</failIf>
 										</logHandler>
 									</configuration>

--- a/docs/src/main/asciidoc/kinesis-stream-binder.adoc
+++ b/docs/src/main/asciidoc/kinesis-stream-binder.adoc
@@ -484,7 +484,7 @@ If [Server-Side Encryption](https://docs.aws.amazon.com/streams/latest/dev/what-
 }
 ----
 
-[[dynamodb-streams-support]]
+[[kinesis-binder-dynamodb-streams-support]]
 === DynamoDB Streams Support
 
 The Kinesis Binder provides support for consuming CDC events from the https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html[DynamoDB Streams].

--- a/docs/src/main/asciidoc/s3.adoc
+++ b/docs/src/main/asciidoc/s3.adoc
@@ -145,9 +145,12 @@ To autoconfigure Encryption Client simply add the following dependency.
 
 We are supporting 3 types of encryption.
 
-1. To configure encryption via KMS key specify `spring.cloud.aws.s3.encryption.key-id` with KMS key arn and this key will be used to encrypt your files.
+==== KMS Key Encryption
+
+To configure encryption via KMS key specify `spring.cloud.aws.s3.encryption.key-id` with KMS key arn and this key will be used to encrypt your files.
 
 Also, following dependency is required.
+
 [source,xml]
 ----
 <dependency>
@@ -157,8 +160,9 @@ Also, following dependency is required.
  </dependency>
 ----
 
+==== RSA Asymmetric Encryption
 
-2. Asymmetric encryption is possible via RSA to enable it you will have to implement `io.awspring.cloud.autoconfigure.s3.S3RsaProvider`
+Asymmetric encryption is possible via RSA. To enable it you will have to implement `io.awspring.cloud.autoconfigure.s3.S3RsaProvider`.
 
 NOTE: You will have to store private and public keys yourself otherwise you won't be able to decrypt the data later.
 
@@ -184,7 +188,9 @@ public class MyRsaProvider implements S3RsaProvider {
 }
 ----
 
-3. Last option is if you want to use symmetric algorithm, this is possible via `io.awspring.cloud.autoconfigure.s3.S3AesProvider`
+==== AES Symmetric Encryption
+
+If you want to use symmetric algorithm, this is possible via `io.awspring.cloud.autoconfigure.s3.S3AesProvider`.
 
 NOTE: Ensure the private key is stored using secure storage mechanisms that prevent unauthorized access.
 


### PR DESCRIPTION
## What
- Configure asciidoctor-maven-plugin to treat warnings as errors (for example, unterminated blocks)
- Fix duplicate section ID warning in kinesis-stream-binder.adoc
- Convert "encryption types" in s3.adoc from a numbered list to subsections to avoid list-continuity warnings

## Why
- This prevents formatting regressions from being merged by failing the docs build on warnings.

Fixes #1571

Note: the first build is expected to fail until #1570 is merged.