### PR TITLE
test: canonicalize S3 inbound adapter temp directory

### DIFF
--- a/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/integration/S3InboundChannelAdapterTests.java
+++ b/spring-cloud-aws-s3/src/test/java/io/awspring/cloud/s3/integration/S3InboundChannelAdapterTests.java
@@ -71,13 +71,13 @@ class S3InboundChannelAdapterTests implements LocalstackContainerTest {
 	private PollableChannel s3FilesChannel;
 
 	@BeforeAll
-	static void setup() {
+	static void setup() throws IOException {
 		S3 = LocalstackContainerTest.s3Client();
 		S3.createBucket(request -> request.bucket(S3_BUCKET));
 		S3.putObject(request -> request.bucket(S3_BUCKET).key("subdir/a.test"), RequestBody.fromString("Hello"));
 		S3.putObject(request -> request.bucket(S3_BUCKET).key("subdir/b.test"), RequestBody.fromString("Bye"));
 
-		LOCAL_FOLDER = TEMPORARY_FOLDER.resolve("local").toFile();
+		LOCAL_FOLDER = TEMPORARY_FOLDER.toRealPath().resolve("local").toFile();
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change

<!--- Put an `x` in the boxes that apply -->

* [x] Bugfix
* [ ] New feature
* [ ] Enhancement
* [ ] Refactoring

## :scroll: Description

Canonicalize the temporary directory used by `S3InboundChannelAdapterTests` before creating the local download directory.

The test now resolves `TEMPORARY_FOLDER` with `toRealPath()`, ensuring that the path used when storing S3 remote-file metadata matches the canonical path later used by Spring Integration when reading the downloaded file.

## :bulb: Motivation and Context

On macOS, JUnit may create temporary directories under `/var/folders`, while file canonicalization resolves the same location under `/private/var/folders`.

The S3 inbound synchronizer stores remote-file metadata using the original absolute path. Spring Integration later looks up that metadata using the canonical file path. Because the two paths differ, the metadata lookup fails and the following expected headers are missing:

* `file_remoteDirectory`
* `file_remoteHostPort`
* `file_remoteFile`

Canonicalizing the temporary directory before configuring the inbound adapter keeps the metadata storage and lookup paths consistent.

## :green_heart: How did you test it?

Ran the focused failing test:

```bash
./mvnw \
  -pl spring-cloud-aws-s3 \
  -Dtest=S3InboundChannelAdapterTests \
  test
```

Ran the complete S3 module tests:

```bash
./mvnw -pl spring-cloud-aws-s3 test
```

Resumed the remaining Maven reactor build:

```bash
./mvnw package -rf :spring-cloud-aws-autoconfigure
```

The remaining reactor build completed successfully.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

* [x] I reviewed submitted code
* [ ] I added tests to verify changes
* [ ] I updated reference documentation to reflect the change
* [x] All tests passing
* [x] No breaking changes

## :crystal_ball: Next steps

None.
