### PR TITLE
#1619 Mark com.fasterxml jackson-databind as optional in S3 module

### DIFF
--- a/spring-cloud-aws-s3/pom.xml
+++ b/spring-cloud-aws-s3/pom.xml
@@ -53,6 +53,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description

Mark `com.fasterxml.jackson.core:jackson-databind` as `<optional>true</optional>` in `spring-cloud-aws-s3/pom.xml`, matching SQS, SNS, and Secrets Manager which already declare it optional.

## :bulb: Motivation and Context

The `tools.jackson.core:jackson-databind` entry added in #1539 is correctly optional, but the `com.fasterxml` entry was missed. This causes `com.fasterxml` jackson-databind (and its transitives) to leak onto the classpath of any project using `spring-cloud-aws-starter-s3`.

Closes #1619

## :green_heart: How did you test it?

Ran the S3 module tests (`./mvnw test -pl spring-cloud-aws-s3 -am`): 103 tests, 0 failures.

## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps