### PR TITLE
Feature: SQS Heartbeating

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -815,6 +815,10 @@ See <<FIFO Support>> for more information.
 - `acknowledgementMode` - Set the acknowledgement mode for the container.
 If any value is set, it will take precedence over the acknowledgement mode defined for the container factory options.
 See <<Acknowledgement Mode>> for more information.
+- `messageVisibilityHeartbeatIntervalSeconds` - Set the interval for sending visibility heartbeats for messages that are being processed.
+Note that this is optional and used in conjunction with `messageVisibilityHeartbeatSeconds`.
+- `messageVisibilityHeartbeatSeconds` - Set the visibility timeout extension to be applied in the heartbeats for messages that are being processed.
+Note that this is optional and used in conjunction with `messageVisibilityHeartbeatIntervalSeconds`, and make sure the interval is shorter than this value.
 
 ===== Listener Method Arguments
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListener.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListener.java
@@ -141,6 +141,16 @@ public @interface SqsListener {
 	String messageVisibilitySeconds() default "";
 
 	/**
+	 * Interval between visibility heartbeat requests sent while listener execution is in progress.
+	 */
+	String messageVisibilityHeartbeatIntervalSeconds() default "";
+
+	/**
+	 * Visibility timeout to apply on each visibility heartbeat request.
+	 */
+	String messageVisibilityHeartbeatSeconds() default "";
+
+	/**
 	 * The acknowledgement mode to be used for the provided queues. If not specified, the acknowledgement mode defined
 	 * for the container factory will be used.
 	 */

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessor.java
@@ -68,6 +68,11 @@ public class SqsListenerAnnotationBeanPostProcessor extends AbstractListenerAnno
 						resolveAsInteger(sqsListenerAnnotation.maxConcurrentMessages(), "maxConcurrentMessages"))
 				.messageVisibility(
 						resolveAsInteger(sqsListenerAnnotation.messageVisibilitySeconds(), "messageVisibility"))
