### PR TITLE
Fix Infinite loop during application startup when a queue does not exist

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsListenerContainerStartupIntegrationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsListenerContainerStartupIntegrationTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2013-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.autoconfigure.sqs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.amazon.sqs.javamessaging.AmazonSQSExtendedAsyncClient;
+import io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration;
+import io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration;
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import io.awspring.cloud.sqs.config.SqsBeanNames;
+import io.awspring.cloud.sqs.listener.DefaultListenerContainerRegistry;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ApplicationContextException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.localstack.LocalStackContainer;
+import org.testcontainers.shaded.org.bouncycastle.util.Arrays;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.QueueDoesNotExistException;
+
+/**
+ * Integration tests for SQS listener startup.
+ *
+ * @author Bruno Garcia
+ */
+@Testcontainers
+@SpringBootTest
+class SqsListenerContainerStartupIntegrationTest {
+
+	private static final String EXISTING_QUEUE_NAME = "messaging-greetings-notifications";
+
+	private static final String MISSING_QUEUE_NAME = "not-existing-queue";
+
+	@Container
+	static LocalStackContainer localstack = new LocalStackContainer(
+			DockerImageName.parse("localstack/localstack:4.4.0"));
+
+	static {
+		localstack.start();
+	}
+
+	private static final String[] BASE_PARAMS = { "spring.cloud.aws.sqs.region=eu-west-1",
+			"spring.cloud.aws.sqs.endpoint=" + localstack.getEndpoint(), "spring.cloud.aws.credentials.access-key=noop",
+			"spring.cloud.aws.credentials.secret-key=noop", "spring.cloud.aws.region.static=eu-west-1" };
+
+	private static final AutoConfigurations BASE_CONFIGURATIONS = AutoConfigurations.of(
+			RegionProviderAutoConfiguration.class, CredentialsProviderAutoConfiguration.class,
+			SqsAutoConfiguration.class, AwsAutoConfiguration.class, ExistingAndMissingQueueListenerConfiguration.class);
+
+	private final ApplicationContextRunner applicationContextRunnerWithFailStrategy = new ApplicationContextRunner()
+			.withClassLoader(new FilteredClassLoader(AmazonSQSExtendedAsyncClient.class))
+			.withPropertyValues(Arrays.append(BASE_PARAMS, "spring.cloud.aws.sqs.queue-not-found-strategy=fail"))
+			.withConfiguration(BASE_CONFIGURATIONS);
+
+	@Test
+	void stopsRegistryWhenOneSqsListenerFailsToResolveQueueOnStartup() {
+		createQueue(EXISTING_QUEUE_NAME);
+		TrackingListenerContainerRegistry registry = new TrackingListenerContainerRegistry();
+
+		applicationContextRunnerWithFailStrategy.withBean(SqsBeanNames.ENDPOINT_REGISTRY_BEAN_NAME,
+				TrackingListenerContainerRegistry.class, () -> registry).run(context -> {
+					assertThat(context.getStartupFailure()).isInstanceOf(ApplicationContextException.class)
+							.hasRootCauseInstanceOf(QueueDoesNotExistException.class);
+
+					assertThat(registry.stopInvocations).hasValue(1);
+					assertThat(registry.getListenerContainers()).hasSize(2)
+							.allSatisfy(container -> assertThat(container.isRunning())
+									.as("Container %s should be stopped", container.getId()).isFalse());
+					assertThat(registry.isRunning()).isFalse();
+				});
+	}
+
+	private static void createQueue(String queueName) {
+		try (SqsAsyncClient client = SqsAsyncClient.builder()
+				.credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("noop", "noop")))
+				.region(Region.EU_WEST_1).endpointOverride(localstack.getEndpoint()).build()) {
+			client.createQueue(request -> request.queueName(queueName)).join();
+		}
+	}
+
+	static class ExistingAndMissingQueueListener {
+
+		@SqsListener(EXISTING_QUEUE_NAME)
+		void listenToExistingQueue(String message) {
+		}
+
+		@SqsListener(MISSING_QUEUE_NAME)
+		void listenToMissingQueue(String message) {
+		}
+	}
+
+	@Configuration
+	static class ExistingAndMissingQueueListenerConfiguration {
+
+		@Bean
+		ExistingAndMissingQueueListener existingAndMissingQueueListener() {
+			return new ExistingAndMissingQueueListener();
+		}
+	}
+
+	static class TrackingListenerContainerRegistry extends DefaultListenerContainerRegistry {
+
+		private final AtomicInteger stopInvocations = new AtomicInteger();
+
+		@Override
+		public void stop() {
+			this.stopInvocations.incrementAndGet();
+			super.stop();
+		}
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistry.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistry.java
@@ -80,10 +80,10 @@ public class DefaultListenerContainerRegistry implements MessageListenerContaine
 	public void start() {
 		synchronized (this.lifecycleMonitor) {
 			logger.debug("Starting {}", getClass().getSimpleName());
+			this.running = true;
 			List<MessageListenerContainer<?>> containersToStart = this.listenerContainers.values().stream()
 					.filter(SmartLifecycle::isAutoStartup).collect(Collectors.toList());
 			LifecycleHandler.get().start(containersToStart);
-			this.running = true;
 			logger.debug("{} started", getClass().getSimpleName());
 		}
 	}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistryTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/DefaultListenerContainerRegistryTests.java
@@ -19,10 +19,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContextException;
+import org.springframework.context.support.GenericApplicationContext;
 
 /**
  * Tests for {@link DefaultListenerContainerRegistry}.
@@ -129,4 +135,78 @@ class DefaultListenerContainerRegistryTests {
 				.isInstanceOf(IllegalArgumentException.class);
 	}
 
+	@Test
+	void shouldRemainRunningAfterContainerFailsToStart() {
+		CountDownLatch healthyContainerUpSignal = new CountDownLatch(1);
+		MessageListenerContainer<Object> healthyContainer = mock(MessageListenerContainer.class);
+		MessageListenerContainer<Object> faultyContainer = mock(MessageListenerContainer.class);
+		String healthyId = "healthy-test-container-id";
+		String faultyId = "faulty-test-container-id";
+		given(healthyContainer.getId()).willReturn(healthyId);
+		given(healthyContainer.isAutoStartup()).willReturn(true);
+		given(faultyContainer.getId()).willReturn(faultyId);
+		given(faultyContainer.isAutoStartup()).willReturn(true);
+		willAnswer(invocation -> {
+			healthyContainerUpSignal.countDown();
+			return null;
+		}).given(healthyContainer).start();
+		String containerFailedToStartMessage = "Container failed to start";
+		willAnswer(invocation -> {
+			// Wait until the healthy container has started before failing the faulty container.
+			if (!healthyContainerUpSignal.await(5, TimeUnit.SECONDS)) {
+				throw new IllegalStateException("Test setup failed: healthy container start was not called");
+			}
+			throw new IllegalStateException(containerFailedToStartMessage);
+		}).given(faultyContainer).start();
+		DefaultListenerContainerRegistry registry = new DefaultListenerContainerRegistry();
+		registry.registerListenerContainer(healthyContainer);
+		registry.registerListenerContainer(faultyContainer);
+		assertThatThrownBy(registry::start).isInstanceOf(CompletionException.class).cause()
+				.isInstanceOf(RuntimeException.class).hasMessage(containerFailedToStartMessage);
+		assertThat(registry.isRunning()).isTrue();
+		registry.stop();
+		then(healthyContainer).should(times(1)).stop();
+		then(faultyContainer).should(times(1)).stop();
+		assertThat(registry.isRunning()).isFalse();
+	}
+
+	@Test
+	void shouldBeStoppedBySpringLifecycleProcessorWhenOneContainerFailsToStart() {
+		CountDownLatch healthyContainerUpSignal = new CountDownLatch(1);
+		MessageListenerContainer<Object> healthyContainer = mock(MessageListenerContainer.class);
+		MessageListenerContainer<Object> faultyContainer = mock(MessageListenerContainer.class);
+		String healthyId = "healthy-test-container-id";
+		String faultyId = "faulty-test-container-id";
+		given(healthyContainer.getId()).willReturn(healthyId);
+		given(healthyContainer.isAutoStartup()).willReturn(true);
+		given(faultyContainer.getId()).willReturn(faultyId);
+		given(faultyContainer.isAutoStartup()).willReturn(true);
+		willAnswer(invocation -> {
+			healthyContainerUpSignal.countDown();
+			return null;
+		}).given(healthyContainer).start();
+		String containerFailedToStartMessage = "Container failed to start";
+		willAnswer(invocation -> {
+			if (!healthyContainerUpSignal.await(5, TimeUnit.SECONDS)) {
+				throw new IllegalStateException("Test setup failed: healthy container start was not called");
+			}
+			throw new IllegalStateException(containerFailedToStartMessage);
+		}).given(faultyContainer).start();
+		DefaultListenerContainerRegistry registry = new DefaultListenerContainerRegistry();
+		registry.registerListenerContainer(healthyContainer);
+		registry.registerListenerContainer(faultyContainer);
+		GenericApplicationContext context = new GenericApplicationContext();
+
+		try (context) {
+			context.registerBean(DefaultListenerContainerRegistry.class, () -> registry);
+			assertThatThrownBy(context::refresh).isInstanceOf(ApplicationContextException.class)
+					.hasMessageContaining(DefaultListenerContainerRegistry.class.getName()).cause()
+					.isInstanceOf(CompletionException.class).cause().isInstanceOf(IllegalStateException.class)
+					.hasMessage(containerFailedToStartMessage);
+
+			then(healthyContainer).should(times(1)).stop();
+			then(faultyContainer).should(times(1)).stop();
+			assertThat(registry.isRunning()).isFalse();
+		}
+	}
 }


### PR DESCRIPTION
Fix Infinite loop during application startup when a queue does not exist (#1512)

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fix Infinite loop during application startup when a queue does not exist. I added some integration tests to verify the hypothesis

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solves #1512. 

## :green_heart: How did you test it?
Unit test and integration test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
