### PR TITLE
fix: correct log, Javadoc, and documentation grammar in SES and SQS

### DIFF
--- a/docs/src/main/asciidoc/ses.adoc
+++ b/docs/src/main/asciidoc/ses.adoc
@@ -59,7 +59,7 @@ class MailSendingService {
 
 Sending attachments with e-mail or HTML e-mails requires MIME messages to be created and sent. In order to create MIME messages,
 the Java Mail API dependency and an implementation need to be in the classpath. Spring Cloud AWS will detect the
-dependency and create a `org.springframework.mail.javamail.JavaMailSender` implementation that allows to create and
+dependency and create a `org.springframework.mail.javamail.JavaMailSender` implementation that allows you to create and
 build MIME messages and send them. Dependencies for the Java Mail API and an implementation are the only needed configuration changes as shown below.
 
 [source,xml,indent=0]

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -1259,7 +1259,7 @@ MessageListenerContainer<Object> listenerContainer(SqsAsyncClient sqsAsyncClient
 }
 ----
 
-NOTE: The `SqsMessageListenerContainer.builder()` allows to specify the `SmartLifecycle.phase`, to override the default value defined in `MessageListenerContainer.DEFAULT_PHASE`
+NOTE: The `SqsMessageListenerContainer.builder()` allows you to specify the `SmartLifecycle.phase`, to override the default value defined in `MessageListenerContainer.DEFAULT_PHASE`
 
 ===== Retrieving Containers from the Registry
 

--- a/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/SimpleEmailServiceJavaMailSender.java
+++ b/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/SimpleEmailServiceJavaMailSender.java
@@ -47,7 +47,7 @@ import software.amazon.awssdk.services.ses.model.SendRawEmailRequest;
 import software.amazon.awssdk.services.ses.model.SendRawEmailResponse;
 
 /**
- * {@link JavaMailSender} implementation that allows to send {@link MimeMessage} using the Simple E-Mail Service. In
+ * {@link JavaMailSender} implementation that allows sending {@link MimeMessage} using the Simple E-Mail Service. In
  * contrast to {@link SimpleEmailServiceMailSender} this class also allows the use of attachment and other mime parts
  * inside mail messages.
  *

--- a/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/SimpleEmailServiceMailSender.java
+++ b/spring-cloud-aws-ses/src/main/java/io/awspring/cloud/ses/SimpleEmailServiceMailSender.java
@@ -92,7 +92,7 @@ public class SimpleEmailServiceMailSender implements MailSender, DisposableBean 
 			try {
 				SendEmailResponse sendEmailResult = getEmailService().sendEmail(prepareMessage(simpleMessage));
 				if (LOGGER.isDebugEnabled()) {
-					LOGGER.debug("Message with id: {} successfully send", sendEmailResult.messageId());
+					LOGGER.debug("Message with id: {} successfully sent", sendEmailResult.messageId());
 				}
 			}
 			catch (SesException e) {


### PR DESCRIPTION
This PR corrects minor spelling/grammatical issues in the logs, Javadoc comments, and Asciidoc documentation for the Simple Email Service (SES) and Simple Queue Service (SQS) modules:

1. **SimpleEmailServiceMailSender**: Fixed a debug logging typo where it logged `"Message with id: {} successfully send"` instead of `"successfully sent"`.
2. **SimpleEmailServiceJavaMailSender Javadoc**: Corrected `allows to send` to `allows sending`.
3. **ses.adoc**: Fixed `allows to create and` to `allows you to create and`.
4. **sqs.adoc**: Fixed `allows to specify the` to `allows you to specify the`.

These adjustments improve overall phrasing, standard grammar usage, and log correctness across the codebase.
