### PR TITLE
Fix `NullPointerException` in Kinesis binder CloudWatch client creation

### DIFF
--- a/spring-cloud-aws-kinesis-stream-binder/src/main/java/io/awspring/cloud/kinesis/stream/binder/config/KinesisBinderConfiguration.java
+++ b/spring-cloud-aws-kinesis-stream-binder/src/main/java/io/awspring/cloud/kinesis/stream/binder/config/KinesisBinderConfiguration.java
@@ -32,7 +32,6 @@ import io.awspring.cloud.kinesis.stream.binder.provisioning.KinesisStreamProvisi
 import io.micrometer.observation.ObservationRegistry;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -204,8 +203,9 @@ public class KinesisBinderConfiguration {
 			ObjectProvider<AwsClientCustomizer<CloudWatchAsyncClientBuilder>> configurer) {
 
 		if (this.hasInputs) {
-			return awsClientBuilderConfigurer.configureAsyncClient(CloudWatchAsyncClient.builder(), properties, null,
-					Stream.of(configurer.getIfAvailable()), null).build();
+			return awsClientBuilderConfigurer
+					.configureAsyncClient(CloudWatchAsyncClient.builder(), properties, null, configurer.stream(), null)
+					.build();
 		}
 		else {
 			return null;

--- a/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/config/KinesisBinderConfigurationTests.java
+++ b/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/config/KinesisBinderConfigurationTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2013-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.kinesis.stream.binder.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.awspring.cloud.autoconfigure.AwsClientCustomizer;
+import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer;
+import io.awspring.cloud.autoconfigure.core.AwsProperties;
+import io.awspring.cloud.autoconfigure.metrics.CloudWatchProperties;
+import io.awspring.cloud.core.region.StaticRegionProvider;
+import io.awspring.cloud.kinesis.stream.binder.properties.KinesisBinderConfigurationProperties;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.cloud.stream.binding.Bindable;
+import org.springframework.core.ResolvableType;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClientBuilder;
+
+/**
+ * Tests for {@link KinesisBinderConfiguration}.
+ *
+ * @author kobeomseok95
+ *
+ * @since 4.1
+ */
+class KinesisBinderConfigurationTests {
+
+	private final DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+	@Test
+	void cloudWatchClientIsCreatedWhenNoCustomizerBeanIsRegistered() {
+		KinesisBinderConfiguration configuration = binderConfiguration();
+
+		try (CloudWatchAsyncClient cloudWatch = configuration.cloudWatch(new CloudWatchProperties(),
+				cloudWatchCustomizers())) {
+
+			assertThat(cloudWatch).isNotNull();
+		}
+	}
+
+	@Test
+	void cloudWatchClientAppliesRegisteredCustomizer() {
+		KinesisBinderConfiguration configuration = binderConfiguration();
+		TrackingCloudWatchCustomizer customizer = new TrackingCloudWatchCustomizer();
+		this.beanFactory.registerSingleton("cloudWatchCustomizer", customizer);
+
+		try (CloudWatchAsyncClient cloudWatch = configuration.cloudWatch(new CloudWatchProperties(),
+				cloudWatchCustomizers())) {
+
+			assertThat(cloudWatch).isNotNull();
+			assertThat(customizer.applied).isTrue();
+		}
+	}
+
+	private KinesisBinderConfiguration binderConfiguration() {
+		AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider
+				.create(AwsBasicCredentials.create("noop", "noop"));
+		AwsRegionProvider regionProvider = new StaticRegionProvider("eu-west-1");
+		AwsClientBuilderConfigurer awsClientBuilderConfigurer = new AwsClientBuilderConfigurer(credentialsProvider,
+				regionProvider, new AwsProperties());
+		Bindable bindableWithInput = new Bindable() {
+
+			@Override
+			public Set<String> getInputs() {
+				return Set.of("input-in-0");
+			}
+
+		};
+		return new KinesisBinderConfiguration(new KinesisBinderConfigurationProperties(), credentialsProvider,
+				regionProvider, awsClientBuilderConfigurer, List.of(bindableWithInput));
+	}
+
+	private ObjectProvider<AwsClientCustomizer<CloudWatchAsyncClientBuilder>> cloudWatchCustomizers() {
+		return this.beanFactory.getBeanProvider(
+				ResolvableType.forClassWithGenerics(AwsClientCustomizer.class, CloudWatchAsyncClientBuilder.class));
+	}
+
+	private static final class TrackingCloudWatchCustomizer
+			implements AwsClientCustomizer<CloudWatchAsyncClientBuilder> {
+
+		private boolean applied;
+
+		@Override
+		public void customize(CloudWatchAsyncClientBuilder builder) {
+			this.applied = true;
+		}
+
+	}
+
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fixes a `NullPointerException` in `KinesisBinderConfiguration.cloudWatch()` that occurs when `spring.cloud.stream.kinesis.binder.kpl-kcl-enabled=true` is set, the application has at least one input binding, and no `AwsClientCustomizer<CloudWatchAsyncClientBuilder>` bean is registered.

The method passed the optional customizer as `Stream.of(configurer.getIfAvailable())`, which produces a stream containing a single `null` element when the bean is absent, causing the NPE inside `AwsClientBuilderConfigurer.configureAsyncClient(...)`. This change uses `configurer.stream()` instead, aligning `cloudWatch()` with the sibling client bean methods (`amazonKinesis()`, `dynamoDB()`, `dynamoDBStreams()`), and removes the now-unused `java.util.stream.Stream` import.


## :bulb: Motivation and Context
Without this fix, enabling the KPL/KCL mode of the Kinesis binder requires registering a no-op `AwsClientCustomizer<CloudWatchAsyncClientBuilder>` bean as a workaround.

Fixes #1651


## :green_heart: How did you test it?
- Added `KinesisBinderConfigurationTests` with two tests:
  - `cloudWatchClientIsCreatedWhenNoCustomizerBeanIsRegistered` — reproduces the reported NPE before the fix and passes after it
  - `cloudWatchClientAppliesRegisteredCustomizer` — verifies a registered customizer is still applied after the change
- Ran the full `spring-cloud-aws-kinesis-stream-binder` test suite (LocalStack/Testcontainers based) — all 25 tests pass


## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change (not needed — internal bugfix, no API or documented behavior change)
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
The bug is present in the released 4.0.x line (verified on 4.0.2), so this may be worth backporting to `4.0.x`.
