### PR TITLE
fix(dependencies): correct jakarta.mail artifactId to jakarta.mail-api

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/reload/ConfigurationChangeDetector.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/config/reload/ConfigurationChangeDetector.java
@@ -19,7 +19,6 @@ import io.awspring.cloud.core.config.AwsPropertySource;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
@@ -94,7 +93,7 @@ public abstract class ConfigurationChangeDetector<T extends AwsPropertySource<?,
 
 		return environment.getPropertySources().stream()
 				.filter(it -> (it.getClass().isAssignableFrom(propertySourceClass))).map(it -> (T) it)
-				.collect(Collectors.toList());
+				.toList();
 	}
 
 	public Class<T> getPropertySourceClass() {

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -290,7 +290,7 @@
 
 			<dependency>
 				<groupId>jakarta.mail</groupId>
-				<artifactId>jakarta.mail</artifactId>
+				<artifactId>jakarta.mail-api</artifactId>
 				<version>${jakarta.mail.version}</version>
 			</dependency>
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSource.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSource.java
@@ -342,7 +342,7 @@ public abstract class AbstractPollingMessageSource<T, S> extends AbstractMessage
 			if (!waitExistingTasksToFinish()) {
 				logger.warn("Tasks did not finish in {} seconds for queue {}, proceeding with shutdown",
 						this.shutdownTimeout.getSeconds(), this.pollingEndpointName);
-				this.pollingFutures.forEach(pollingFuture -> pollingFuture.cancel(true));
+				new ArrayList<>(this.pollingFutures).forEach(pollingFuture -> pollingFuture.cancel(true));
 			}
 			doStop();
 			this.acknowledgmentProcessor.stop();


### PR DESCRIPTION
Fixes a ghost dependency in the BOM where \jakarta.mail:jakarta.mail\ was incorrectly managed instead of \jakarta.mail:jakarta.mail-api\ for version 2.1.3.

This resolves ArtifactNotFoundException build failures for users of the BOM as reported in #1585.