### PR TITLE
Avoid reflective copying in SqsContainerOptions builder

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractContainerOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractContainerOptions.java
@@ -315,6 +315,10 @@ public abstract class AbstractContainerOptions<O extends ContainerOptions<O, B>,
 		protected Builder() {
 		}
 
+		protected Builder(Builder<?, ?> builder) {
+			copyStateFrom(builder);
+		}
+
 		protected Builder(AbstractContainerOptions<?, ?> options) {
 			this.maxConcurrentMessages = options.maxConcurrentMessages;
 			this.maxMessagesPerPoll = options.maxMessagesPerPoll;
@@ -336,6 +340,29 @@ public abstract class AbstractContainerOptions<O extends ContainerOptions<O, B>,
 			this.acknowledgementResultTaskExecutor = options.acknowledgementResultTaskExecutor;
 			this.observationRegistry = options.observationRegistry;
 			this.observationConvention = options.observationConvention;
+		}
+
+		protected void copyStateFrom(Builder<?, ?> builder) {
+			this.maxConcurrentMessages = builder.maxConcurrentMessages;
+			this.maxMessagesPerPoll = builder.maxMessagesPerPoll;
+			this.autoStartup = builder.autoStartup;
+			this.pollTimeout = builder.pollTimeout;
+			this.pollBackOffPolicy = builder.pollBackOffPolicy;
+			this.maxDelayBetweenPolls = builder.maxDelayBetweenPolls;
+			this.listenerShutdownTimeout = builder.listenerShutdownTimeout;
+			this.acknowledgementShutdownTimeout = builder.acknowledgementShutdownTimeout;
+			this.backPressureMode = builder.backPressureMode;
+			this.backPressureHandlerFactory = builder.backPressureHandlerFactory;
+			this.listenerMode = builder.listenerMode;
+			this.messageConverter = builder.messageConverter;
+			this.acknowledgementMode = builder.acknowledgementMode;
+			this.acknowledgementOrdering = builder.acknowledgementOrdering;
+			this.acknowledgementInterval = builder.acknowledgementInterval;
+			this.acknowledgementThreshold = builder.acknowledgementThreshold;
+			this.componentsTaskExecutor = builder.componentsTaskExecutor;
+			this.acknowledgementResultTaskExecutor = builder.acknowledgementResultTaskExecutor;
+			this.observationRegistry = builder.observationRegistry;
+			this.observationConvention = builder.observationConvention;
 		}
 
 		@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsContainerOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsContainerOptions.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.ReflectionUtils;
 import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 
@@ -182,6 +181,17 @@ public class SqsContainerOptions extends AbstractContainerOptions<SqsContainerOp
 			this.convertMessageIdToUuid = options.convertMessageIdToUuid;
 		}
 
+		protected BuilderImpl(BuilderImpl builder) {
+			super(builder);
+			this.queueAttributeNames = builder.queueAttributeNames;
+			this.messageAttributeNames = builder.messageAttributeNames;
+			this.messageSystemAttributeNames = builder.messageSystemAttributeNames;
+			this.messageVisibility = builder.messageVisibility;
+			this.fifoBatchGroupingStrategy = builder.fifoBatchGroupingStrategy;
+			this.queueNotFoundStrategy = builder.queueNotFoundStrategy;
+			this.convertMessageIdToUuid = builder.convertMessageIdToUuid;
+		}
+
 		@Override
 		public SqsContainerOptionsBuilder queueAttributeNames(Collection<QueueAttributeName> queueAttributeNames) {
 			Assert.notEmpty(queueAttributeNames, "queueAttributeNames cannot be empty");
@@ -248,14 +258,22 @@ public class SqsContainerOptions extends AbstractContainerOptions<SqsContainerOp
 
 		@Override
 		public SqsContainerOptionsBuilder createCopy() {
-			BuilderImpl builder = new BuilderImpl();
-			ReflectionUtils.shallowCopyFieldState(this, builder);
-			return builder;
+			return new BuilderImpl(this);
 		}
 
 		@Override
 		public void fromBuilder(SqsContainerOptionsBuilder builder) {
-			ReflectionUtils.shallowCopyFieldState(builder, this);
+			Assert.notNull(builder, "builder cannot be null");
+			BuilderImpl source = builder instanceof BuilderImpl ? (BuilderImpl) builder
+					: new BuilderImpl(builder.build());
+			super.copyStateFrom(source);
+			this.queueAttributeNames = source.queueAttributeNames;
+			this.messageAttributeNames = source.messageAttributeNames;
+			this.messageSystemAttributeNames = source.messageSystemAttributeNames;
+			this.messageVisibility = source.messageVisibility;
+			this.fifoBatchGroupingStrategy = source.fifoBatchGroupingStrategy;
+			this.queueNotFoundStrategy = source.queueNotFoundStrategy;
+			this.convertMessageIdToUuid = source.convertMessageIdToUuid;
 		}
 	}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/config/SqsMessageListenerContainerFactoryTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/config/SqsMessageListenerContainerFactoryTests.java
