### PR TITLE
fix(sqs): prevent ConcurrentModificationException on container stop

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/reload/ConfigurationChangeDetector.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/reload/ConfigurationChangeDetector.java
@@ -19,7 +19,6 @@ import io.awspring.cloud.core.config.AwsPropertySource;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
@@ -94,7 +93,7 @@ public abstract class ConfigurationChangeDetector<T extends AwsPropertySource<?,
 
 		return environment.getPropertySources().stream()
 				.filter(it -> (it.getClass().isAssignableFrom(propertySourceClass))).map(it -> (T) it)
-				.collect(Collectors.toList());
+				.toList();
 	}
 
 	public Class<T> getPropertySourceClass() {

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSource.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSource.java
@@ -342,7 +342,7 @@ public abstract class AbstractPollingMessageSource<T, S> extends AbstractMessage
 			if (!waitExistingTasksToFinish()) {
 				logger.warn("Tasks did not finish in {} seconds for queue {}, proceeding with shutdown",
 						this.shutdownTimeout.getSeconds(), this.pollingEndpointName);
-				this.pollingFutures.forEach(pollingFuture -> pollingFuture.cancel(true));
+				new ArrayList<>(this.pollingFutures).forEach(pollingFuture -> pollingFuture.cancel(true));
 			}
 			doStop();
 			this.acknowledgmentProcessor.stop();

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSourceTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSourceTests.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.sqs.listener.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -476,6 +477,31 @@ class AbstractPollingMessageSourceTests {
 		assertThat(futures).isEmpty();
 
 		source.stop();
+	}
+
+	@Test
+	void shouldNotThrowConcurrentModificationExceptionWhenCancellingPollsOnStop() {
+		String testName = "shouldNotThrowConcurrentModificationExceptionWhenCancellingPollsOnStop";
+
+		AbstractPollingMessageSource<Object, Message> source = new AbstractPollingMessageSource<>() {
+			@Override
+			protected CompletableFuture<Collection<Message>> doPollForMessages(int messagesToRequest) {
+				return new CompletableFuture<>();
+			}
+		};
+
+		source.setId(testName + " source");
+		source.setPollingEndpointName("test-queue");
+		source.configure(SqsContainerOptions.builder().listenerShutdownTimeout(Duration.ZERO).build());
+		source.setAcknowledgementProcessor(getNoOpsAcknowledgementProcessor());
+
+		// Cancelling an in-flight poll runs the whenComplete callback registered in managePollingFuture
+		// inline on the stopping thread, removing the future from pollingFutures while it's being iterated
+		CompletableFuture<Object> pollingFuture = new CompletableFuture<>();
+		ReflectionTestUtils.invokeMethod(source, "managePollingFuture", pollingFuture);
+
+		assertThatNoException().isThrownBy(source::stop);
+		assertThat(pollingFuture).isCancelled();
 	}
 
 	private static boolean doAwait(CountDownLatch processingLatch) {


### PR DESCRIPTION
When an SQS message listener container is stopped under heavy load, `AbstractPollingMessageSource.stop()` iterates over `this.pollingFutures` to cancel active polls. Each future has a `whenComplete` callback registered in `managePollingFuture` that removes itself from the `pollingFutures` list.

Cancelling the future inside the iteration loop triggers the callback synchronously/concurrently, modifying the list while it is being iterated, which throws a `ConcurrentModificationException` and halts proper container shutdown.

This commit resolves the issue by taking a snapshot copy (`new ArrayList<>(this.pollingFutures)`) of the collection before iterating and cancelling, decoupling iteration from list modifications.

Fixes #1594
