### PR TITLE
Include failure details in SendBatchOperationFailedException message

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AbstractMessagingTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AbstractMessagingTemplate.java
@@ -400,8 +400,14 @@ public abstract class AbstractMessagingTemplate<S> implements MessagingOperation
 	}
 
 	private <T> CompletableFuture<SendResult.Batch<T>> handleFailedSendBatch(String endpoint,
-			SendResult.Batch<T> result) {
-		return CompletableFuture.failedFuture(new SendBatchOperationFailedException("", endpoint, result));
+	                                                                         SendResult.Batch<T> result) {
+		return CompletableFuture.failedFuture(new SendBatchOperationFailedException(
+			"Batch send operation failed for %d of %d messages to endpoint %s. Failed message IDs: %s. Errors: %s"
+				.formatted(result.failed().size(),
+					result.failed().size() + result.successful().size(), endpoint,
+					MessageHeaderUtils.getId(result.failed().stream().map(SendResult.Failed::message).toList()),
+					result.failed().stream().map(SendResult.Failed::errorMessage)
+						.collect(Collectors.joining("; "))), endpoint, result));
 	}
 
 	private <T> Collection<S> convertMessagesToSend(Collection<Message<T>> messages) {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -574,6 +574,37 @@ class SqsTemplateTests {
 	}
 
 	@Test
+	void shouldIncludeFailureDetailsInBatchExceptionMessage() {
+		String queue = "test-queue";
+		Message<String> message1 = MessageBuilder.withPayload("test-payload-1").build();
+		Message<String> message2 = MessageBuilder.withPayload("test-payload-2").build();
+
+		GetQueueUrlResponse urlResponse = GetQueueUrlResponse.builder().queueUrl(queue).build();
+		given(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+			.willReturn(CompletableFuture.completedFuture(urlResponse));
+		mockQueueAttributes(mockClient, Map.of());
+		SendMessageBatchResponse response = SendMessageBatchResponse.builder()
+			.successful(builder -> builder.id(message1.getHeaders().getId().toString())
+				.messageId(UUID.randomUUID().toString()))
+			.failed(builder -> builder.id(message2.getHeaders().getId().toString()).message("send failed")
+				.code("BC01").senderFault(true))
+			.build();
+		given(mockClient.sendMessageBatch(any(SendMessageBatchRequest.class)))
+			.willReturn(CompletableFuture.completedFuture(response));
+
+		SqsOperations template = SqsTemplate.newSyncTemplate(mockClient);
+		assertThatThrownBy(() -> template.sendMany(queue, List.of(message1, message2)))
+			.isInstanceOf(SendBatchOperationFailedException.class)
+			.isInstanceOfSatisfying(SendBatchOperationFailedException.class, ex -> {
+				assertThat(ex.getMessage())
+					.contains("1 of 2")
+					.contains(queue)
+					.contains(message2.getHeaders().getId().toString())
+					.contains("send failed");
+			});
+	}
+
+	@Test
 	void shouldCreateByDefaultIfQueueNotFound() {
 		String queue = "test-queue";
 		String payload = "test-payload";


### PR DESCRIPTION
 ## :loudspeaker: Type of change
  - [x] Bugfix                                                                                                                         
  - [ ] New feature                                                                                                                                                                                                                                                                                                
  - [ ] Enhancement                                                                                                                                                                                                                                                                                                
  - [ ] Refactoring                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                   
  ## :scroll: Description                                                                                                                                                                                                                                                                                          
  `SendBatchOperationFailedException` was constructed with an empty message string, making it impossible to diagnose batch send failures from the exception message alone. The message now includes the number of failed vs total messages, the target endpoint, the failed message IDs, and the error messages from AWS.                                                                                                                                                                                                                                                                                                        
   
                                                                                                                                                                                                                                                                                                                   
  ## :bulb: Motivation and Context
  When a batch send partially fails, the thrown exception carried no useful information in its message. Callers relying on logging or error reporting had to inspect the exception object programmatically to understand what went wrong.
                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                   
  ## :green_heart: How did you test it?                                                                                                                                                                                                                                                                            
  Added unit test `shouldIncludeFailureDetailsInBatchExceptionMessage` in `SqsTemplateTests` that simulates a partial batch failure and asserts the exception message contains the failed/total count, endpoint name, failed message ID, and error message.                                                        
                                                                                                                                                                                                                                                                                                                   
   
  ## :pencil: Checklist                                                                                                                                                                                                                                                                                            
  - [x] I reviewed submitted code
  - [x] I added tests to verify changes
  - [ ] I updated reference documentation to reflect the change                                                                                                                                                                                                                                                    
  - [ ] All tests passing                                                                                                                                                                                                                                                                                          
  - [ ] No breaking changes                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                   
  ## :crystal_ball: Next steps                                                                                                                                                                                                                                                                                     
  Run the full test suite to confirm no regressions.