+				.messageVisibilityHeartbeatInterval(
+						resolveAsInteger(sqsListenerAnnotation.messageVisibilityHeartbeatIntervalSeconds(),
+								"messageVisibilityHeartbeatInterval"))
+				.messageVisibilityHeartbeat(resolveAsInteger(sqsListenerAnnotation.messageVisibilityHeartbeatSeconds(),
+						"messageVisibilityHeartbeat"))
 				.acknowledgementMode(resolveAcknowledgement(sqsListenerAnnotation.acknowledgementMode())).build();
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/SqsEndpoint.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/SqsEndpoint.java
@@ -38,6 +38,10 @@ public class SqsEndpoint extends AbstractEndpoint {
 
 	private final Integer messageVisibility;
 
+	private final Integer messageVisibilityHeartbeatInterval;
+
+	private final Integer messageVisibilityHeartbeat;
+
 	private final Integer maxMessagesPerPoll;
 
 	@Nullable
@@ -48,6 +52,8 @@ public class SqsEndpoint extends AbstractEndpoint {
 		this.maxConcurrentMessages = builder.maxConcurrentMessages;
 		this.pollTimeoutSeconds = builder.pollTimeoutSeconds;
 		this.messageVisibility = builder.messageVisibility;
+		this.messageVisibilityHeartbeatInterval = builder.messageVisibilityHeartbeatInterval;
+		this.messageVisibilityHeartbeat = builder.messageVisibilityHeartbeat;
 		this.maxMessagesPerPoll = builder.maxMessagesPerPoll;
 		this.acknowledgementMode = builder.acknowledgementMode;
 	}
@@ -98,6 +104,26 @@ public class SqsEndpoint extends AbstractEndpoint {
 	}
 
 	/**
+	 * Return the visibility heartbeat interval for this endpoint.
+	 * @return the visibility heartbeat interval.
+	 */
+	@Nullable
+	public Duration getMessageVisibilityHeartbeatInterval() {
+		return this.messageVisibilityHeartbeatInterval != null
+				? Duration.ofSeconds(this.messageVisibilityHeartbeatInterval)
+				: null;
+	}
+
+	/**
+	 * Return the visibility timeout to apply on each heartbeat request for this endpoint.
+	 * @return the visibility heartbeat timeout.
+	 */
+	@Nullable
+	public Duration getMessageVisibilityHeartbeat() {
+		return this.messageVisibilityHeartbeat != null ? Duration.ofSeconds(this.messageVisibilityHeartbeat) : null;
+	}
+
+	/**
 	 * Returns the acknowledgement mode configured for this endpoint.
 	 * @return the acknowledgement mode.
 	 */
@@ -117,6 +143,10 @@ public class SqsEndpoint extends AbstractEndpoint {
 		private String factoryName;
 
 		private Integer messageVisibility;
+
+		private Integer messageVisibilityHeartbeatInterval;
+
+		private Integer messageVisibilityHeartbeat;
 
 		private String id;
 
@@ -152,6 +182,16 @@ public class SqsEndpoint extends AbstractEndpoint {
 
 		public SqsEndpointBuilder messageVisibility(Integer messageVisibility) {
 			this.messageVisibility = messageVisibility;
+			return this;
+		}
+
+		public SqsEndpointBuilder messageVisibilityHeartbeatInterval(Integer messageVisibilityHeartbeatInterval) {
+			this.messageVisibilityHeartbeatInterval = messageVisibilityHeartbeatInterval;
+			return this;
+		}
+
+		public SqsEndpointBuilder messageVisibilityHeartbeat(Integer messageVisibilityHeartbeat) {
+			this.messageVisibilityHeartbeat = messageVisibilityHeartbeat;
 			return this;
 		}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/SqsMessageListenerContainerFactory.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/SqsMessageListenerContainerFactory.java
@@ -173,6 +173,10 @@ public class SqsMessageListenerContainerFactory<T> extends
 				.acceptIfNotNull(sqsEndpoint.getMaxMessagesPerPoll(), options::maxMessagesPerPoll)
 				.acceptIfNotNull(sqsEndpoint.getPollTimeout(), options::pollTimeout)
 				.acceptIfNotNull(sqsEndpoint.getMessageVisibility(), options::messageVisibility)
+				.acceptIfNotNull(sqsEndpoint.getMessageVisibilityHeartbeatInterval(),
+						options::messageVisibilityHeartbeatInterval)
+				.acceptIfNotNull(sqsEndpoint.getMessageVisibilityHeartbeat(),
+						options::messageVisibilityHeartbeatTimeout)
 				.acceptIfNotNull(sqsEndpoint.getAcknowledgementMode(), options::acknowledgementMode);
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/FifoSqsComponentFactory.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/FifoSqsComponentFactory.java
@@ -27,6 +27,7 @@ import io.awspring.cloud.sqs.listener.sink.MessageSink;
 import io.awspring.cloud.sqs.listener.sink.OrderedMessageSink;
 import io.awspring.cloud.sqs.listener.sink.adapter.MessageGroupingSinkAdapter;
 import io.awspring.cloud.sqs.listener.sink.adapter.MessageVisibilityExtendingSinkAdapter;
+import io.awspring.cloud.sqs.listener.sink.adapter.MessageVisibilityHeartbeatSinkAdapter;
 import io.awspring.cloud.sqs.listener.source.FifoSqsMessageSource;
 import io.awspring.cloud.sqs.listener.source.MessageSource;
 import java.time.Duration;
@@ -72,6 +73,8 @@ public class FifoSqsComponentFactory<T> implements ContainerComponentFactory<T, 
 		MessageSink<T> deliverySink = createDeliverySink(options.getListenerMode());
 		MessageSink<T> wrappedDeliverySink = maybeWrapWithVisibilityAdapter(deliverySink,
 				options.getMessageVisibility());
+		wrappedDeliverySink = maybeWrapWithVisibilityHeartbeatAdapter(wrappedDeliverySink,
+				options.getMessageVisibilityHeartbeatInterval(), options.getMessageVisibilityHeartbeatTimeout());
 		return maybeWrapWithMessageGroupingAdapter(options, wrappedDeliverySink);
 	}
 
@@ -102,6 +105,18 @@ public class FifoSqsComponentFactory<T> implements ContainerComponentFactory<T, 
 				deliverySink);
 		visibilityAdapter.setMessageVisibility(messageVisibility);
 		return visibilityAdapter;
+	}
+
+	private MessageSink<T> maybeWrapWithVisibilityHeartbeatAdapter(MessageSink<T> deliverySink,
+			@Nullable Duration heartbeatInterval, @Nullable Duration heartbeatTimeout) {
+		if (heartbeatInterval == null || heartbeatTimeout == null) {
+			return deliverySink;
+		}
+		MessageVisibilityHeartbeatSinkAdapter<T> heartbeatAdapter = new MessageVisibilityHeartbeatSinkAdapter<>(
+				deliverySink);
+		heartbeatAdapter.setHeartbeatInterval(heartbeatInterval);
+		heartbeatAdapter.setHeartbeatVisibilityTimeout(heartbeatTimeout);
+		return heartbeatAdapter;
 	}
 
 	private Function<Message<T>, String> getMessageGroupingFunction() {

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsContainerOptions.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsContainerOptions.java
@@ -40,6 +40,12 @@ public class SqsContainerOptions extends AbstractContainerOptions<SqsContainerOp
 	@Nullable
 	private final Duration messageVisibility;
 
+	@Nullable
+	private final Duration messageVisibilityHeartbeatInterval;
+
+	@Nullable
+	private final Duration messageVisibilityHeartbeatTimeout;
+
 	private final FifoBatchGroupingStrategy fifoBatchGroupingStrategy;
 
 	private final Collection<QueueAttributeName> queueAttributeNames;
@@ -62,6 +68,8 @@ public class SqsContainerOptions extends AbstractContainerOptions<SqsContainerOp
 		this.messageAttributeNames = builder.messageAttributeNames;
 		this.messageSystemAttributeNames = builder.messageSystemAttributeNames;
 		this.messageVisibility = builder.messageVisibility;
+		this.messageVisibilityHeartbeatInterval = builder.messageVisibilityHeartbeatInterval;
+		this.messageVisibilityHeartbeatTimeout = builder.messageVisibilityHeartbeatTimeout;
 		this.queueNotFoundStrategy = builder.queueNotFoundStrategy;
 		this.fifoBatchGroupingStrategy = builder.fifoBatchGroupingStrategy;
 		this.convertMessageIdToUuid = builder.convertMessageIdToUuid;
@@ -106,6 +114,24 @@ public class SqsContainerOptions extends AbstractContainerOptions<SqsContainerOp
 	@Nullable
 	public Duration getMessageVisibility() {
 		return this.messageVisibility;
+	}
+
+	/**
+	 * Get the interval between visibility heartbeat requests sent while a message is being processed.
+	 * @return the heartbeat interval.
+	 */
+	@Nullable
+	public Duration getMessageVisibilityHeartbeatInterval() {
+		return this.messageVisibilityHeartbeatInterval;
+	}
+
+	/**
+	 * Get the visibility timeout to apply on each visibility heartbeat request.
+	 * @return the heartbeat timeout.
+	 */
+	@Nullable
+	public Duration getMessageVisibilityHeartbeatTimeout() {
+		return this.messageVisibilityHeartbeatTimeout;
 	}
 
 	/**
@@ -165,6 +191,12 @@ public class SqsContainerOptions extends AbstractContainerOptions<SqsContainerOp
 		@Nullable
 		private Duration messageVisibility;
 
+		@Nullable
+		private Duration messageVisibilityHeartbeatInterval;
+
+		@Nullable
+		private Duration messageVisibilityHeartbeatTimeout;
+
 		private boolean convertMessageIdToUuid = true;
 
 		protected BuilderImpl() {
@@ -177,6 +209,8 @@ public class SqsContainerOptions extends AbstractContainerOptions<SqsContainerOp
 			this.messageAttributeNames = options.messageAttributeNames;
 			this.messageSystemAttributeNames = options.messageSystemAttributeNames;
 			this.messageVisibility = options.messageVisibility;
+			this.messageVisibilityHeartbeatInterval = options.messageVisibilityHeartbeatInterval;
+			this.messageVisibilityHeartbeatTimeout = options.messageVisibilityHeartbeatTimeout;
 			this.fifoBatchGroupingStrategy = options.fifoBatchGroupingStrategy;
 			this.queueNotFoundStrategy = options.queueNotFoundStrategy;
 			this.convertMessageIdToUuid = options.convertMessageIdToUuid;
@@ -209,6 +243,28 @@ public class SqsContainerOptions extends AbstractContainerOptions<SqsContainerOp
 		public SqsContainerOptionsBuilder messageVisibility(Duration messageVisibility) {
 			Assert.notNull(messageVisibility, "messageVisibility cannot be null");
 			this.messageVisibility = messageVisibility;
+			return this;
+		}
+
+		@Override
+		public SqsContainerOptionsBuilder messageVisibilityHeartbeatInterval(
+				Duration messageVisibilityHeartbeatInterval) {
+			Assert.notNull(messageVisibilityHeartbeatInterval, "messageVisibilityHeartbeatInterval cannot be null");
+			Assert.isTrue(
+					!messageVisibilityHeartbeatInterval.isNegative() && !messageVisibilityHeartbeatInterval.isZero(),
+					"messageVisibilityHeartbeatInterval must be greater than zero");
+			this.messageVisibilityHeartbeatInterval = messageVisibilityHeartbeatInterval;
+			return this;
+		}
+
+		@Override
+		public SqsContainerOptionsBuilder messageVisibilityHeartbeatTimeout(
+				Duration messageVisibilityHeartbeatTimeout) {
+			Assert.notNull(messageVisibilityHeartbeatTimeout, "messageVisibilityHeartbeatTimeout cannot be null");
+			Assert.isTrue(
+					!messageVisibilityHeartbeatTimeout.isNegative() && !messageVisibilityHeartbeatTimeout.isZero(),
+					"messageVisibilityHeartbeatTimeout must be greater than zero");
+			this.messageVisibilityHeartbeatTimeout = messageVisibilityHeartbeatTimeout;
 			return this;
 		}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsContainerOptionsBuilder.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/SqsContainerOptionsBuilder.java
@@ -61,6 +61,20 @@ public interface SqsContainerOptionsBuilder
 	SqsContainerOptionsBuilder messageVisibility(Duration messageVisibility);
 
 	/**
+	 * Set the interval between visibility heartbeat requests sent while a message is being processed.
+	 * @param messageVisibilityHeartbeatInterval the heartbeat interval.
+	 * @return this instance.
+	 */
+	SqsContainerOptionsBuilder messageVisibilityHeartbeatInterval(Duration messageVisibilityHeartbeatInterval);
+
+	/**
+	 * Set the visibility timeout to apply on each visibility heartbeat request.
+	 * @param messageVisibilityHeartbeatTimeout the timeout to set on each heartbeat.
+	 * @return this instance.
+	 */
+	SqsContainerOptionsBuilder messageVisibilityHeartbeatTimeout(Duration messageVisibilityHeartbeatTimeout);
+
+	/**
 	 * Set how the messages from FIFO queues should be grouped when container listener mode is
 	 * {@link ListenerMode#BATCH}. By default, messages are grouped in batches by message group, which are processed in
 	 * parallel, maintaining order within each message group.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/StandardSqsComponentFactory.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/StandardSqsComponentFactory.java
@@ -24,10 +24,12 @@ import io.awspring.cloud.sqs.listener.acknowledgement.ImmediateAcknowledgementPr
 import io.awspring.cloud.sqs.listener.sink.BatchMessageSink;
 import io.awspring.cloud.sqs.listener.sink.FanOutMessageSink;
 import io.awspring.cloud.sqs.listener.sink.MessageSink;
+import io.awspring.cloud.sqs.listener.sink.adapter.MessageVisibilityHeartbeatSinkAdapter;
 import io.awspring.cloud.sqs.listener.source.MessageSource;
 import io.awspring.cloud.sqs.listener.source.StandardSqsMessageSource;
 import java.time.Duration;
 import java.util.Collection;
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -57,11 +59,25 @@ public class StandardSqsComponentFactory<T> implements ContainerComponentFactory
 	// @formatter:off
 	@Override
 	public MessageSink<T> createMessageSink(SqsContainerOptions options) {
-		return ListenerMode.SINGLE_MESSAGE.equals(options.getListenerMode())
+		MessageSink<T> messageSink = ListenerMode.SINGLE_MESSAGE.equals(options.getListenerMode())
 			? new FanOutMessageSink<>()
 			: new BatchMessageSink<>();
+		return maybeWrapWithVisibilityHeartbeatAdapter(messageSink,
+				options.getMessageVisibilityHeartbeatInterval(), options.getMessageVisibilityHeartbeatTimeout());
 	}
 	// @formatter:on
+
+	private MessageSink<T> maybeWrapWithVisibilityHeartbeatAdapter(MessageSink<T> messageSink,
+			@Nullable Duration heartbeatInterval, @Nullable Duration heartbeatTimeout) {
+		if (heartbeatInterval == null || heartbeatTimeout == null) {
+			return messageSink;
+		}
+		MessageVisibilityHeartbeatSinkAdapter<T> heartbeatSinkAdapter = new MessageVisibilityHeartbeatSinkAdapter<>(
+				messageSink);
+		heartbeatSinkAdapter.setHeartbeatInterval(heartbeatInterval);
+		heartbeatSinkAdapter.setHeartbeatVisibilityTimeout(heartbeatTimeout);
+		return heartbeatSinkAdapter;
+	}
 
 	@Override
 	public AcknowledgementProcessor<T> createAcknowledgementProcessor(SqsContainerOptions options) {

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/sink/adapter/MessageVisibilityHeartbeatSinkAdapter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/sink/adapter/MessageVisibilityHeartbeatSinkAdapter.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2013-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.sink.adapter;
+
+import io.awspring.cloud.sqs.MessageHeaderUtils;
+import io.awspring.cloud.sqs.listener.BatchVisibility;
+import io.awspring.cloud.sqs.listener.MessageProcessingContext;
+import io.awspring.cloud.sqs.listener.QueueMessageVisibility;
+import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
+import io.awspring.cloud.sqs.listener.sink.MessageSink;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.messaging.Message;
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link AbstractDelegatingMessageListeningSinkAdapter} that adds an interceptor responsible for periodically
+ * extending visibility while a message (or message batch) is being processed.
+ *
+ * @author Tomaz Fernandes
+ * @since 3.5
+ */
+public class MessageVisibilityHeartbeatSinkAdapter<T> extends AbstractDelegatingMessageListeningSinkAdapter<T> {
+
+	private static final Logger logger = LoggerFactory.getLogger(MessageVisibilityHeartbeatSinkAdapter.class);
+
+	private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofSeconds(10);
+
+	private static final Duration DEFAULT_HEARTBEAT_VISIBILITY_TIMEOUT = Duration.ofSeconds(30);
+
+	private static final String THREAD_NAME_PREFIX = "sqs-message-visibility-heartbeat-";
+
+	private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
+
+	private int heartbeatVisibilityTimeoutSeconds = (int) DEFAULT_HEARTBEAT_VISIBILITY_TIMEOUT.getSeconds();
+
+	private volatile boolean running;
+
+	private final Object lifecycleMonitor = new Object();
+
+	@Nullable
+	private ScheduledExecutorService scheduler;
+
+	public MessageVisibilityHeartbeatSinkAdapter(MessageSink<T> delegate) {
+		super(delegate);
+	}
+
+	public void setHeartbeatInterval(Duration heartbeatInterval) {
+		Assert.notNull(heartbeatInterval, "heartbeatInterval cannot be null");
+		Assert.isTrue(!heartbeatInterval.isNegative() && !heartbeatInterval.isZero(),
+				"heartbeatInterval must be greater than zero");
+		this.heartbeatInterval = heartbeatInterval;
+	}
+
+	public void setHeartbeatVisibilityTimeout(Duration heartbeatVisibilityTimeout) {
+		Assert.notNull(heartbeatVisibilityTimeout, "heartbeatVisibilityTimeout cannot be null");
+		Assert.isTrue(!heartbeatVisibilityTimeout.isNegative() && !heartbeatVisibilityTimeout.isZero(),
+				"heartbeatVisibilityTimeout must be greater than zero");
+		this.heartbeatVisibilityTimeoutSeconds = (int) heartbeatVisibilityTimeout.getSeconds();
+	}
+
+	@Override
+	public CompletableFuture<Void> emit(Collection<Message<T>> messages, MessageProcessingContext<T> context) {
+		logger.trace("Adding visibility heartbeat interceptor for messages {}", MessageHeaderUtils.getId(messages));
+		return getDelegate().emit(messages,
+				context.addInterceptor(new MessageVisibilityHeartbeatInterceptor(messages)));
+	}
+
+	@Override
+	public void start() {
+		if (isRunning()) {
+			return;
+		}
+		synchronized (this.lifecycleMonitor) {
+			if (isRunning()) {
+				return;
+			}
+			this.scheduler = createScheduler();
+			super.start();
+			this.running = true;
+		}
+	}
+
+	@Override
+	public void stop() {
+		if (!isRunning()) {
+			return;
+		}
+		synchronized (this.lifecycleMonitor) {
+			if (!isRunning()) {
+				return;
+			}
+			this.running = false;
+			ScheduledExecutorService localScheduler = this.scheduler;
+			this.scheduler = null;
+			if (localScheduler != null) {
+				localScheduler.shutdownNow();
+			}
+			super.stop();
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.running && super.isRunning();
+	}
+
+	protected ScheduledExecutorService createScheduler() {
+		return Executors.newSingleThreadScheduledExecutor(new CustomizableThreadFactory(THREAD_NAME_PREFIX));
+	}
+
+	private class MessageVisibilityHeartbeatInterceptor implements AsyncMessageInterceptor<T> {
+
+		private final Collection<Message<T>> originalMessages;
+
+		private final Map<String, ScheduledFuture<?>> runningMessageHeartbeats = new ConcurrentHashMap<>();
+
+		@Nullable
+		private ScheduledFuture<?> runningBatchHeartbeat;
+
+		MessageVisibilityHeartbeatInterceptor(Collection<Message<T>> originalMessages) {
+			this.originalMessages = Collections.unmodifiableCollection(new ArrayList<>(originalMessages));
+		}
+
+		@Override
+		public CompletableFuture<Message<T>> intercept(Message<T> message) {
+			String messageId = MessageHeaderUtils.getId(message);
+			this.runningMessageHeartbeats.computeIfAbsent(messageId,
+					id -> scheduleHeartbeat(() -> getMessageVisibility(message).changeToAsync(
+							MessageVisibilityHeartbeatSinkAdapter.this.heartbeatVisibilityTimeoutSeconds), id));
+			return CompletableFuture.completedFuture(message);
+		}
+
+		@Override
+		public CompletableFuture<Collection<Message<T>>> intercept(Collection<Message<T>> messages) {
+			if (this.runningBatchHeartbeat == null) {
+				this.runningBatchHeartbeat = scheduleHeartbeat(
+						() -> getBatchVisibility(messages).changeToAsync(
+								MessageVisibilityHeartbeatSinkAdapter.this.heartbeatVisibilityTimeoutSeconds),
+						MessageHeaderUtils.getId(messages));
+			}
+			return CompletableFuture.completedFuture(messages);
+		}
+
+		@Override
+		public CompletableFuture<Void> afterProcessing(Message<T> message, @Nullable Throwable t) {
+			String messageId = MessageHeaderUtils.getId(message);
+			cancelHeartbeat(this.runningMessageHeartbeats.remove(messageId), messageId);
+			return CompletableFuture.completedFuture(null);
+		}
+
+		@Override
+		public CompletableFuture<Void> afterProcessing(Collection<Message<T>> messages, @Nullable Throwable t) {
+			cancelHeartbeat(this.runningBatchHeartbeat, MessageHeaderUtils.getId(messages));
+			this.runningBatchHeartbeat = null;
+			this.originalMessages.forEach(msg -> {
+				String id = MessageHeaderUtils.getId(msg);
+				cancelHeartbeat(this.runningMessageHeartbeats.remove(id), id);
+			});
+			return CompletableFuture.completedFuture(null);
+		}
+
+		private ScheduledFuture<?> scheduleHeartbeat(Supplier<CompletableFuture<Void>> heartbeatAction, String id) {
+			ScheduledExecutorService localScheduler = MessageVisibilityHeartbeatSinkAdapter.this.scheduler;
+			Assert.state(localScheduler != null, "heartbeat scheduler not initialized");
+			logger.trace("Scheduling visibility heartbeat for {} every {}ms", id,
+					MessageVisibilityHeartbeatSinkAdapter.this.heartbeatInterval.toMillis());
+			return localScheduler.scheduleAtFixedRate(() -> {
+				try {
+					heartbeatAction.get().whenComplete((v, t) -> {
+						if (t != null) {
+							logger.warn("Error sending visibility heartbeat for {}", id, t);
+						}
+						else {
+							logger.trace("Visibility heartbeat sent for {}", id);
+						}
+					});
+				}
+				catch (Exception ex) {
+					logger.warn("Error preparing visibility heartbeat for {}", id, ex);
+				}
+			}, MessageVisibilityHeartbeatSinkAdapter.this.heartbeatInterval.toMillis(),
+					MessageVisibilityHeartbeatSinkAdapter.this.heartbeatInterval.toMillis(), TimeUnit.MILLISECONDS);
+		}
+
+		private void cancelHeartbeat(@Nullable ScheduledFuture<?> future, String id) {
+			if (future != null) {
+				future.cancel(true);
+				logger.trace("Cancelled visibility heartbeat for {}", id);
+			}
+		}
+
+		private QueueMessageVisibility getMessageVisibility(Message<T> message) {
+			return MessageHeaderUtils.getHeader(message, SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER,
+					QueueMessageVisibility.class);
+		}
+
+		@SuppressWarnings("unchecked")
+		private BatchVisibility getBatchVisibility(Collection<Message<T>> messages) {
+			QueueMessageVisibility visibility = getMessageVisibility(messages.iterator().next());
+			return visibility.toBatchVisibility((Collection<Message<?>>) (Collection<?>) messages);
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/sink/adapter/MessageVisibilityHeartbeatSinkAdapter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/sink/adapter/MessageVisibilityHeartbeatSinkAdapter.java
@@ -44,9 +44,14 @@ import org.springframework.util.Assert;
 /**
  * A {@link AbstractDelegatingMessageListeningSinkAdapter} that adds an interceptor responsible for periodically
  * extending visibility while a message (or message batch) is being processed.
+ * This is known as heart beating and recommended in SQS best practices for cases when expected duration is unknown.
+ * See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html#visibility-timeout-best-practices
+ * > If you're unsure about the exact processing time, begin with a shorter timeout (for example, 2 minutes)
+ *   and extend it as necessary. Implement a heartbeat mechanism to periodically extend the visibility timeout,
+ *   ensuring the message remains invisible until processing is complete.
  *
- * @author Tomaz Fernandes
- * @since 3.5
+ * @author kzurawski
+ * @since 4.1.0
  */
 public class MessageVisibilityHeartbeatSinkAdapter<T> extends AbstractDelegatingMessageListeningSinkAdapter<T> {
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessorTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/annotation/SqsListenerAnnotationBeanPostProcessorTests.java
@@ -31,6 +31,7 @@ import io.awspring.cloud.sqs.listener.MessageListenerContainer;
 import io.awspring.cloud.sqs.listener.MessageListenerContainerRegistry;
 import io.awspring.cloud.sqs.support.converter.legacy.LegacyJackson2MessageConverterMigration;
 import io.awspring.cloud.sqs.support.resolver.BatchPayloadMethodArgumentResolver;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -258,6 +259,33 @@ class SqsListenerAnnotationBeanPostProcessorTests {
 		});
 	}
 
+	@Test
+	void shouldMapVisibilityHeartbeatFromAnnotationToEndpoint() {
+		ListableBeanFactory beanFactory = mock(ListableBeanFactory.class);
+		MessageListenerContainerRegistry registry = mock(MessageListenerContainerRegistry.class);
+		MessageListenerContainerFactory<?> factory = mock(MessageListenerContainerFactory.class);
+
+		when(beanFactory.getBean(SqsBeanNames.ENDPOINT_REGISTRY_BEAN_NAME, MessageListenerContainerRegistry.class))
+				.thenReturn(registry);
+		when(beanFactory.containsBean(EndpointRegistrar.DEFAULT_LISTENER_CONTAINER_FACTORY_BEAN_NAME)).thenReturn(true);
+		when(beanFactory.getBean(EndpointRegistrar.DEFAULT_LISTENER_CONTAINER_FACTORY_BEAN_NAME,
+				MessageListenerContainerFactory.class)).thenReturn(factory);
+
+		SqsListenerAnnotationBeanPostProcessor processor = new SqsListenerAnnotationBeanPostProcessor();
+
+		HeartbeatListener bean = new HeartbeatListener();
+		processor.setBeanFactory(beanFactory);
+		processor.postProcessAfterInitialization(bean, "heartbeatListener");
+		processor.afterSingletonsInstantiated();
+
+		ArgumentCaptor<Endpoint> captor = ArgumentCaptor.forClass(Endpoint.class);
+		then(factory).should().createContainer(captor.capture());
+		assertThat(captor.getValue()).isInstanceOfSatisfying(SqsEndpoint.class, endpoint -> {
+			assertThat(endpoint.getMessageVisibilityHeartbeatInterval()).isEqualTo(Duration.ofSeconds(3));
+			assertThat(endpoint.getMessageVisibilityHeartbeat()).isEqualTo(Duration.ofSeconds(20));
+		});
+	}
+
 	static class Listener {
 
 		@SqsListener("myQueue")
@@ -288,6 +316,14 @@ class SqsListenerAnnotationBeanPostProcessorTests {
 		}
 
 		@SqsListener("#{ sqsQueueNameReader.listQueueNames() }")
+		void listen(String message) {
+		}
+
+	}
+
+	static class HeartbeatListener {
+
+		@SqsListener(queueNames = "heartbeatQueue", messageVisibilityHeartbeatIntervalSeconds = "3", messageVisibilityHeartbeatSeconds = "20")
 		void listen(String message) {
 		}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/config/SqsMessageListenerContainerFactoryTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/config/SqsMessageListenerContainerFactoryTests.java
@@ -56,6 +56,8 @@ class SqsMessageListenerContainerFactoryTests {
 		SqsEndpoint endpoint = mock(SqsEndpoint.class);
 		given(endpoint.getMaxConcurrentMessages()).willReturn(null);
 		given(endpoint.getMessageVisibility()).willReturn(null);
+		given(endpoint.getMessageVisibilityHeartbeatInterval()).willReturn(null);
+		given(endpoint.getMessageVisibilityHeartbeat()).willReturn(null);
 		given(endpoint.getMaxMessagesPerPoll()).willReturn(null);
 		given(endpoint.getPollTimeout()).willReturn(null);
 		given(endpoint.getLogicalNames()).willReturn(queueNames);
@@ -87,8 +89,12 @@ class SqsMessageListenerContainerFactoryTests {
 		int messagesPerPoll = 7;
 		Duration pollTimeout = Duration.ofSeconds(6);
 		Duration visibility = Duration.ofSeconds(8);
+		Duration heartbeatInterval = Duration.ofSeconds(2);
+		Duration heartbeatTimeout = Duration.ofSeconds(12);
 		given(endpoint.getMaxConcurrentMessages()).willReturn(inflight);
 		given(endpoint.getMessageVisibility()).willReturn(visibility);
+		given(endpoint.getMessageVisibilityHeartbeatInterval()).willReturn(heartbeatInterval);
+		given(endpoint.getMessageVisibilityHeartbeat()).willReturn(heartbeatTimeout);
 		given(endpoint.getMaxMessagesPerPoll()).willReturn(messagesPerPoll);
 		given(endpoint.getPollTimeout()).willReturn(pollTimeout);
 		given(endpoint.getLogicalNames()).willReturn(queueNames);
@@ -101,6 +107,8 @@ class SqsMessageListenerContainerFactoryTests {
 		assertThat(container.getContainerOptions()).isInstanceOfSatisfying(SqsContainerOptions.class, options -> {
 			assertThat(options.getMaxConcurrentMessages()).isEqualTo(inflight);
 			assertThat(options.getMessageVisibility()).isEqualTo(visibility);
+			assertThat(options.getMessageVisibilityHeartbeatInterval()).isEqualTo(heartbeatInterval);
+			assertThat(options.getMessageVisibilityHeartbeatTimeout()).isEqualTo(heartbeatTimeout);
 			assertThat(options.getPollTimeout()).isEqualTo(pollTimeout);
 			assertThat(options.getMaxMessagesPerPoll()).isEqualTo(messagesPerPoll);
 		});
@@ -171,6 +179,8 @@ class SqsMessageListenerContainerFactoryTests {
 
 		given(sqsEndpoint.getMaxConcurrentMessages()).willReturn(null);
 		given(sqsEndpoint.getMessageVisibility()).willReturn(null);
+		given(sqsEndpoint.getMessageVisibilityHeartbeatInterval()).willReturn(null);
+		given(sqsEndpoint.getMessageVisibilityHeartbeat()).willReturn(null);
 		given(sqsEndpoint.getMaxMessagesPerPoll()).willReturn(null);
 		given(sqsEndpoint.getPollTimeout()).willReturn(null);
 		given(multiMethodSqsEndpoint.getLogicalNames()).willReturn(queueNames);
@@ -203,8 +213,12 @@ class SqsMessageListenerContainerFactoryTests {
 		int messagesPerPoll = 7;
 		Duration pollTimeout = Duration.ofSeconds(6);
 		Duration visibility = Duration.ofSeconds(8);
+		Duration heartbeatInterval = Duration.ofSeconds(2);
+		Duration heartbeatTimeout = Duration.ofSeconds(12);
 		given(sqsEndpoint.getMaxConcurrentMessages()).willReturn(inflight);
 		given(sqsEndpoint.getMessageVisibility()).willReturn(visibility);
+		given(sqsEndpoint.getMessageVisibilityHeartbeatInterval()).willReturn(heartbeatInterval);
+		given(sqsEndpoint.getMessageVisibilityHeartbeat()).willReturn(heartbeatTimeout);
 		given(sqsEndpoint.getMaxMessagesPerPoll()).willReturn(messagesPerPoll);
 		given(sqsEndpoint.getPollTimeout()).willReturn(pollTimeout);
 		given(multiMethodSqsEndpoint.getLogicalNames()).willReturn(queueNames);
@@ -218,6 +232,8 @@ class SqsMessageListenerContainerFactoryTests {
 		assertThat(container.getContainerOptions()).isInstanceOfSatisfying(SqsContainerOptions.class, options -> {
 			assertThat(options.getMaxConcurrentMessages()).isEqualTo(inflight);
 			assertThat(options.getMessageVisibility()).isEqualTo(visibility);
+			assertThat(options.getMessageVisibilityHeartbeatInterval()).isEqualTo(heartbeatInterval);
+			assertThat(options.getMessageVisibilityHeartbeatTimeout()).isEqualTo(heartbeatTimeout);
 			assertThat(options.getPollTimeout()).isEqualTo(pollTimeout);
 			assertThat(options.getMaxMessagesPerPoll()).isEqualTo(messagesPerPoll);
 		});

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/ContainerOptionsTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/ContainerOptionsTests.java
@@ -178,7 +178,8 @@ class ContainerOptionsTests {
 		SqsListenerObservation.Convention observationConvention = mock(SqsListenerObservation.Convention.class);
 
 		return SqsContainerOptions.builder().acknowledgementShutdownTimeout(Duration.ofSeconds(7))
-				.messageVisibility(Duration.ofSeconds(11))
+				.messageVisibility(Duration.ofSeconds(11)).messageVisibilityHeartbeatInterval(Duration.ofSeconds(2))
+				.messageVisibilityHeartbeatTimeout(Duration.ofSeconds(30))
 				.pollBackOffPolicy(BackOffPolicyBuilder.newBuilder().delay(1000).build())
 				.queueAttributeNames(Collections.singletonList(QueueAttributeName.QUEUE_ARN))
 				.messageSystemAttributeNames(Collections.singletonList(MessageSystemAttributeName.MESSAGE_GROUP_ID))

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/FifoSqsComponentFactoryTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/FifoSqsComponentFactoryTests.java
@@ -27,6 +27,7 @@ import io.awspring.cloud.sqs.listener.sink.MessageSink;
 import io.awspring.cloud.sqs.listener.sink.OrderedMessageSink;
 import io.awspring.cloud.sqs.listener.sink.adapter.MessageGroupingSinkAdapter;
 import io.awspring.cloud.sqs.listener.sink.adapter.MessageVisibilityExtendingSinkAdapter;
+import io.awspring.cloud.sqs.listener.sink.adapter.MessageVisibilityHeartbeatSinkAdapter;
 import java.time.Duration;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.junit.jupiter.api.Test;
@@ -68,6 +69,19 @@ class FifoSqsComponentFactoryTests {
 				.extracting("delegate").isInstanceOf(MessageVisibilityExtendingSinkAdapter.class);
 		visibilitySinkAssertion.extracting("messageVisibility").isEqualTo((int) visbilityDuration.getSeconds());
 		visibilitySinkAssertion.extracting("delegate").isInstanceOf(OrderedMessageSink.class);
+	}
+
+	@Test
+	void shouldCreateGroupingSinkWithVisibilityHeartbeat() {
+		FifoSqsComponentFactory<Object> componentFactory = new FifoSqsComponentFactory<>();
+		MessageSink<Object> messageSink = componentFactory.createMessageSink(SqsContainerOptions.builder()
+				.messageVisibility(Duration.ofSeconds(1)).messageVisibilityHeartbeatInterval(Duration.ofSeconds(1))
+				.messageVisibilityHeartbeatTimeout(Duration.ofSeconds(15)).build());
+		assertThat(messageSink).isInstanceOf(MessageGroupingSinkAdapter.class)
+				.asInstanceOf(type(MessageGroupingSinkAdapter.class)).extracting("delegate")
+				.isInstanceOf(MessageVisibilityHeartbeatSinkAdapter.class).extracting("delegate")
+				.isInstanceOf(MessageVisibilityExtendingSinkAdapter.class).extracting("delegate")
+				.isInstanceOf(OrderedMessageSink.class);
 	}
 
 	@Test

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/StandardSqsComponentFactoryTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/StandardSqsComponentFactoryTests.java
@@ -25,6 +25,7 @@ import io.awspring.cloud.sqs.listener.acknowledgement.ImmediateAcknowledgementPr
 import io.awspring.cloud.sqs.listener.sink.BatchMessageSink;
 import io.awspring.cloud.sqs.listener.sink.FanOutMessageSink;
 import io.awspring.cloud.sqs.listener.sink.MessageSink;
+import io.awspring.cloud.sqs.listener.sink.adapter.MessageVisibilityHeartbeatSinkAdapter;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
@@ -48,6 +49,26 @@ class StandardSqsComponentFactoryTests {
 		MessageSink<Object> messageSink = componentFactory
 				.createMessageSink(SqsContainerOptions.builder().listenerMode(ListenerMode.BATCH).build());
 		assertThat(messageSink).isInstanceOf(BatchMessageSink.class);
+	}
+
+	@Test
+	void shouldCreateSingleMessageSinkWithVisibilityHeartbeat() {
+		ContainerComponentFactory<Object, SqsContainerOptions> componentFactory = new StandardSqsComponentFactory<>();
+		MessageSink<Object> messageSink = componentFactory.createMessageSink(
+				SqsContainerOptions.builder().messageVisibilityHeartbeatInterval(Duration.ofSeconds(1))
+						.messageVisibilityHeartbeatTimeout(Duration.ofSeconds(15)).build());
+		assertThat(messageSink).isInstanceOf(MessageVisibilityHeartbeatSinkAdapter.class).extracting("delegate")
+				.isInstanceOf(FanOutMessageSink.class);
+	}
+
+	@Test
+	void shouldCreateBatchSinkWithVisibilityHeartbeat() {
+		ContainerComponentFactory<Object, SqsContainerOptions> componentFactory = new StandardSqsComponentFactory<>();
+		MessageSink<Object> messageSink = componentFactory.createMessageSink(SqsContainerOptions.builder()
+				.listenerMode(ListenerMode.BATCH).messageVisibilityHeartbeatInterval(Duration.ofSeconds(1))
+				.messageVisibilityHeartbeatTimeout(Duration.ofSeconds(15)).build());
+		assertThat(messageSink).isInstanceOf(MessageVisibilityHeartbeatSinkAdapter.class).extracting("delegate")
+				.isInstanceOf(BatchMessageSink.class);
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Implements / Fixes #1554 : Implement heartbeat for long running tasks. 

This allows a consumer of SQS which doesn't know up front the maximum time it will process a message, to use a "heartbeat" mechanism where it periodically checks back in with SQS to extend the visibility timeout, per AWS best practices https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html

This has _benefits_ over setting a really long maximum visibility timeout
- If process fails long before maximum visibility timeout you set, it reduces latency of the message getting picked back up by a consumer, or moving into the dead letter queue (if configured)
- If process goes beyond the maximum visibility timeout, but is still in progress, it prevents the message from getting picked up by another consumer, which would've caused extra work/cost and potentially other issues (including dead lettering things that actually completed)
- Reduces effort to implement SQS listeners overall, you can set the default visibility timeout for rough expected amount for it to complete processing (or just default of 30 seconds, or your own standard default), as long as you setup the heartbeat to happen before visibility timeout

The _costs_ over setting a really long maximum visibility timeout
- There is overhead of making the heartbeat, it's a rather small overhead individually (simple call to SQS, single future), but if configured too frequently and running large amounts of SQS messages on the same server, it could add up (especially if you under provision for your CPU and misconfigure the heartbeat to happen too frequently)


## :bulb: Motivation and Context
This is pretty standard practice for SQS, especially for longer or variable time processing. Motivating by having issues with messages ending up in dead letter because timeout wasn't long enough for some items, and caused it to be processed multiple times


## :green_heart: How did you test it?
Unit tests, and I made a queue and ran it locally, I setup a queue and put messages on it, that normally would timeout but now doesn't. I could see the logs about heart beating as well.

Note this was to test it out, one shouldn't do a heartbeat every 1 second
```java
 @SqsListener(value = "test-sqs-heartbeat-queue", messageVisibilityHeartbeatIntervalSeconds ="1",messageVisibilityHeartbeatSeconds = "30")
    public void listenToTest(String message) {
        LOGGER.info("Start processing {}", message);
        for(int i = 0; i < 10; i++){
            try {
                LOGGER.info("Processing message, task #{} - {}", i, message);
                Thread.sleep(6000);
            } catch (InterruptedException e) {}
        }
        LOGGER.info("End processing {}", message);
    }
```

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Make some release that has it in it, and include in changelog?