### PR TITLE
Fix duplicate DeleteMessageBatchRequestEntry ids when SQS redelivers a message within one ack batch

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementExecutor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementExecutor.java
@@ -25,6 +25,7 @@ import io.awspring.cloud.sqs.listener.SqsHeaders;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -98,14 +99,15 @@ public class SqsAcknowledgementExecutor<T>
 				MessageHeaderUtils.getId(messagesToAck));
 		StopWatch watch = new StopWatch();
 		watch.start();
+		List<Message<T>> orderedMessages = new ArrayList<>(messagesToAck);
 		return CompletableFutures.exceptionallyCompose(this.sqsAsyncClient
-			.deleteMessageBatch(createDeleteMessageBatchRequest(messagesToAck)).thenCompose(
-					response -> handleDeleteMessageBatchResponse(messagesToAck, response)),
-			t -> toAcknowledgementFailure(messagesToAck, t))
-			.whenComplete((v, t) -> logAckResult(messagesToAck, t, watch));
+			.deleteMessageBatch(createDeleteMessageBatchRequest(orderedMessages)).thenCompose(
+					response -> handleDeleteMessageBatchResponse(orderedMessages, response)),
+			t -> toAcknowledgementFailure(orderedMessages, t))
+			.whenComplete((v, t) -> logAckResult(orderedMessages, t, watch));
 	}
 