@@ -32,6 +32,7 @@ import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
 import io.awspring.cloud.sqs.listener.errorhandler.ErrorHandler;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor;
+import io.awspring.cloud.sqs.support.converter.MessagingMessageConverter;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -225,5 +226,18 @@ class SqsMessageListenerContainerFactoryTests {
 		assertThat(container.getId()).isEqualTo(id);
 		assertThat(container.getQueueNames()).containsExactlyElementsOf(queueNames);
 
+	}
+
+	@Test
+	void shouldPreserveCustomMessageConverterWhenCreatingContainer() {
+		SqsAsyncClient client = mock(SqsAsyncClient.class);
+		MessagingMessageConverter<Object> converter = mock(MessagingMessageConverter.class);
+		SqsMessageListenerContainerFactory<Object> factory = new SqsMessageListenerContainerFactory<>();
+		factory.setSqsAsyncClient(client);
+		factory.configure(options -> options.messageConverter(converter));
+
+		SqsMessageListenerContainer<Object> container = factory.createContainer("test-queue");
+
+		assertThat(container.getContainerOptions().getMessageConverter()).isSameAs(converter);
 	}
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/ContainerOptionsTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/ContainerOptionsTests.java
@@ -74,10 +74,40 @@ class ContainerOptionsTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
+	void shouldCreateCopyOfBuilderWithCustomMessageConverter() {
+		MessagingMessageConverter<Object> converter = mock(MessagingMessageConverter.class);
+		SqsContainerOptionsBuilder builder = createConfiguredBuilder().messageConverter(converter);
+		SqsContainerOptionsBuilder copy = builder.createCopy();
+		assertThat(copy.build().getMessageConverter()).isSameAs(converter);
+	}
+
+	@Test
+	void shouldCreateCopyOfBuilderBeforeMaxMessagesPerPollValidation() {
+		SqsContainerOptionsBuilder copy = SqsContainerOptions.builder().maxMessagesPerPoll(11).createCopy();
+		SqsContainerOptions options = copy.maxConcurrentMessages(11).build();
+		assertThat(options.getMaxMessagesPerPoll()).isEqualTo(11);
+		assertThat(options.getMaxConcurrentMessages()).isEqualTo(11);
+	}
+
+	@Test
 	void shouldHaveSameFieldsInBuilder() {
 		SqsContainerOptions options = createConfiguredOptions();
 		SqsContainerOptionsBuilder builtCopy = options.toBuilder();
 		assertThat(options).usingRecursiveComparison().isEqualTo(builtCopy);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void shouldCopyBuilderStateWithCustomMessageConverter() {
+		MessagingMessageConverter<Object> converter = mock(MessagingMessageConverter.class);
+		SqsContainerOptionsBuilder source = createConfiguredBuilder().messageConverter(converter);
+		SqsContainerOptionsBuilder target = SqsContainerOptions.builder();
+		target.fromBuilder(source);
+		SqsContainerOptions copiedOptions = target.build();
+		SqsContainerOptions expectedOptions = source.build();
+		assertThat(copiedOptions).usingRecursiveComparison().isEqualTo(expectedOptions);
+		assertThat(copiedOptions.getMessageConverter()).isSameAs(converter);
 	}
 
 	@Test


### PR DESCRIPTION
  ## :loudspeaker: Type of change
  - [x] Bugfix
  - [ ] New feature
  - [ ] Enhancement
  - [ ] Refactoring


  ## :scroll: Description
  Replace reflective builder state copying in `SqsContainerOptions` with explicit field copying.

  This change updates the SQS container options builder copy paths to avoid `ReflectionUtils.shallowCopyFieldState(...)` and preserve custom `messageConverter` configuration when options are copied through builder/container creation flows.

  It also adds regression tests for:
  - builder `createCopy()`
  - `fromBuilder(...)`
  - container creation through `SqsMessageListenerContainerFactory`


  ## :bulb: Motivation and Context
  This fixes the issue where custom `messageConverter` configuration could be lost or behave incorrectly when `SqsContainerOptions` were copied.

  It also removes reflection from this builder-copy path, which is a better fit for AOT/native scenarios.

  Fixes #1598


  ## :green_heart: How did you test it?
  Ran focused SQS tests covering the changed code paths:

  - `mvn -o -pl spring-cloud-aws-sqs -Dtest=ContainerOptionsTests,SqsMessageListenerContainerFactoryTests test`

  Also verified the project still packages successfully with tests skipped:

  - `mvn -o -DskipTests clean package`



  ## :pencil: Checklist
  - [x] I reviewed submitted code
  - [x] I added tests to verify changes
  - [ ] I updated reference documentation to reflect the change
  - [ ] All tests passing
  - [x] No breaking changes


  ## :crystal_ball: Next steps
  None.