### PR TITLE
refactor(sqs): modernize stream collector in MessageHeaderUtils

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/MessageHeaderUtils.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/MessageHeaderUtils.java
@@ -81,7 +81,7 @@ public class MessageHeaderUtils {
 	 */
 	public static <T, U> Collection<T> getHeader(Collection<Message<U>> messages, String headerName,
 			Class<T> classToCast) {
-		return messages.stream().map(msg -> getHeader(msg, headerName, classToCast)).collect(Collectors.toList());
+		return messages.stream().map(msg -> getHeader(msg, headerName, classToCast)).toList();
 	}
 
 	/**


### PR DESCRIPTION
Modernizes the legacy stream collection .collect(Collectors.toList()) to the standard, memory-efficient Java 16+ .toList() inside MessageHeaderUtils.