-	private CompletableFuture<Void> handleDeleteMessageBatchResponse(Collection<Message<T>> messagesToAck,
+	private CompletableFuture<Void> handleDeleteMessageBatchResponse(List<Message<T>> messagesToAck,
 			DeleteMessageBatchResponse response) {
 		if (!response.failed().isEmpty()) {
 			return CompletableFutures.<Void>failedFuture(createPartialFailureException(messagesToAck, response));
@@ -122,17 +124,26 @@ public class SqsAcknowledgementExecutor<T>
 		return CompletableFutures.<Void>failedFuture(createAcknowledgementException(messagesToAck, cause));
 	}
 
-	private SqsAcknowledgementException createPartialFailureException(Collection<Message<T>> messages,
+	private SqsAcknowledgementException createPartialFailureException(List<Message<T>> messages,
 			DeleteMessageBatchResponse response) {
-		Set<String> messageIds = messages.stream().map(MessageHeaderUtils::getId).collect(Collectors.toSet());
-		Set<String> failedIds = response.failed().stream()
-				.map(BatchResultErrorEntry::id)
-				.collect(Collectors.toSet());
+		Set<Integer> failedIndices = new HashSet<>();
+		boolean allIdsCorrelated = true;
+		for (BatchResultErrorEntry errorEntry : response.failed()) {
+			Integer index = parseBatchEntryIndex(errorEntry.id());
+			if (index == null || index < 0 || index >= messages.size()) {
+				allIdsCorrelated = false;
+				break;
+			}
+			failedIndices.add(index);
+		}
 
-		if (!messageIds.containsAll(failedIds)) {
+		if (!allIdsCorrelated) {
+			Set<String> rawFailedIds = response.failed().stream()
+					.map(BatchResultErrorEntry::id)
+					.collect(Collectors.toSet());
 			logger.warn("Could not correlate all acknowledgement failure ids in queue {}: {}", this.queueName,
-					failedIds);
-			return new SqsAcknowledgementException("Could not correlate acknowledgement failure ids: " + failedIds,
+					rawFailedIds);
+			return new SqsAcknowledgementException("Could not correlate acknowledgement failure ids: " + rawFailedIds,
 					Collections.emptyList(), messages.stream().map(msg -> (Message<?>) msg).collect(Collectors.toList()),
 					this.queueUrl, null);
 		}
@@ -140,33 +151,46 @@ public class SqsAcknowledgementExecutor<T>
 		List<Message<?>> successfulMessages = new ArrayList<>();
 		List<Message<?>> failedMessages = new ArrayList<>();
 
-		for(Message<T> msg : messages) {
-			if(failedIds.contains(MessageHeaderUtils.getId(msg))) {
-				failedMessages.add(msg);
+		for (int i = 0; i < messages.size(); i++) {
+			if (failedIndices.contains(i)) {
+				failedMessages.add(messages.get(i));
 			} else {
-				successfulMessages.add(msg);
+				successfulMessages.add(messages.get(i));
 			}
 		}
 
-		logger.warn("Some messages could not be acknowledged in queue {}: {}", this.queueName, failedIds);
+		Set<String> failedMessageIds = failedMessages.stream()
+				.map(MessageHeaderUtils::getId)
+				.collect(Collectors.toSet());
+		logger.warn("Some messages could not be acknowledged in queue {}: {}", this.queueName, failedMessageIds);
 
-		return new SqsAcknowledgementException("Error acknowledging messages " + failedIds, successfulMessages,
+		return new SqsAcknowledgementException("Error acknowledging messages " + failedMessageIds, successfulMessages,
 				failedMessages, this.queueUrl, null);
 	}
 
-	private DeleteMessageBatchRequest createDeleteMessageBatchRequest(Collection<Message<T>> messagesToAck) {
-		return DeleteMessageBatchRequest
-			.builder()
-			.queueUrl(this.queueUrl)
-			.entries(messagesToAck.stream().map(this::toDeleteMessageEntry).collect(Collectors.toList()))
-			.build();
+	private Integer parseBatchEntryIndex(String id) {
+		try {
+			return Integer.valueOf(id);
+		}
+		catch (NumberFormatException ex) {
+			return null;
+		}
 	}
 
-	private DeleteMessageBatchRequestEntry toDeleteMessageEntry(Message<T> message) {
+	private DeleteMessageBatchRequest createDeleteMessageBatchRequest(List<Message<T>> messagesToAck) {
+		List<DeleteMessageBatchRequestEntry> entries = new ArrayList<>(messagesToAck.size());
+		for (int i = 0; i < messagesToAck.size(); i++) {
+			entries.add(toDeleteMessageEntry(messagesToAck.get(i), i));
+		}
+		return DeleteMessageBatchRequest.builder().queueUrl(this.queueUrl).entries(entries).build();
+	}
+
+	// Positional index keeps the batch-local id unique even when SQS redelivers the same message id.
+	private DeleteMessageBatchRequestEntry toDeleteMessageEntry(Message<T> message, int index) {
 		return DeleteMessageBatchRequestEntry
 			.builder()
 			.receiptHandle(MessageHeaderUtils.getHeaderAsString(message, SqsHeaders.SQS_RECEIPT_HANDLE_HEADER))
-			.id(MessageHeaderUtils.getId(message))
+			.id(Integer.toString(index))
 			.build();
 	}
 	// @formatter:on

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementExecutorTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/SqsAcknowledgementExecutorTests.java
@@ -26,9 +26,12 @@ import io.awspring.cloud.sqs.CompletableFutures;
 import io.awspring.cloud.sqs.SqsAcknowledgementException;
 import io.awspring.cloud.sqs.listener.QueueAttributes;
 import io.awspring.cloud.sqs.listener.SqsHeaders;
+import io.awspring.cloud.sqs.support.converter.MessagingMessageHeaders;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import org.junit.jupiter.api.Test;
@@ -151,8 +154,8 @@ class SqsAcknowledgementExecutorTests {
 		given(queueAttributes.getQueueName()).willReturn(queueName);
 		given(queueAttributes.getQueueUrl()).willReturn(queueUrl);
 
-		BatchResultErrorEntry failedEntry = BatchResultErrorEntry.builder().id(failedMessageHeaders.getId().toString())
-				.code("ReceiptHandleIsInvalid").message("Receipt handle expired").build();
+		BatchResultErrorEntry failedEntry = BatchResultErrorEntry.builder().id("0").code("ReceiptHandleIsInvalid")
+				.message("Receipt handle expired").build();
 
 		DeleteMessageBatchResponse partialFailureResponse = DeleteMessageBatchResponse.builder().failed(failedEntry)
 				.build();
@@ -170,6 +173,35 @@ class SqsAcknowledgementExecutorTests {
 					assertThat(ex.getFailedAcknowledgementMessages()).containsExactly(failedMessage);
 					assertThat(ex.getSuccessfullyAcknowledgedMessages()).containsExactly(successfulMessage);
 				});
+	}
+
+	@Test
+	void shouldUseUniqueBatchEntryIdsWhenMessageIdIsDuplicated() throws Exception {
+		UUID sharedMessageId = UUID.randomUUID();
+		MessageHeaders firstHeaders = new MessagingMessageHeaders(
+				Map.of(SqsHeaders.SQS_RECEIPT_HANDLE_HEADER, receiptHandle), sharedMessageId);
+		MessageHeaders secondHeaders = new MessagingMessageHeaders(
+				Map.of(SqsHeaders.SQS_RECEIPT_HANDLE_HEADER, secondReceiptHandle), sharedMessageId);
+		Collection<Message<String>> messagesToAck = List.of(message, secondMessage);
+		given(message.getHeaders()).willReturn(firstHeaders);
+		given(secondMessage.getHeaders()).willReturn(secondHeaders);
+		given(queueAttributes.getQueueName()).willReturn(queueName);
+		given(queueAttributes.getQueueUrl()).willReturn(queueUrl);
+		given(sqsAsyncClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
+				.willReturn(CompletableFuture.completedFuture(DeleteMessageBatchResponse.builder().build()));
+
+		SqsAcknowledgementExecutor<String> executor = new SqsAcknowledgementExecutor<>();
+		executor.setSqsAsyncClient(sqsAsyncClient);
+		executor.setQueueAttributes(queueAttributes);
+		executor.execute(messagesToAck).get();
+
+		ArgumentCaptor<DeleteMessageBatchRequest> requestCaptor = ArgumentCaptor
+				.forClass(DeleteMessageBatchRequest.class);
+		verify(sqsAsyncClient).deleteMessageBatch(requestCaptor.capture());
+		List<DeleteMessageBatchRequestEntry> entries = requestCaptor.getValue().entries();
+		assertThat(entries).extracting(DeleteMessageBatchRequestEntry::id).doesNotHaveDuplicates();
+		assertThat(entries).extracting(DeleteMessageBatchRequestEntry::receiptHandle).containsExactly(receiptHandle,
+				secondReceiptHandle);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
`SqsAcknowledgementExecutor` used `MessageHeaderUtils.getId(message)` — the Spring message id derived from the SQS `messageId` — as the `DeleteMessageBatchRequestEntry.id`. On a Standard queue, if the same SQS message is redelivered within one acknowledgement batch, two entries end up with the same id and AWS rejects the entire batch with `BatchEntryIdsNotDistinctException`. The reporter's analysis and full repro are in #1634.

## Fix
Batch entry id is now a positional index into the snapshot list of messages passed to `deleteMessageBatch`. SQS only requires the id to be unique within a single request and doesn't otherwise interpret it, so a positional index is sufficient and keeps the mapping trivial.

Partial-failure correlation is updated accordingly: `createPartialFailureException` parses each `BatchResultErrorEntry.id` as an index into the ordered batch and buckets messages by index. If any returned id doesn't parse to a valid index — which shouldn't happen but preserves the previous defensive behaviour — the executor still returns the existing "cannot correlate all failure ids" case, treating every message as failed.

## Tests
- **New regression test**: `shouldUseUniqueBatchEntryIdsWhenMessageIdIsDuplicated` — two mock messages sharing the same Spring message id (via `MessagingMessageHeaders` with an explicit shared UUID) but with distinct receipt handles → asserts the captured `DeleteMessageBatchRequest` entries have distinct ids and preserve both receipt handles in order. Fails on `main` (`BatchEntryIdsNotDistinctException` path exercised), passes with this change.
- **Existing partial-failure test updated**: `shouldWrapPartialBatchFailure` now uses `id("0")` (positional) instead of the message-header UUID.
- Full sqs module test suite: **634 tests, 0 failures, 0 errors, 5 skipped** (`./mvnw -pl spring-cloud-aws-sqs -am test` — includes localstack integration tests).

Fixes #1634