### PR TITLE
Fix an infinite loop during application startup when a queue does not exist (#1512)

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistry.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistry.java
@@ -80,10 +80,13 @@ public class DefaultListenerContainerRegistry implements MessageListenerContaine
 	public void start() {
 		synchronized (this.lifecycleMonitor) {
 			logger.debug("Starting {}", getClass().getSimpleName());
+			// set running to true before starting the containers so that, if a container fails to start, Spring's
+			// DefaultLifecycleProcessor still invokes stop() on this registry during shutdown, which prevents
+			// hanging the JVM
+			this.running = true;
 			List<MessageListenerContainer<?>> containersToStart = this.listenerContainers.values().stream()
 					.filter(SmartLifecycle::isAutoStartup).collect(Collectors.toList());
 			LifecycleHandler.get().start(containersToStart);
-			this.running = true;
 			logger.debug("{} started", getClass().getSimpleName());
 		}
 	}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistryTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistryTests.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
@@ -116,6 +117,26 @@ class DefaultListenerContainerRegistryTests {
 		assertThat(registry.isRunning()).isFalse();
 		then(container1).should(times(0)).start();
 		then(container1).should().stop();
+	}
+
+	@Test
+	void shouldBeMarkedRunningWhenContainerFailsToStartSoRegistryIsStoppedOnShutdown() {
+		// a failing container simulates e.g. a queue that does not exist with QueueNotFoundStrategy.FAIL,
+		// which could lead to hanging the JVM
+		MessageListenerContainer<Object> failingContainer = mock(MessageListenerContainer.class);
+		given(failingContainer.getId()).willReturn("failing-container-id");
+		given(failingContainer.isAutoStartup()).willReturn(true);
+		var exception = new IllegalStateException("Queue does not exist");
+		willThrow(exception).given(failingContainer).start();
+		DefaultListenerContainerRegistry registry = new DefaultListenerContainerRegistry();
+		registry.registerListenerContainer(failingContainer);
+
+		assertThatThrownBy(registry::start).hasRootCause(exception);
+		assertThat(registry.isRunning()).isTrue();
+
+		registry.stop();
+		assertThat(registry.isRunning()).isFalse();
+		then(failingContainer).should().stop();
 	}
 
 	@Test


### PR DESCRIPTION
Fix an infinite loop during application startup when a queue does not exist (#1512)

## :loudspeaker: Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Solves #1512 based on https://github.com/awspring/spring-cloud-aws/issues/1512#issuecomment-3770688229 suggestion.


## :bulb: Motivation and Context

Solves #1512


## :green_heart: How did you test it?

Unit test created, which fails without the fix. Additional manual test using snapshot version built locally, and https://github.com/klach-ocado/sqs-listener-infinite-loop minimal reproducible example.


## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps

None