### PR TITLE
style: modernize stream collection in ConfigurationChangeDetector

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/reload/ConfigurationChangeDetector.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/reload/ConfigurationChangeDetector.java
@@ -19,7 +19,6 @@ import io.awspring.cloud.core.config.AwsPropertySource;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
@@ -94,7 +93,7 @@ public abstract class ConfigurationChangeDetector<T extends AwsPropertySource<?,
 
 		return environment.getPropertySources().stream()
 				.filter(it -> (it.getClass().isAssignableFrom(propertySourceClass))).map(it -> (T) it)
-				.collect(Collectors.toList());
+				.toList();
 	}
 
 	public Class<T> getPropertySourceClass() {


### PR DESCRIPTION
This Pull Request modernizes the stream collection pipeline inside \ConfigurationChangeDetector\ under the autoconfigure module:

- Replaces the obsolete \.collect(Collectors.toList())\ call with the standard Java 16+ \.toList()\ method.
- Cleans up and removes the unused \java.util.stream.Collectors\ import statement.