### PR TITLE
fix: add descriptive error message to SendBatchOperationFailedException

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AbstractMessagingTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/AbstractMessagingTemplate.java
@@ -401,7 +401,12 @@ public abstract class AbstractMessagingTemplate<S> implements MessagingOperation
 
 	private <T> CompletableFuture<SendResult.Batch<T>> handleFailedSendBatch(String endpoint,
 			SendResult.Batch<T> result) {
-		return CompletableFuture.failedFuture(new SendBatchOperationFailedException("", endpoint, result));
+		String errorMessage = "Send batch operation failed for endpoint %s. Failed messages: %s.".formatted(endpoint,
+				result.failed().stream()
+						.map(failed -> "[Message ID: %s, Error: %s]"
+								.formatted(MessageHeaderUtils.getRawMessageId(failed.message()), failed.errorMessage()))
+						.collect(Collectors.joining(", ")));
+		return CompletableFuture.failedFuture(new SendBatchOperationFailedException(errorMessage, endpoint, result));
 	}
 
 	private <T> Collection<S> convertMessagesToSend(Collection<Message<T>> messages) {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/SqsTemplateTests.java
@@ -23,6 +23,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.MessageHeaderUtils;
 import io.awspring.cloud.sqs.QueueAttributesResolvingException;
 import io.awspring.cloud.sqs.SqsAcknowledgementException;
 import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
@@ -555,6 +556,8 @@ class SqsTemplateTests {
 		assertThatThrownBy(() -> template.sendMany(queue, messages))
 				.isInstanceOf(SendBatchOperationFailedException.class)
 				.isInstanceOfSatisfying(SendBatchOperationFailedException.class, ex -> {
+					assertThat(ex.getMessage()).contains(queue).contains(testErrorMessage)
+							.contains(MessageHeaderUtils.getRawMessageId(message2));
 					assertThat(ex.getFailedMessages().iterator().next().getPayload()).isEqualTo(payload2);
 					assertThat(ex.getEndpoint()).isEqualTo(queue);
 					SendResult.Batch<String> sendBatchResult = ex.getSendBatchResult(String.class);


### PR DESCRIPTION
This PR addresses Issue #1605 by constructing a detailed, descriptive exception message when creating a `SendBatchOperationFailedException`.

### Problem
Previously, in `AbstractMessagingTemplate.handleFailedSendBatch`, a `SendBatchOperationFailedException` was created with a hardcoded empty string `""` as the exception message. As a result, `e.getMessage()` returned `""`, rendering the exception silent in logs and requiring developers to manually extract details via `e.getSendBatchResult().failed()`.

### Solution
This PR updates `AbstractMessagingTemplate` to dynamically construct a diagnostic error message when a batch send operation fails. The message now contains:
- The target SQS queue/endpoint.
- The raw SQS message ID (or Spring message ID) of each failed message in the batch.
- The associated failure error message returned from the SQS client.

### Testing
- Added assertions to the existing `shouldThrowIfHasFailedMessagesInBatchByDefault` unit test in `SqsTemplateTests` to verify that `SendBatchOperationFailedException` contains a message with the expected queue name, failed message ID, and SQS error details.
- Verified that all unit tests pass successfully.
