### PR TITLE
Fix SQS MessageInterceptor exceptions handling

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AsyncComponentAdapters.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AsyncComponentAdapters.java
@@ -381,17 +381,23 @@ public class AsyncComponentAdapters {
 
 			@Override
 			public Message<MessageType> onExecutionError(Message<MessageType> message, Throwable t) {
-				if (observationContext != null && ListenerExecutionFailedException.hasListenerException(t)) {
+				if (observationContext != null && MessageProcessingException.hasProcessingException(t)) {
 					Message<MessageType> failedMessage = Objects.requireNonNull(
-							ListenerExecutionFailedException.unwrapMessage(t),
-							"Message not found in Listener Exception.");
+							MessageProcessingException.unwrapMessage(t), "Message not found in processing exception.");
 					Message<MessageType> messageWithHeader = MessageHeaderUtils.addHeaderIfAbsent(failedMessage,
 							ObservationThreadLocalAccessor.KEY, observationContext);
-					throw new ListenerExecutionFailedException(t.getMessage(), t.getCause(), messageWithHeader);
+					throw rewrapWithUpdatedMessage(t, messageWithHeader);
 				}
 				return message;
 			}
 		}
+	}
+
+	private static <T> RuntimeException rewrapWithUpdatedMessage(Throwable t, Message<T> message) {
+		if (t instanceof InterceptorExecutionFailedException) {
+			return new InterceptorExecutionFailedException(t.getMessage(), t.getCause(), message);
+		}
+		return new ListenerExecutionFailedException(t.getMessage(), t.getCause(), message);
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/InterceptorExecutionFailedException.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/InterceptorExecutionFailedException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import org.springframework.messaging.Message;
+
+/**
+ * Exception thrown when a {@link io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor} throws during
+ * before-processing execution. Contains the {@link Message} instance or instances for which the interceptor failed,
+ * allowing downstream pipeline stages such as the error handler and acknowledgement handler to retrieve the message and
+ * act accordingly.
+ *
+ * @author Tomaz Fernandes
+ * @since 4.1
+ * @see MessageProcessingException
+ * @see ListenerExecutionFailedException
+ */
+public class InterceptorExecutionFailedException extends RuntimeException implements MessageProcessingException {
+
+	private final Collection<Message<?>> failedMessages;
+
+	public InterceptorExecutionFailedException(String message, Throwable cause, Message<?> failedMessage) {
+		super(message, cause);
+		this.failedMessages = Collections.singletonList(failedMessage);
+	}
+
+	public <T> InterceptorExecutionFailedException(String message, Throwable cause,
+			Collection<Message<T>> failedMessages) {
+		super(message, cause);
+		this.failedMessages = failedMessages.stream().map(msg -> (Message<?>) msg).collect(Collectors.toList());
+	}
+
+	@Override
+	public Collection<Message<?>> getFailedMessages() {
+		return this.failedMessages;
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ListenerExecutionFailedException.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/ListenerExecutionFailedException.java
@@ -19,8 +19,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
@@ -31,9 +29,7 @@ import org.springframework.util.Assert;
  * @author Tomaz Fernandes
  * @since 3.0
  */
-public class ListenerExecutionFailedException extends RuntimeException {
-
-	private static final Logger logger = LoggerFactory.getLogger(ListenerExecutionFailedException.class);
+public class ListenerExecutionFailedException extends RuntimeException implements MessageProcessingException {
 
 	private final Collection<Message<?>> failedMessages;
 
@@ -66,57 +62,42 @@ public class ListenerExecutionFailedException extends RuntimeException {
 	}
 
 	/**
-	 * Look for a potentially nested {@link ListenerExecutionFailedException} and if found return the wrapped
-	 * {@link Message} instance.
+	 * Look for a potentially nested {@link MessageProcessingException} in the cause chain and if found return the
+	 * wrapped {@link Message} instance.
 	 * @param t the throwable
 	 * @param <T> the message type.
 	 * @return the message.
+	 * @deprecated use {@link MessageProcessingException#unwrapMessage(Throwable)} instead.
 	 */
-	// @formatter:off
-	@SuppressWarnings("unchecked")
+	@Deprecated
 	@Nullable
 	public static <T> Message<T> unwrapMessage(Throwable t) {
-		Throwable exception = findListenerException(t);
-		return t == null
-				? null
-				: exception != null
-					? (Message<T>) ((ListenerExecutionFailedException) exception).getFailedMessage()
-				: (Message<T>) wrapAndRethrowError(t);
+		return MessageProcessingException.unwrapMessage(t);
 	}
 
 	/**
-	 * Look for a potentially nested {@link ListenerExecutionFailedException} and if found return the wrapped {@link Message} instances.
+	 * Look for a potentially nested {@link MessageProcessingException} in the cause chain and if found return the
+	 * wrapped {@link Message} instances.
 	 * @param t the throwable
 	 * @param <T> the message type.
 	 * @return the messages.
+	 * @deprecated use {@link MessageProcessingException#unwrapMessages(Throwable)} instead.
 	 */
-	@SuppressWarnings("unchecked")
+	@Deprecated
 	@Nullable
 	public static <T> Collection<Message<T>> unwrapMessages(Throwable t) {
-		Throwable exception = findListenerException(t);
-		return t == null
-			? null
-			: exception != null
-				? ((ListenerExecutionFailedException) exception).getFailedMessages().stream().map(msg -> (Message<T>) msg).collect(Collectors.toList())
-				: (Collection<Message<T>>) wrapAndRethrowError(t);
+		return MessageProcessingException.unwrapMessages(t);
 	}
 
-	@Nullable
-	private static Throwable findListenerException(Throwable t) {
-		return t == null
-			? null
-			: t instanceof ListenerExecutionFailedException
-				? t
-				: findListenerException(t.getCause());
-	}
-	// @formatter:on
-
-	private static Object wrapAndRethrowError(Throwable t) {
-		throw new IllegalArgumentException("No ListenerExecutionFailedException found to unwrap messages.", t);
-	}
-
+	/**
+	 * Check whether a {@link MessageProcessingException} is present anywhere in the cause chain of {@code t}.
+	 * @param t the throwable.
+	 * @return whether a {@link MessageProcessingException} is present.
+	 * @deprecated use {@link MessageProcessingException#hasProcessingException(Throwable)} instead.
+	 */
+	@Deprecated
 	public static boolean hasListenerException(Throwable t) {
-		return findListenerException(t) != null;
+		return MessageProcessingException.hasProcessingException(t);
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/MessageProcessingException.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/MessageProcessingException.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
+import org.springframework.messaging.Message;
+
+/**
+ * Implemented by exceptions that carry references to the {@link Message} instances that failed during processing.
+ * Provides static utility methods for traversing the cause chain and extracting message references.
+ *
+ * @author Tomaz Fernandes
+ * @since 4.1
+ * @see ListenerExecutionFailedException
+ * @see InterceptorExecutionFailedException
+ */
+public interface MessageProcessingException {
+
+	/**
+	 * Return the messages for which processing failed.
+	 * @return the messages.
+	 */
+	Collection<Message<?>> getFailedMessages();
+
+	/**
+	 * Look for a potentially nested {@link MessageProcessingException} in the cause chain and if found return the
+	 * wrapped {@link Message} instance.
+	 * @param t the throwable
+	 * @param <T> the message payload type.
+	 * @return the message, or {@code null} if {@code t} is {@code null}.
+	 */
+	@SuppressWarnings("unchecked")
+	@Nullable
+	static <T> Message<T> unwrapMessage(@Nullable Throwable t) {
+		Throwable exception = findProcessingException(t);
+		return t == null ? null
+				: exception != null
+						? (Message<T>) ((MessageProcessingException) exception).getFailedMessages().iterator().next()
+						: (Message<T>) wrapAndRethrowError(t);
+	}
+
+	/**
+	 * Look for a potentially nested {@link MessageProcessingException} in the cause chain and if found return the
+	 * wrapped {@link Message} instances.
+	 * @param t the throwable
+	 * @param <T> the message payload type.
+	 * @return the messages, or {@code null} if {@code t} is {@code null}.
+	 */
+	@SuppressWarnings("unchecked")
+	@Nullable
+	static <T> Collection<Message<T>> unwrapMessages(@Nullable Throwable t) {
+		Throwable exception = findProcessingException(t);
+		return t == null ? null
+				: exception != null
+						? ((MessageProcessingException) exception).getFailedMessages().stream()
+								.map(msg -> (Message<T>) msg).collect(Collectors.toList())
+						: (Collection<Message<T>>) wrapAndRethrowError(t);
+	}
+
+	/**
+	 * Check whether a {@link MessageProcessingException} is present anywhere in the cause chain of {@code t}.
+	 * @param t the throwable.
+	 * @return {@code true} if a {@link MessageProcessingException} is present.
+	 */
+	static boolean hasProcessingException(Throwable t) {
+		return findProcessingException(t) != null;
+	}
+
+	@Nullable
+	private static Throwable findProcessingException(@Nullable Throwable t) {
+		return t == null ? null : t instanceof MessageProcessingException ? t : findProcessingException(t.getCause());
+	}
+
+	private static Object wrapAndRethrowError(Throwable t) {
+		throw new IllegalArgumentException("No MessageProcessingException found to unwrap messages.", t);
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/pipeline/AbstractAfterProcessingInterceptorExecutionStage.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/pipeline/AbstractAfterProcessingInterceptorExecutionStage.java
@@ -16,11 +16,12 @@
 package io.awspring.cloud.sqs.listener.pipeline;
 
 import io.awspring.cloud.sqs.CompletableFutures;
-import io.awspring.cloud.sqs.listener.ListenerExecutionFailedException;
 import io.awspring.cloud.sqs.listener.MessageProcessingContext;
+import io.awspring.cloud.sqs.listener.MessageProcessingException;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.messaging.Message;
@@ -43,7 +44,7 @@ public abstract class AbstractAfterProcessingInterceptorExecutionStage<T> implem
 		return CompletableFutures.handleCompose(messageFuture,
 			(v, t) -> t == null
 				? applyInterceptors(v, null, getMessageInterceptors(context))
-				: applyInterceptors(ListenerExecutionFailedException.unwrapMessage(t), t, getMessageInterceptors(context))
+				: applyInterceptors(MessageProcessingException.unwrapMessage(t), t, getMessageInterceptors(context))
 				.thenCompose(msg -> CompletableFutures.failedFuture(t)));
 	}
 
@@ -64,11 +65,12 @@ public abstract class AbstractAfterProcessingInterceptorExecutionStage<T> implem
 		return CompletableFutures.handleCompose(messagesFuture,
 			(v, t) -> t == null
 				? applyInterceptors(v, null, getMessageInterceptors(context))
-				: applyInterceptors(ListenerExecutionFailedException.unwrapMessages(t), t, getMessageInterceptors(context))
+				// unwrapMessages is @Nullable but never returns null when t != null — it either returns the collection or throws
+				: applyInterceptors(MessageProcessingException.unwrapMessages(t), t, getMessageInterceptors(context))
 				.thenCompose(msg -> CompletableFutures.failedFuture(t)));
 	}
 
-	private CompletableFuture<Collection<Message<T>>> applyInterceptors(Collection<Message<T>> messages, Throwable t,
+	private CompletableFuture<Collection<Message<T>>> applyInterceptors(Collection<Message<T>> messages, @Nullable Throwable t,
 			Collection<AsyncMessageInterceptor<T>> messageInterceptors) {
 		return messageInterceptors.stream()
 			.reduce(CompletableFuture.<Void>completedFuture(null),

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/pipeline/AbstractBeforeProcessingInterceptorExecutionStage.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/pipeline/AbstractBeforeProcessingInterceptorExecutionStage.java
@@ -15,8 +15,11 @@
  */
 package io.awspring.cloud.sqs.listener.pipeline;
 
+import io.awspring.cloud.sqs.CompletableFutures;
 import io.awspring.cloud.sqs.MessageHeaderUtils;
+import io.awspring.cloud.sqs.listener.InterceptorExecutionFailedException;
 import io.awspring.cloud.sqs.listener.MessageProcessingContext;
+import io.awspring.cloud.sqs.listener.MessageProcessingException;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -40,20 +43,26 @@ public abstract class AbstractBeforeProcessingInterceptorExecutionStage<T> imple
 	@Override
 	public CompletableFuture<Message<T>> process(Message<T> message, MessageProcessingContext<T> context) {
 		logger.trace("Processing message {}", MessageHeaderUtils.getId(message));
-		return getInterceptors(context).stream().reduce(CompletableFuture.completedFuture(message), (messageFuture,
-				interceptor) -> messageFuture.thenCompose(interceptor::intercept).thenApply(validateMessageNotNull()),
-				(a, b) -> a);
+		return CompletableFutures.exceptionallyCompose(
+				getInterceptors(context).stream().reduce(CompletableFuture.completedFuture(message),
+						(messageFuture, interceptor) -> messageFuture.thenCompose(interceptor::intercept)
+								.thenApply(validateMessageNotNull()),
+						(a, b) -> a),
+				t -> CompletableFutures.failedFuture(MessageProcessingException.hasProcessingException(t) ? t
+						: new InterceptorExecutionFailedException("Interceptor threw an exception", t, message)));
 	}
 
 	@Override
 	public CompletableFuture<Collection<Message<T>>> process(Collection<Message<T>> messages,
 			MessageProcessingContext<T> context) {
 		logger.trace("Processing messages {}", MessageHeaderUtils.getId(messages));
-		return getInterceptors(context)
-				.stream().reduce(
-						CompletableFuture.completedFuture(messages), (messageFuture, interceptor) -> messageFuture
+		return CompletableFutures.exceptionallyCompose(
+				getInterceptors(context).stream().reduce(CompletableFuture.completedFuture(messages),
+						(messageFuture, interceptor) -> messageFuture
 								.thenCompose(interceptor::intercept).thenApply(validateMessagesNotEmpty()),
-						(a, b) -> a);
+						(a, b) -> a),
+				t -> CompletableFutures.failedFuture(MessageProcessingException.hasProcessingException(t) ? t
+						: new InterceptorExecutionFailedException("Interceptor threw an exception", t, messages)));
 	}
 
 	protected abstract Collection<AsyncMessageInterceptor<T>> getInterceptors(MessageProcessingContext<T> context);

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/pipeline/AcknowledgementHandlerExecutionStage.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/pipeline/AcknowledgementHandlerExecutionStage.java
@@ -16,8 +16,8 @@
 package io.awspring.cloud.sqs.listener.pipeline;
 
 import io.awspring.cloud.sqs.CompletableFutures;
-import io.awspring.cloud.sqs.listener.ListenerExecutionFailedException;
 import io.awspring.cloud.sqs.listener.MessageProcessingContext;
+import io.awspring.cloud.sqs.listener.MessageProcessingException;
 import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementHandler;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -47,8 +47,7 @@ public class AcknowledgementHandlerExecutionStage<T> implements MessageProcessin
 		return CompletableFutures.handleCompose(messageFuture, (v, t) -> t == null
 				? this.acknowledgementHandler.onSuccess(v, context.getAcknowledgmentCallback()).thenApply(theVoid -> v)
 				: this.acknowledgementHandler
-						.onError(ListenerExecutionFailedException.unwrapMessage(t), t,
-								context.getAcknowledgmentCallback())
+						.onError(MessageProcessingException.unwrapMessage(t), t, context.getAcknowledgmentCallback())
 						.thenCompose(theVoid -> CompletableFutures.failedFuture(t)));
 	}
 
@@ -56,7 +55,9 @@ public class AcknowledgementHandlerExecutionStage<T> implements MessageProcessin
 	public CompletableFuture<Collection<Message<T>>> processMany(
 			CompletableFuture<Collection<Message<T>>> messagesFuture, MessageProcessingContext<T> context) {
 		return CompletableFutures.handleCompose(messagesFuture, (v, t) -> {
-			Collection<Message<T>> originalMessages = ListenerExecutionFailedException.unwrapMessages(t);
+			// unwrapMessages returns null when t is null, but originalMessages is only used in the t != null branch
+			// below
+			Collection<Message<T>> originalMessages = MessageProcessingException.unwrapMessages(t);
 			return t == null
 					? this.acknowledgementHandler.onSuccess(v, context.getAcknowledgmentCallback())
 							.thenApply(theVoid -> v)

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/pipeline/ErrorHandlerExecutionStage.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/pipeline/ErrorHandlerExecutionStage.java
@@ -19,6 +19,7 @@ import io.awspring.cloud.sqs.CompletableFutures;
 import io.awspring.cloud.sqs.MessageHeaderUtils;
 import io.awspring.cloud.sqs.listener.ListenerExecutionFailedException;
 import io.awspring.cloud.sqs.listener.MessageProcessingContext;
+import io.awspring.cloud.sqs.listener.MessageProcessingException;
 import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -48,7 +49,7 @@ public class ErrorHandlerExecutionStage<T> implements MessageProcessingPipeline<
 			MessageProcessingContext<T> context) {
 		return this.errorHandler == null ? messageFuture
 				: CompletableFutures.exceptionallyCompose(messageFuture,
-						t -> handleError(ListenerExecutionFailedException.unwrapMessage(t), t));
+						t -> handleError(MessageProcessingException.unwrapMessage(t), t));
 	}
 
 	private CompletableFuture<Message<T>> handleError(Message<T> failedMessage, Throwable t) {
@@ -59,7 +60,7 @@ public class ErrorHandlerExecutionStage<T> implements MessageProcessingPipeline<
 	}
 
 	private Throwable maybeWrap(Message<T> failedMessage, Throwable eht) {
-		return ListenerExecutionFailedException.hasListenerException(eht) ? eht
+		return MessageProcessingException.hasProcessingException(eht) ? eht
 				: new ListenerExecutionFailedException("Error handler returned an exception", eht, failedMessage);
 	}
 
@@ -68,7 +69,7 @@ public class ErrorHandlerExecutionStage<T> implements MessageProcessingPipeline<
 			CompletableFuture<Collection<Message<T>>> messagesFuture, MessageProcessingContext<T> context) {
 		return this.errorHandler == null ? messagesFuture
 				: CompletableFutures.exceptionallyCompose(messagesFuture,
-						t -> handleErrors(ListenerExecutionFailedException.unwrapMessages(t), t));
+						t -> handleErrors(MessageProcessingException.unwrapMessages(t), t));
 	}
 
 	private CompletableFuture<Collection<Message<T>>> handleErrors(Collection<Message<T>> failedMessages, Throwable t) {
@@ -79,7 +80,7 @@ public class ErrorHandlerExecutionStage<T> implements MessageProcessingPipeline<
 	}
 
 	private Throwable maybeWrap(Collection<Message<T>> failedMessages, Throwable eht) {
-		return ListenerExecutionFailedException.hasListenerException(eht) ? eht
+		return MessageProcessingException.hasProcessingException(eht) ? eht
 				: new ListenerExecutionFailedException("Error handler returned an exception", eht, failedMessages);
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/pipeline/MessageListenerExecutionStage.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/pipeline/MessageListenerExecutionStage.java
@@ -20,6 +20,7 @@ import io.awspring.cloud.sqs.MessageHeaderUtils;
 import io.awspring.cloud.sqs.listener.AsyncMessageListener;
 import io.awspring.cloud.sqs.listener.ListenerExecutionFailedException;
 import io.awspring.cloud.sqs.listener.MessageProcessingContext;
+import io.awspring.cloud.sqs.listener.MessageProcessingException;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
@@ -47,7 +48,7 @@ public class MessageListenerExecutionStage<T> implements MessageProcessingPipeli
 		logger.trace("Processing message {}", MessageHeaderUtils.getId(message));
 		return CompletableFutures.exceptionallyCompose(
 				this.messageListener.onMessage(message).thenApply(theVoid -> message),
-				t -> CompletableFutures.failedFuture(ListenerExecutionFailedException.hasListenerException(t) ? t
+				t -> CompletableFutures.failedFuture(MessageProcessingException.hasProcessingException(t) ? t
 						: new ListenerExecutionFailedException("Listener failed to process message", t, message)));
 	}
 
@@ -57,7 +58,7 @@ public class MessageListenerExecutionStage<T> implements MessageProcessingPipeli
 		logger.trace("Processing messages {}", MessageHeaderUtils.getId(messages));
 		return CompletableFutures.exceptionallyCompose(
 				this.messageListener.onMessage(messages).thenApply(theVoid -> messages),
-				t -> CompletableFutures.failedFuture(ListenerExecutionFailedException.hasListenerException(t) ? t
+				t -> CompletableFutures.failedFuture(MessageProcessingException.hasProcessingException(t) ? t
 						: new ListenerExecutionFailedException("Listener failed to process messages", t, messages)));
 	}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsInterceptorIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsInterceptorIntegrationTests.java
@@ -22,8 +22,10 @@ import io.awspring.cloud.sqs.MessageHeaderUtils;
 import io.awspring.cloud.sqs.annotation.SqsListener;
 import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration;
 import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
+import io.awspring.cloud.sqs.listener.InterceptorExecutionFailedException;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
 import io.awspring.cloud.sqs.listener.StandardSqsComponentFactory;
+import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementResultCallback;
 import io.awspring.cloud.sqs.listener.acknowledgement.BatchingAcknowledgementProcessor;
 import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementMode;
 import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
@@ -34,10 +36,12 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -68,6 +72,12 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 
 	static final String RECEIVES_CHANGED_MESSAGE_ON_ERROR_QUEUE_NAME = "receives_changed_message_on_error_test_queue";
 
+	static final String INTERCEPTOR_THROWS_QUEUE_NAME = "interceptor_throws_test_queue";
+
+	static final String INTERCEPTOR_THROWS_BATCH_QUEUE_NAME = "interceptor_throws_batch_test_queue";
+
+	static final String INTERCEPTOR_THROWS_RECOVERS_QUEUE_NAME = "interceptor_throws_recovers_test_queue";
+
 	static final String SHOULD_CHANGE_PAYLOAD = "should-change-payload";
 
 	private static final String CHANGED_PAYLOAD = "Changed payload";
@@ -78,7 +88,10 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 	static void beforeTests() {
 		SqsAsyncClient client = createAsyncClient();
 		CompletableFuture.allOf(createQueue(client, RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME),
-				createQueue(client, RECEIVES_CHANGED_MESSAGE_ON_ERROR_QUEUE_NAME)).join();
+				createQueue(client, RECEIVES_CHANGED_MESSAGE_ON_ERROR_QUEUE_NAME),
+				createQueue(client, INTERCEPTOR_THROWS_QUEUE_NAME),
+				createQueue(client, INTERCEPTOR_THROWS_BATCH_QUEUE_NAME),
+				createQueue(client, INTERCEPTOR_THROWS_RECOVERS_QUEUE_NAME)).join();
 	}
 
 	@Autowired
@@ -89,6 +102,37 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 
 	@Autowired(required = false)
 	ReceivesChangedPayloadListener receivesChangedPayloadListener;
+
+	@Test
+	void shouldInvokeErrorHandlerAndAfterProcessingInterceptorWhenInterceptorThrows() throws Exception {
+		sqsTemplate.send(INTERCEPTOR_THROWS_QUEUE_NAME, "any-payload");
+		assertThat(latchContainer.interceptorThrowsErrorHandlerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.interceptorThrowsAfterProcessingLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.interceptorThrowsException.get().getCause())
+				.isInstanceOf(InterceptorExecutionFailedException.class);
+		assertThat(latchContainer.interceptorThrowsAfterProcessingException.get().getCause())
+				.isInstanceOf(InterceptorExecutionFailedException.class);
+	}
+
+	@Test
+	void shouldInvokeErrorHandlerAndAfterProcessingInterceptorWhenInterceptorThrowsBatch() throws Exception {
+		sqsTemplate.send(INTERCEPTOR_THROWS_BATCH_QUEUE_NAME, "any-payload");
+		assertThat(latchContainer.interceptorThrowsBatchErrorHandlerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.interceptorThrowsBatchAfterProcessingLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.interceptorThrowsBatchException.get().getCause())
+				.isInstanceOf(InterceptorExecutionFailedException.class);
+		assertThat(latchContainer.interceptorThrowsBatchAfterProcessingException.get().getCause())
+				.isInstanceOf(InterceptorExecutionFailedException.class);
+	}
+
+	@Test
+	void shouldAcknowledgeAndNotProcessWhenErrorHandlerRecoversInterceptorException() throws Exception {
+		sqsTemplate.send(INTERCEPTOR_THROWS_RECOVERS_QUEUE_NAME, "any-payload");
+		assertThat(latchContainer.interceptorThrowsRecoversAckLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.interceptorThrowsRecoversAfterProcessingLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.interceptorThrowsRecoversAfterProcessingException.get()).isNull();
+		assertThat(latchContainer.interceptorThrowsRecoversListenerCalled).isFalse();
+	}
 
 	@Test
 	void shouldReceiveChangedMessageOnComponents() throws Exception {
@@ -144,11 +188,65 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 		}
 	}
 
+	static class InterceptorThrowsRecoversListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@SqsListener(queueNames = INTERCEPTOR_THROWS_RECOVERS_QUEUE_NAME, id = "interceptor-throws-recovers", factory = "interceptorThrowsRecoversFactory")
+		void listen(Message<String> message) {
+			latchContainer.interceptorThrowsRecoversListenerCalled = true;
+		}
+
+	}
+
+	static class InterceptorThrowsListener {
+
+		@SqsListener(queueNames = INTERCEPTOR_THROWS_QUEUE_NAME, id = "interceptor-throws", factory = "interceptorThrowsFactory")
+		void listen(Message<String> message) {
+			throw new RuntimeException("Listener should not be called when interceptor throws");
+		}
+
+	}
+
+	static class InterceptorThrowsBatchListener {
+
+		@SqsListener(queueNames = INTERCEPTOR_THROWS_BATCH_QUEUE_NAME, id = "interceptor-throws-batch", factory = "interceptorThrowsBatchFactory")
+		void listen(List<Message<String>> messages) {
+			throw new RuntimeException("Listener should not be called when interceptor throws");
+		}
+
+	}
+
 	static class LatchContainer {
 
 		final CountDownLatch receivesChangedMessageLatch = new CountDownLatch(3);
 
 		final CountDownLatch receivesChangedMessageOnErrorLatch = new CountDownLatch(3);
+
+		final CountDownLatch interceptorThrowsErrorHandlerLatch = new CountDownLatch(1);
+
+		final CountDownLatch interceptorThrowsAfterProcessingLatch = new CountDownLatch(1);
+
+		final AtomicReference<Throwable> interceptorThrowsException = new AtomicReference<>();
+
+		final AtomicReference<Throwable> interceptorThrowsAfterProcessingException = new AtomicReference<>();
+
+		final CountDownLatch interceptorThrowsBatchErrorHandlerLatch = new CountDownLatch(1);
+
+		final CountDownLatch interceptorThrowsBatchAfterProcessingLatch = new CountDownLatch(1);
+
+		final AtomicReference<Throwable> interceptorThrowsBatchException = new AtomicReference<>();
+
+		final AtomicReference<Throwable> interceptorThrowsBatchAfterProcessingException = new AtomicReference<>();
+
+		final CountDownLatch interceptorThrowsRecoversAckLatch = new CountDownLatch(1);
+
+		final CountDownLatch interceptorThrowsRecoversAfterProcessingLatch = new CountDownLatch(1);
+
+		final AtomicReference<Throwable> interceptorThrowsRecoversAfterProcessingException = new AtomicReference<>();
+
+		volatile boolean interceptorThrowsRecoversListenerCalled = false;
 
 	}
 
@@ -172,6 +270,116 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 			return factory;
 		}
 		// @formatter:on
+
+		@Bean
+		public SqsMessageListenerContainerFactory<String> interceptorThrowsFactory() {
+			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
+			factory.configure(options -> options.maxDelayBetweenPolls(Duration.ofSeconds(1))
+					.acknowledgementMode(AcknowledgementMode.ALWAYS).pollTimeout(Duration.ofSeconds(3)));
+			factory.setSqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient);
+			factory.addMessageInterceptor(new AsyncMessageInterceptor<String>() {
+				@Override
+				public CompletableFuture<Message<String>> intercept(Message<String> message) {
+					throw new RuntimeException("Expected interceptor exception");
+				}
+
+				@Override
+				public CompletableFuture<Void> afterProcessing(Message<String> message, Throwable t) {
+					latchContainer.interceptorThrowsAfterProcessingException.set(t);
+					latchContainer.interceptorThrowsAfterProcessingLatch.countDown();
+					return CompletableFuture.completedFuture(null);
+				}
+			});
+			factory.setErrorHandler(new AsyncErrorHandler<String>() {
+				@Override
+				public CompletableFuture<Void> handle(Message<String> message, Throwable t) {
+					latchContainer.interceptorThrowsException.set(t);
+					latchContainer.interceptorThrowsErrorHandlerLatch.countDown();
+					return CompletableFutures.failedFuture(t);
+				}
+			});
+			return factory;
+		}
+
+		@Bean
+		public SqsMessageListenerContainerFactory<String> interceptorThrowsBatchFactory() {
+			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
+			factory.configure(options -> options.maxDelayBetweenPolls(Duration.ofSeconds(1))
+					.acknowledgementMode(AcknowledgementMode.ALWAYS).pollTimeout(Duration.ofSeconds(3)));
+			factory.setSqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient);
+			factory.addMessageInterceptor(new AsyncMessageInterceptor<String>() {
+				@Override
+				public CompletableFuture<Collection<Message<String>>> intercept(Collection<Message<String>> messages) {
+					throw new RuntimeException("Expected batch interceptor exception");
+				}
+
+				@Override
+				public CompletableFuture<Void> afterProcessing(Collection<Message<String>> messages, Throwable t) {
+					latchContainer.interceptorThrowsBatchAfterProcessingException.set(t);
+					latchContainer.interceptorThrowsBatchAfterProcessingLatch.countDown();
+					return CompletableFuture.completedFuture(null);
+				}
+			});
+			factory.setErrorHandler(new AsyncErrorHandler<String>() {
+				@Override
+				public CompletableFuture<Void> handle(Collection<Message<String>> messages, Throwable t) {
+					latchContainer.interceptorThrowsBatchException.set(t);
+					latchContainer.interceptorThrowsBatchErrorHandlerLatch.countDown();
+					return CompletableFutures.failedFuture(t);
+				}
+			});
+			return factory;
+		}
+
+		@Bean
+		public SqsMessageListenerContainerFactory<String> interceptorThrowsRecoversFactory() {
+			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
+			factory.configure(options -> options.maxDelayBetweenPolls(Duration.ofSeconds(1))
+					.acknowledgementMode(AcknowledgementMode.ON_SUCCESS).pollTimeout(Duration.ofSeconds(3)));
+			factory.setSqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient);
+			factory.addMessageInterceptor(new AsyncMessageInterceptor<String>() {
+				@Override
+				public CompletableFuture<Message<String>> intercept(Message<String> message) {
+					throw new RuntimeException("Simulated duplicate — interceptor rejects message");
+				}
+
+				@Override
+				public CompletableFuture<Void> afterProcessing(Message<String> message, Throwable t) {
+					latchContainer.interceptorThrowsRecoversAfterProcessingException.set(t);
+					latchContainer.interceptorThrowsRecoversAfterProcessingLatch.countDown();
+					return CompletableFuture.completedFuture(null);
+				}
+			});
+			factory.setErrorHandler(new AsyncErrorHandler<String>() {
+				@Override
+				public CompletableFuture<Void> handle(Message<String> message, Throwable t) {
+					// swallow — message is considered handled (e.g. duplicate, skip it)
+					return CompletableFuture.completedFuture(null);
+				}
+			});
+			factory.setAcknowledgementResultCallback(new AcknowledgementResultCallback<String>() {
+				@Override
+				public void onSuccess(Collection<Message<String>> messages) {
+					latchContainer.interceptorThrowsRecoversAckLatch.countDown();
+				}
+			});
+			return factory;
+		}
+
+		@Bean
+		InterceptorThrowsRecoversListener interceptorThrowsRecoversListener() {
+			return new InterceptorThrowsRecoversListener();
+		}
+
+		@Bean
+		InterceptorThrowsListener interceptorThrowsListener() {
+			return new InterceptorThrowsListener();
+		}
+
+		@Bean
+		InterceptorThrowsBatchListener interceptorThrowsBatchListener() {
+			return new InterceptorThrowsBatchListener();
+		}
 
 		@Bean
 		ReceivesChangedPayloadListener receivesChangedPayloadListener() {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/pipeline/BeforeProcessingContextInterceptorExecutionStageTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/pipeline/BeforeProcessingContextInterceptorExecutionStageTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.awspring.cloud.sqs.listener.AsyncMessageListener;
+import io.awspring.cloud.sqs.listener.InterceptorExecutionFailedException;
 import io.awspring.cloud.sqs.listener.MessageProcessingContext;
 import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementHandler;
 import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
@@ -167,8 +168,11 @@ class BeforeProcessingContextInterceptorExecutionStageTests {
 				createConfiguration());
 		CompletableFuture<Message<Object>> future = stage.process(message1, context);
 		assertThat(future).isCompletedExceptionally();
-		assertThatThrownBy(future::join).isInstanceOf(CompletionException.class).extracting(Throwable::getCause)
-				.isEqualTo(exception);
+		assertThatThrownBy(future::join).isInstanceOf(CompletionException.class).cause()
+				.isInstanceOf(InterceptorExecutionFailedException.class)
+				.satisfies(e -> assertThat(((InterceptorExecutionFailedException) e).getFailedMessages())
+						.containsExactly(message1))
+				.cause().hasCauseInstanceOf(RuntimeException.class);
 
 		verify(interceptor1).intercept(message1);
 		verify(interceptor2, never()).intercept(any(Message.class));
@@ -202,8 +206,11 @@ class BeforeProcessingContextInterceptorExecutionStageTests {
 				createConfiguration());
 		CompletableFuture<Collection<Message<Object>>> future = stage.process(firstBatch, context);
 		assertThat(future).isCompletedExceptionally();
-		assertThatThrownBy(future::join).isInstanceOf(CompletionException.class).extracting(Throwable::getCause)
-				.isEqualTo(exception);
+		assertThatThrownBy(future::join).isInstanceOf(CompletionException.class).cause()
+				.isInstanceOf(InterceptorExecutionFailedException.class)
+				.satisfies(e -> assertThat(((InterceptorExecutionFailedException) e).getFailedMessages())
+						.containsExactlyElementsOf(firstBatch))
+				.cause().hasCauseInstanceOf(RuntimeException.class);
 
 		verify(interceptor1).intercept(firstBatch);
 		verify(interceptor2, never()).intercept(any(Message.class));

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/pipeline/BeforeProcessingInterceptorExecutionStageTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/pipeline/BeforeProcessingInterceptorExecutionStageTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.awspring.cloud.sqs.listener.AsyncMessageListener;
+import io.awspring.cloud.sqs.listener.InterceptorExecutionFailedException;
 import io.awspring.cloud.sqs.listener.MessageProcessingContext;
 import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementHandler;
 import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
@@ -104,8 +105,10 @@ class BeforeProcessingInterceptorExecutionStageTests {
 		MessageProcessingPipeline<Object> stage = new BeforeProcessingInterceptorExecutionStage<>(
 				createConfiguration(Arrays.asList(interceptor1, interceptor2)));
 		CompletableFuture<Message<Object>> future = stage.process(message1, context);
-		assertThatThrownBy(future::join).isInstanceOf(CompletionException.class).extracting(Throwable::getCause)
-				.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(future::join).isInstanceOf(CompletionException.class).cause()
+				.isInstanceOf(InterceptorExecutionFailedException.class)
+				.satisfies(e -> assertThat(((InterceptorExecutionFailedException) e).getFailedMessages())
+						.containsExactly(message1));
 
 		InOrder inOrder = inOrder(interceptor1, interceptor2);
 		inOrder.verify(interceptor1).intercept(message1);
@@ -222,8 +225,10 @@ class BeforeProcessingInterceptorExecutionStageTests {
 		MessageProcessingPipeline<Object> stage = new BeforeProcessingInterceptorExecutionStage<>(
 				createConfiguration(Arrays.asList(interceptor1, interceptor2)));
 		CompletableFuture<Collection<Message<Object>>> result = stage.process(firstBatch, context);
-		assertThatThrownBy(result::join).isInstanceOf(CompletionException.class).extracting(Throwable::getCause)
-				.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(result::join).isInstanceOf(CompletionException.class).cause()
+				.isInstanceOf(InterceptorExecutionFailedException.class)
+				.satisfies(e -> assertThat(((InterceptorExecutionFailedException) e).getFailedMessages())
+						.containsExactlyElementsOf(firstBatch));
 
 		InOrder inOrder = inOrder(interceptor1, interceptor2);
 		inOrder.verify(interceptor1).intercept(firstBatch);
@@ -249,8 +254,11 @@ class BeforeProcessingInterceptorExecutionStageTests {
 				createConfiguration(Arrays.asList(interceptor1, interceptor2, interceptor3)));
 		CompletableFuture<Message<Object>> future = stage.process(message1, context);
 		assertThat(future).isCompletedExceptionally();
-		assertThatThrownBy(future::join).isInstanceOf(CompletionException.class).extracting(Throwable::getCause)
-				.isEqualTo(exception);
+		assertThatThrownBy(future::join).isInstanceOf(CompletionException.class).cause()
+				.isInstanceOf(InterceptorExecutionFailedException.class)
+				.satisfies(e -> assertThat(((InterceptorExecutionFailedException) e).getFailedMessages())
+						.containsExactly(message1))
+				.cause().hasCauseInstanceOf(RuntimeException.class);
 
 		verify(interceptor1).intercept(message1);
 		verify(interceptor2, never()).intercept(any(Message.class));
@@ -283,8 +291,11 @@ class BeforeProcessingInterceptorExecutionStageTests {
 				createConfiguration(Arrays.asList(interceptor1, interceptor2, interceptor3)));
 		CompletableFuture<Collection<Message<Object>>> future = stage.process(firstBatch, context);
 		assertThat(future).isCompletedExceptionally();
-		assertThatThrownBy(future::join).isInstanceOf(CompletionException.class).extracting(Throwable::getCause)
-				.isEqualTo(exception);
+		assertThatThrownBy(future::join).isInstanceOf(CompletionException.class).cause()
+				.isInstanceOf(InterceptorExecutionFailedException.class)
+				.satisfies(e -> assertThat(((InterceptorExecutionFailedException) e).getFailedMessages())
+						.containsExactlyElementsOf(firstBatch))
+				.cause().hasCauseInstanceOf(RuntimeException.class);
 
 		verify(interceptor1).intercept(firstBatch);
 		verify(interceptor2, never()).intercept(any(Message.class));

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -1209,7 +1209,8 @@ class SqsTemplateTests {
 		SendResult<String> result = template.send(to -> to.queue(queue).payload(payload));
 		assertThat(result.messageId())
 				.isEqualTo(UUID.nameUUIDFromBytes(nonUuidMessageId.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
-		assertThat(result.additionalInformation().get(SqsTemplateParameters.SQS_RAW_MESSAGE_ID_PARAMETER_NAME)).isEqualTo(nonUuidMessageId);
+		assertThat(result.additionalInformation().get(SqsTemplateParameters.SQS_RAW_MESSAGE_ID_PARAMETER_NAME))
+				.isEqualTo(nonUuidMessageId);
 	}
 
 	@Test


### PR DESCRIPTION
## Why

Closes #1595

When a `MessageInterceptor` throws an exception, the `MessageListenerExecutionStage` is never reached, so the exception never gets wrapped in `ListenerExecutionFailedException`. All downstream pipeline stages (`ErrorHandler`, after-processing interceptors, `AcknowledgementHandler`) expect to unwrap a message from the exception chain and fail with `IllegalArgumentException: No ListenerExecutionFailedException found to unwrap messages`.

This breaks valid use cases like interceptor-based idempotency checks that rely on the `ErrorHandler` to gracefully handle rejection.

## What

- Introduce `MessageProcessingException` interface as a common marker for exceptions that carry message references through the processing pipeline
- Add `InterceptorExecutionFailedException` for failures in before-processing interceptors
- `ListenerExecutionFailedException` now implements `MessageProcessingException`; static utility methods deprecated in favour of `MessageProcessingException` equivalents

## How

- Wrap interceptor exceptions in `InterceptorExecutionFailedException` via `exceptionallyCompose` in `AbstractBeforeProcessingInterceptorExecutionStage` (both single and batch paths)
- Update all downstream stages (`ErrorHandlerExecutionStage`, `AbstractAfterProcessingInterceptorExecutionStage`, `AcknowledgementHandlerExecutionStage`) to use `MessageProcessingException` for unwrapping
- Update observation adapter in `AsyncComponentAdapters` to preserve exception type when re-wrapping with updated message headers

## Acceptance Criteria

- [x] Interceptor exceptions wrapped in `InterceptorExecutionFailedException` with message reference
- [x] `ErrorHandler.handle()` invoked for interceptor failures (single and batch)
- [x] After-processing interceptors called on interceptor failure
- [x] `AcknowledgementHandler` works correctly for interceptor failures
- [x] Both blocking and async interceptor paths covered
- [x] Observation adapter preserves exception type when re-wrapping
- [x] No regression in existing tests
- [x] Pipeline composition order unchanged

## Testing

- Updated unit tests in `BeforeProcessingInterceptorExecutionStageTests` and `BeforeProcessingContextInterceptorExecutionStageTests` to assert `InterceptorExecutionFailedException` with correct message references
- Added integration tests verifying `ErrorHandler` and `afterProcessing` interceptor invocation when an interceptor throws (single and batch paths)
- Added integration test verifying end-to-end recovery: interceptor throws → error handler swallows → message acknowledged → listener never called