### PR TITLE
Add virtual thread support for SQS message listener containers

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -13,6 +13,8 @@ Spring Cloud AWS has dedicated support to transfer Java objects with Amazon SQS 
 
 NOTE: Since 4.1.0 Spring Cloud AWS SQS also supports SQS-compatible brokers such as Yandex Message Queue. See <<sqs-compatible-brokers-support>>.
 
+NOTE: Since 4.1.0, the framework supports <<virtual-threads, virtual threads>> (JDK 21+) for message listener containers.
+
 A Spring Boot starter is provided to auto-configure SQS integration beans.
 Maven coordinates, using <<index.adoc#bill-of-materials, Spring Cloud AWS BOM>>:
 
@@ -2333,6 +2335,8 @@ NOTE: In order to achieve higher throughput, it's encouraged that, at least for 
 
 ==== Threading and Blocking Components
 
+NOTE: See <<virtual-threads>> for virtual thread support.
+
 Message processing always starts in a framework thread from the default or provided `TaskExecutor`.
 
 If an async component is invoked and the execution returns to the framework on a different thread, such thread will be used until a `blocking` component is found, when the execution switches back to a `TaskExecutor` thread to avoid blocking i.e. `SqsAsyncClient` or `HttpClient` threads.
@@ -2349,8 +2353,34 @@ The default `TaskExecutor` is a `ThreadPoolTaskExecutor`, and a different `compo
 
 When providing a custom executor, it's important that it's configured to support all threads that will be created, which should be (maxConcurrentMessages * total number of queues).
 
-IMPORTANT: To avoid unnecessary thread hopping between blocking components, a `MessageExecutionThreadFactory` MUST be set to the executor.
+Since 4.1.0, the framework supports <<virtual-threads, virtual threads>>. If platform threads are used, a `MessageExecutionThreadFactory` MUST be set to the executor to avoid unnecessary thread hopping between blocking components.
 
+[[virtual-threads]]
+==== Virtual Threads Support
+
+Since 4.1.0, the framework supports virtual threads (JDK 21+). To use virtual threads, provide a virtual thread executor as the `componentsTaskExecutor`:
+
+[source,java]
+----
+@Bean
+SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFactory(SqsAsyncClient sqsAsyncClient) {
+    SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor();
+    executor.setVirtualThreads(true);
+    SqsMessageListenerContainerFactory<Object> factory = new SqsMessageListenerContainerFactory<>();
+    factory.configure(options -> options
+        .componentsTaskExecutor(executor)
+        .maxConcurrentMessages(5000));
+    factory.setSqsAsyncClient(sqsAsyncClient);
+    return factory;
+}
+----
+
+When virtual threads are detected, the framework automatically:
+
+* Skips the `MessageExecutionThreadFactory` requirement
+* Detects when a `CompletableFuture` completes on a platform thread and hops back to a virtual thread before continuing execution
+
+Virtual threads allow higher `maxConcurrentMessages` values compared to platform threads, since each virtual thread has minimal memory overhead. This is particularly beneficial for I/O-bound workloads where listeners spend time waiting on databases, HTTP calls, or other services.
 
 === Client Customization
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/VirtualThreadUtils.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/VirtualThreadUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs;
+
+import java.lang.reflect.Method;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Utility class for virtual thread detection. Uses reflection to access {@code Thread.isVirtual()} (JDK 21+) while
+ * maintaining compatibility with JDK 17.
+ *
+ * @author Tomaz Fernandes
+ * @since 4.1.0
+ * @see MessageExecutionThread
+ */
+public class VirtualThreadUtils {
+
+	@Nullable
+	private static final Method IS_VIRTUAL;
+
+	static {
+		Method m = null;
+		try {
+			m = Thread.class.getMethod("isVirtual");
+		}
+		catch (NoSuchMethodException e) {
+			// JDK < 21
+		}
+		IS_VIRTUAL = m;
+	}
+
+	private VirtualThreadUtils() {
+	}
+
+	/**
+	 * Check whether the given thread is a virtual thread.
+	 * @param thread the thread to check.
+	 * @return {@code true} if the thread is virtual, {@code false} if not or if running on JDK &lt; 21.
+	 */
+	public static boolean isVirtual(Thread thread) {
+		if (IS_VIRTUAL == null) {
+			return false;
+		}
+		try {
+			return (boolean) IS_VIRTUAL.invoke(thread);
+		}
+		catch (Exception e) {
+			return false;
+		}
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractPipelineMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractPipelineMessageListenerContainer.java
@@ -20,6 +20,7 @@ import io.awspring.cloud.sqs.LifecycleHandler;
 import io.awspring.cloud.sqs.MessageExecutionThread;
 import io.awspring.cloud.sqs.MessageExecutionThreadFactory;
 import io.awspring.cloud.sqs.UnsupportedThreadFactoryException;
+import io.awspring.cloud.sqs.VirtualThreadUtils;
 import io.awspring.cloud.sqs.listener.backpressure.BackPressureHandler;
 import io.awspring.cloud.sqs.listener.backpressure.BackPressureHandlerFactory;
 import io.awspring.cloud.sqs.listener.pipeline.AcknowledgementHandlerExecutionStage;
@@ -145,10 +146,14 @@ public abstract class AbstractPipelineMessageListenerContainer<T, O extends Cont
 	}
 
 	private void verifyThreadType() {
-		if (!MessageExecutionThread.class.isAssignableFrom(Thread.currentThread().getClass())) {
-			throw new UnsupportedThreadFactoryException("Custom TaskExecutors must use a %s."
-				.formatted(MessageExecutionThreadFactory.class.getSimpleName()));
+		if (Thread.currentThread() instanceof MessageExecutionThread) {
+			return;
 		}
+		if (VirtualThreadUtils.isVirtual(Thread.currentThread())) {
+			return;
+		}
+		throw new UnsupportedThreadFactoryException("Custom TaskExecutors must use a %s or virtual threads."
+			.formatted(MessageExecutionThreadFactory.class.getSimpleName()));
 	}
 	// @formatter:on
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AsyncComponentAdapters.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AsyncComponentAdapters.java
@@ -18,6 +18,7 @@ package io.awspring.cloud.sqs.listener;
 import io.awspring.cloud.sqs.CompletableFutures;
 import io.awspring.cloud.sqs.MessageExecutionThread;
 import io.awspring.cloud.sqs.MessageHeaderUtils;
+import io.awspring.cloud.sqs.VirtualThreadUtils;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementResultCallback;
 import io.awspring.cloud.sqs.listener.acknowledgement.AsyncAcknowledgementResultCallback;
 import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
@@ -112,23 +113,28 @@ public class AsyncComponentAdapters {
 		}
 
 		protected <T> CompletableFuture<T> execute(Supplier<T> executable) {
-			if (Thread.currentThread() instanceof MessageExecutionThread) {
-				logger.trace("Already in a {}, not switching", MessageExecutionThread.class.getSimpleName());
+			if (isOnExpectedThread()) {
+				logger.trace("Already on expected thread, not switching");
 				return supplyInSameThread(executable);
 			}
-			logger.trace("Not in a {}, submitting to executor", MessageExecutionThread.class.getSimpleName());
+			logger.trace("Not on expected thread, submitting to executor");
 			Assert.notNull(this.taskExecutor, "Task executor not set");
 			return supplyInNewThread(executable);
 		}
 
 		protected CompletableFuture<Void> execute(Runnable executable) {
-			if (Thread.currentThread() instanceof MessageExecutionThread) {
-				logger.trace("Already in a {}, not switching", MessageExecutionThread.class.getSimpleName());
+			if (isOnExpectedThread()) {
+				logger.trace("Already on expected thread, not switching");
 				return runInSameThread(executable);
 			}
-			logger.trace("Not in a {}, submitting to executor", MessageExecutionThread.class.getSimpleName());
+			logger.trace("Not on expected thread, submitting to executor");
 			Assert.notNull(this.taskExecutor, "Task executor not set");
 			return runInNewThread(executable);
+		}
+
+		private boolean isOnExpectedThread() {
+			return Thread.currentThread() instanceof MessageExecutionThread
+					|| VirtualThreadUtils.isVirtual(Thread.currentThread());
 		}
 
 		private CompletableFuture<Void> runInSameThread(Runnable blockingProcess) {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/VirtualThreadUtilsTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/VirtualThreadUtilsTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link VirtualThreadUtils}.
+ *
+ * @author Tomaz Fernandes
+ */
+class VirtualThreadUtilsTests {
+
+	@Test
+	void shouldReturnFalseForPlatformThread() {
+		assertThat(VirtualThreadUtils.isVirtual(Thread.currentThread())).isFalse();
+	}
+
+	@Test
+	void shouldReturnFalseForMessageExecutionThread() {
+		MessageExecutionThread thread = new MessageExecutionThread();
+		assertThat(VirtualThreadUtils.isVirtual(thread)).isFalse();
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsPerformanceHarness.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsPerformanceHarness.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.integration;
+
+import io.awspring.cloud.sqs.listener.SqsMessageListenerContainer;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.Assert;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+/**
+ * Reusable harness for measuring SQS message processing performance under different container configurations.
+ *
+ * <p>
+ * The harness sends messages to a queue, starts a container, and measures how long it takes to process all messages. It
+ * reports throughput (messages/second) and latency percentiles (p50, p95, p99).
+ *
+ * <p>
+ * Usage:
+ *
+ * <pre>{@code
+ * var harness = new SqsPerformanceHarness(sqsAsyncClient);
+ *
+ * // Simple run with default container
+ * var result = harness.run(RunParameters.builder().queueName("my-queue").messageCount(1000)
+ * 		.processingDelay(Duration.ofSeconds(1)).build());
+ *
+ * // Run with custom container configuration
+ * var result = harness.run(RunParameters.builder().queueName("my-queue").messageCount(1000).build(),
+ * 		builder -> builder
+ * 				.configure(options -> options.componentsTaskExecutor(myExecutor).maxConcurrentMessages(500))
+ * 				.messageInterceptor(myInterceptor));
+ *
+ * result.report("My Test");
+ * }</pre>
+ *
+ * <p>
+ * The harness owns the message listener (for latch/latency tracking). The {@code containerConfigurer} can set any other
+ * container property (options, interceptors, error handlers) but should not override the listener.
+ *
+ * <p>
+ * Messages are sent in parallel with a throttle of 50 concurrent batch sends and retry with backoff.
+ *
+ * @author Tomaz Fernandes
+ * @since 4.1.0
+ * @see SqsPerformanceTests
+ */
+class SqsPerformanceHarness {
+
+	private static final Logger logger = LoggerFactory.getLogger(SqsPerformanceHarness.class);
+
+	private final SqsAsyncClient sqsAsyncClient;
+
+	private final SqsTemplate sqsTemplate;
+
+	SqsPerformanceHarness(SqsAsyncClient sqsAsyncClient) {
+		this.sqsAsyncClient = sqsAsyncClient;
+		this.sqsTemplate = SqsTemplate.newTemplate(sqsAsyncClient);
+	}
+
+	/**
+	 * Run a performance test with the given parameters and container configuration.
+	 * @param params the test parameters.
+	 * @param containerConfigurer customization for the container builder (options, interceptors, error handlers, etc).
+	 *     The message listener is set by the harness and should not be overridden.
+	 * @return the performance result.
+	 */
+	PerformanceResult run(RunParameters params,
+			Consumer<SqsMessageListenerContainer.Builder<Object>> containerConfigurer) {
+		Assert.isTrue(params.messageCount > 0, "messageCount must be positive");
+		CountDownLatch latch = new CountDownLatch(params.messageCount);
+		List<Long> latencies = Collections.synchronizedList(new ArrayList<>(params.messageCount));
+
+		SqsMessageListenerContainer.Builder<Object> builder = SqsMessageListenerContainer.builder()
+				.sqsAsyncClient(this.sqsAsyncClient).queueNames(params.queueName).messageListener(message -> {
+					if (!params.processingDelay.isZero()) {
+						try {
+							Thread.sleep(params.processingDelay.toMillis());
+						}
+						catch (InterruptedException e) {
+							Thread.currentThread().interrupt();
+						}
+					}
+					Instant sent = Instant.ofEpochMilli(message.getHeaders().getTimestamp());
+					latencies.add(Duration.between(sent, Instant.now()).toMillis());
+					latch.countDown();
+				});
+		containerConfigurer.accept(builder);
+		SqsMessageListenerContainer<Object> container = builder.build();
+
+		sendMessages(params.queueName, params.messageCount);
+		container.start();
+		try {
+			Instant start = Instant.now();
+			boolean completed = latch.await(params.timeout.toSeconds(), TimeUnit.SECONDS);
+			Duration totalDuration = Duration.between(start, Instant.now());
+			Assert.isTrue(completed, "Timed out waiting for messages. Processed: "
+					+ (params.messageCount - latch.getCount()) + "/" + params.messageCount);
+			return new PerformanceResult(params.messageCount, totalDuration, new ArrayList<>(latencies));
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("Interrupted during performance test", e);
+		}
+		finally {
+			container.stop();
+		}
+	}
+
+	/**
+	 * Run a performance test with default container configuration.
+	 */
+	PerformanceResult run(RunParameters params) {
+		return run(params, builder -> {
+		});
+	}
+
+	private void sendMessages(String queueName, int messageCount) {
+		int batchSize = Math.min(messageCount, 10);
+		int batches = messageCount / batchSize;
+		int remainder = messageCount % batchSize;
+		int concurrentSends = Math.min(batches, 50);
+		Semaphore sendThrottle = new Semaphore(concurrentSends);
+		List<CompletableFuture<?>> futures = new ArrayList<>();
+		for (int i = 0; i < batches; i++) {
+			int batchIndex = i;
+			try {
+				sendThrottle.acquire();
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new RuntimeException(e);
+			}
+			var messages = IntStream.range(0, batchSize)
+					.mapToObj(j -> MessageBuilder.withPayload("perf-msg-" + (batchIndex * batchSize + j)).build())
+					.toList();
+			futures.add(sendWithRetry(queueName, messages, 3).whenComplete((r, t) -> sendThrottle.release()));
+		}
+		if (remainder > 0) {
+			futures.add(sqsTemplate.sendManyAsync(queueName, IntStream.range(0, remainder)
+					.mapToObj(j -> MessageBuilder.withPayload("perf-msg-remainder-" + j).build()).toList()));
+		}
+		CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
+		logger.info("Sent {} messages to {}", messageCount, queueName);
+	}
+
+	private <T> CompletableFuture<?> sendWithRetry(String queueName,
+			java.util.Collection<org.springframework.messaging.Message<T>> messages, int retriesLeft) {
+		return sqsTemplate.sendManyAsync(queueName, messages).thenApply(r -> (Object) r).exceptionally(t -> {
+			if (retriesLeft <= 0) {
+				throw new RuntimeException("Send failed after retries", t);
+			}
+			logger.warn("Send failed, retrying ({} left): {}", retriesLeft, t.getMessage());
+			try {
+				Thread.sleep(1000L * (4 - retriesLeft));
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			sendWithRetry(queueName, messages, retriesLeft - 1).join();
+			return null;
+		});
+	}
+
+	/**
+	 * Parameters for a performance test run.
+	 */
+	static class RunParameters {
+
+		final String queueName;
+
+		final int messageCount;
+
+		final Duration timeout;
+
+		final Duration processingDelay;
+
+		private RunParameters(Builder builder) {
+			this.queueName = builder.queueName;
+			this.messageCount = builder.messageCount;
+			this.timeout = builder.timeout;
+			this.processingDelay = builder.processingDelay;
+		}
+
+		static Builder builder() {
+			return new Builder();
+		}
+
+		static class Builder {
+
+			private String queueName;
+
+			private int messageCount = 200;
+
+			private Duration timeout = Duration.ofSeconds(60);
+
+			private Duration processingDelay = Duration.ZERO;
+
+			Builder queueName(String queueName) {
+				this.queueName = queueName;
+				return this;
+			}
+
+			Builder messageCount(int messageCount) {
+				this.messageCount = messageCount;
+				return this;
+			}
+
+			Builder timeout(Duration timeout) {
+				this.timeout = timeout;
+				return this;
+			}
+
+			Builder processingDelay(Duration processingDelay) {
+				this.processingDelay = processingDelay;
+				return this;
+			}
+
+			RunParameters build() {
+				Assert.hasText(queueName, "queueName must be set");
+				return new RunParameters(this);
+			}
+
+		}
+
+	}
+
+	/**
+	 * Result of a performance test run.
+	 */
+	static class PerformanceResult {
+
+		private final int messageCount;
+
+		private final Duration totalDuration;
+
+		private final List<Long> latencies;
+
+		PerformanceResult(int messageCount, Duration totalDuration, List<Long> latencies) {
+			this.messageCount = messageCount;
+			this.totalDuration = totalDuration;
+			this.latencies = latencies;
+			Collections.sort(this.latencies);
+		}
+
+		double messagesPerSecond() {
+			return messageCount / (totalDuration.toMillis() / 1000.0);
+		}
+
+		long p50() {
+			return percentile(50);
+		}
+
+		long p95() {
+			return percentile(95);
+		}
+
+		long p99() {
+			return percentile(99);
+		}
+
+		Duration totalDuration() {
+			return totalDuration;
+		}
+
+		int messageCount() {
+			return messageCount;
+		}
+
+		private long percentile(int p) {
+			if (latencies.isEmpty()) {
+				return 0;
+			}
+			int index = (int) Math.ceil(p / 100.0 * latencies.size()) - 1;
+			return latencies.get(Math.max(0, index));
+		}
+
+		void report(String name) {
+			logger.info("""
+
+					=== {} ===
+					Messages:     {}
+					Duration:     {}.{}s
+					Throughput:   {} msg/s
+					Latency p50:  {}ms | p95: {}ms | p99: {}ms""", name, messageCount, totalDuration.toSeconds(),
+					String.format("%03d", totalDuration.toMillisPart()), String.format("%.0f", messagesPerSecond()),
+					p50(), p95(), p99());
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsPerformanceTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsPerformanceTests.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.awspring.cloud.sqs.integration.SqsPerformanceHarness.RunParameters;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+/**
+ * Performance comparison tests for SQS message processing under different container configurations.
+ *
+ * <p>
+ * These tests measure relative throughput — assertions compare configurations against each other rather than against
+ * absolute thresholds, making them valid across different environments.
+ *
+ * <p>
+ * Disabled by default. Run with {@code mvn test -Dperformance=true -Dtest=SqsPerformanceTests}.
+ *
+ * <p>
+ * By default tests run against LocalStack. To run against AWS, set {@code useLocalStackClient = false} in
+ * {@link BaseSqsIntegrationTest}.
+ *
+ * @author Tomaz Fernandes
+ * @since 4.1.0
+ */
+@org.junit.jupiter.api.condition.EnabledIfSystemProperty(named = "performance", matches = "true")
+class SqsPerformanceTests extends BaseSqsIntegrationTest {
+
+	private static final String Q = "perf-test-";
+
+	private static SqsPerformanceHarness harness;
+
+	@BeforeAll
+	static void setupHarness() {
+		SqsAsyncClient client = createAsyncClient();
+		CompletableFuture.allOf(createQueue(client, Q + "default"), createQueue(client, Q + "virtual"),
+				createQueue(client, Q + "default-loaded"), createQueue(client, Q + "virtual-loaded"),
+				createQueue(client, Q + "default-500"), createQueue(client, Q + "virtual-500"),
+				createQueue(client, Q + "virtual-10k"), createQueue(client, Q + "vt-interceptor")).join();
+		harness = new SqsPerformanceHarness(client);
+	}
+
+	@Test
+	@EnabledForJreRange(min = JRE.JAVA_21)
+	void virtualThreadsShouldMatchDefaultPerformance() {
+		var defaultResult = harness.run(RunParameters.builder().queueName(Q + "default").messageCount(200).build());
+		var virtualResult = harness.run(RunParameters.builder().queueName(Q + "virtual").messageCount(200).build(),
+				builder -> builder.configure(options -> options.componentsTaskExecutor(virtualThreadExecutor())));
+
+		defaultResult.report("Default (Platform Threads)");
+		virtualResult.report("Virtual Threads");
+
+		assertThat(virtualResult.messagesPerSecond()).as("Virtual threads should be within 80%% of default throughput")
+				.isGreaterThan(defaultResult.messagesPerSecond() * 0.8);
+	}
+
+	@Test
+	@EnabledForJreRange(min = JRE.JAVA_21)
+	void virtualThreadsShouldMatchDefaultPerformanceUnderLoad() {
+		var defaultResult = harness.run(RunParameters.builder().queueName(Q + "default-loaded").messageCount(50)
+				.processingDelay(Duration.ofSeconds(1)).build());
+		var virtualResult = harness.run(
+				RunParameters.builder().queueName(Q + "virtual-loaded").messageCount(50)
+						.processingDelay(Duration.ofSeconds(1)).build(),
+				builder -> builder.configure(options -> options.componentsTaskExecutor(virtualThreadExecutor())));
+
+		defaultResult.report("Default (Platform Threads) - 1s load");
+		virtualResult.report("Virtual Threads - 1s load");
+
+		assertThat(virtualResult.messagesPerSecond())
+				.as("Virtual threads with load should be within 80%% of default throughput")
+				.isGreaterThan(defaultResult.messagesPerSecond() * 0.8);
+	}
+
+	@Test
+	@EnabledForJreRange(min = JRE.JAVA_21)
+	void virtualThreadsShouldScaleWithHighConcurrencyUnderLoad() {
+		var defaultResult = harness.run(
+				RunParameters.builder().queueName(Q + "default-500").messageCount(500)
+						.processingDelay(Duration.ofSeconds(1)).build(),
+				builder -> builder.configure(options -> options.maxConcurrentMessages(500)));
+		var virtualResult = harness.run(
+				RunParameters.builder().queueName(Q + "virtual-500").messageCount(500)
+						.processingDelay(Duration.ofSeconds(1)).build(),
+				builder -> builder.configure(
+						options -> options.maxConcurrentMessages(500).componentsTaskExecutor(virtualThreadExecutor())));
+
+		defaultResult.report("Default (Platform Threads) - 500 concurrent, 1s load");
+		virtualResult.report("Virtual Threads - 500 concurrent, 1s load");
+
+		assertThat(virtualResult.messagesPerSecond())
+				.as("Virtual threads should be at least as fast as platform threads at high concurrency")
+				.isGreaterThan(defaultResult.messagesPerSecond() * 0.8);
+	}
+
+	@Test
+	@EnabledForJreRange(min = JRE.JAVA_21)
+	void virtualThreadsShouldHandleTenThousandConcurrentMessages() {
+		var params = RunParameters.builder().queueName(Q + "virtual-10k").messageCount(10_000)
+				.timeout(Duration.ofSeconds(60)).processingDelay(Duration.ofSeconds(1)).build();
+
+		var result = harness.run(params, builder -> builder.configure(
+				options -> options.maxConcurrentMessages(10_000).componentsTaskExecutor(virtualThreadExecutor())));
+
+		result.report("Virtual Threads - 10k concurrent, 1s load");
+
+		assertThat(result.messagesPerSecond()).as("Should process at high throughput with 10k virtual threads")
+				.isGreaterThan(100);
+	}
+
+	@Test
+	@EnabledForJreRange(min = JRE.JAVA_21)
+	void virtualThreadsShouldWorkWithBlockingInterceptor() {
+		var params = RunParameters.builder().queueName(Q + "vt-interceptor").messageCount(50)
+				.timeout(Duration.ofSeconds(60)).processingDelay(Duration.ofSeconds(1)).build();
+
+		var result = harness.run(params,
+				builder -> builder.configure(options -> options.componentsTaskExecutor(virtualThreadExecutor()))
+						.messageInterceptor(blockingInterceptor(Duration.ofMillis(200))));
+
+		result.report("Virtual Threads - blocking interceptor (200ms) + 1s listener load");
+
+		assertThat(result.messagesPerSecond()).isGreaterThan(0);
+		assertThat(result.p50()).as("Latency should reflect interceptor + listener delay").isGreaterThanOrEqualTo(1200);
+	}
+
+	private static SimpleAsyncTaskExecutor virtualThreadExecutor() {
+		SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor();
+		executor.setVirtualThreads(true);
+		return executor;
+	}
+
+	private static io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor<Object> blockingInterceptor(
+			Duration delay) {
+		return new io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor<>() {
+			@Override
+			public org.springframework.messaging.Message<Object> intercept(
+					org.springframework.messaging.Message<Object> message) {
+				try {
+					Thread.sleep(delay.toMillis());
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+				return message;
+			}
+		};
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainerTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainerTests.java
@@ -193,6 +193,22 @@ class SqsMessageListenerContainerTests {
 	}
 
 	@Test
+	@org.junit.jupiter.api.condition.EnabledForJreRange(min = org.junit.jupiter.api.condition.JRE.JAVA_21)
+	void shouldNotThrowIfVirtualThreadExecutor() {
+		SqsAsyncClient client = mock(SqsAsyncClient.class);
+		given(client.getQueueUrl(any(GetQueueUrlRequest.class))).willReturn(
+				CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("test-queue").build()));
+		SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor();
+		executor.setVirtualThreads(true);
+		SqsMessageListenerContainer<Object> container = SqsMessageListenerContainer.builder().sqsAsyncClient(client)
+				.queueNames("test-queue").componentFactories(getNoOpsComponentFactory())
+				.configure(options -> options.componentsTaskExecutor(executor)).messageListener(msg -> {
+				}).build();
+		container.start();
+		container.stop();
+	}
+
+	@Test
 	void shouldThrowIfMixedQueueTypes() {
 		SqsAsyncClient client = mock(SqsAsyncClient.class);
 		SqsMessageListenerContainer.Builder<Object> builder = SqsMessageListenerContainer.builder()


### PR DESCRIPTION
Allow `VirtualThreadTaskExecutor` to be used as the `componentsTaskExecutor` by supporting both `MessageExecutionThread` and virtual-thread execution for user-provided components and listeners.

This preserves the existing hop-back safety mechanism while allowing execution to continue on either `MessageExecutionThread` or virtual threads on JDK 21+. Reflection is used to detect virtual threads so the JDK 17 baseline remains unchanged.

Also adds `SqsPerformanceHarness` / `SqsPerformanceTests` for comparing message-processing throughput under different container configurations. These tests are disabled by default and can be run with `-Dperformance=true`.

Closes gh-924


# SQS Virtual Threads Performance Results

Results from `SqsPerformanceTests` comparing default (platform threads) vs virtual threads.

| Test | Infra | Messages | Concurrent | Load | Throughput (default) | Throughput (VT) | p50 (default) | p50 (VT) |
|------|-------|----------|-----------|------|---------------------|----------------|--------------|----------|
| No load | LocalStack | 200 | 10 | - | 1,786 msg/s | 2,439 msg/s | 0ms | 0ms |
| 1s load | LocalStack | 50 | 10 | 1s | 10 msg/s | 10 msg/s | 1,003ms | 1,002ms |
| 500 concurrent, 1s load | LocalStack | 500 | 500 | 1s | 242 msg/s | 242 msg/s | 1,001ms | 1,001ms |
| 10k concurrent, 1s load | LocalStack | 10,000 | 10,000 | 1s | - | 3,235 msg/s | - | 1,000ms |
| 2k concurrent, 2s load | AWS | 2,000 | 2,000 | 2s | 304 msg/s | 339 msg/s | 2,004ms | 2,000ms |
| 10k concurrent, 1s load | AWS | 10,000 | 10,000 | 1s | - | 1,939 msg/s | - | 1,000ms |
| Blocking interceptor (200ms) + 1s load | LocalStack | 50 | 10 | 1s | - | 8 msg/s | - | 1,208ms |

## Key Takeaways

- At low concurrency, virtual threads and platform threads perform similarly in these runs.
- At 2k concurrent against AWS, virtual threads showed about 11% higher throughput with slightly tighter p50 latency.
- 10k concurrent runs completed successfully with virtual threads in this setup.
- Blocking interceptors also worked correctly with virtual threads in these tests.
- In the higher-concurrency AWS runs, the main observed bottleneck was the AWS SDK HTTP connection pool rather than the thread model.