### PR TITLE
Fix build broken by CollectionUtils stream collector change

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/CollectionUtils.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/CollectionUtils.java
@@ -18,6 +18,7 @@ package io.awspring.cloud.sqs;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class CollectionUtils {
@@ -27,7 +28,7 @@ public class CollectionUtils {
 		int totalSize = messagesToUse.size();
 		return IntStream.rangeClosed(0, (totalSize - 1) / pageSize)
 				.mapToObj(index -> messagesToUse.subList(index * pageSize, Math.min((index + 1) * pageSize, totalSize)))
-				.toList();
+				.collect(Collectors.toList());
 	}
 
 	private static <T> List<T> getAsList(Collection<T> elements) {


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description

`main` currently does not compile:

```
[ERROR] .../io/awspring/cloud/sqs/CollectionUtils.java:[30,40] incompatible types:
        java.util.List<java.util.List<T>> cannot be converted to
        java.util.List<java.util.Collection<T>>
```

This restores `Collectors.toList()` in `CollectionUtils.partition`.

## :bulb: Motivation and Context

#1626 replaced `.collect(Collectors.toList())` with `.toList()`. Those are not
interchangeable here, because the method returns `List<Collection<T>>` while the
lambda produces `List<T>`:

```java
public static <T> List<Collection<T>> partition(Collection<T> messagesToAck, int pageSize) {
    ...
    return IntStream.rangeClosed(0, (totalSize - 1) / pageSize)
            .mapToObj(index -> messagesToUse.subList(...))
            .toList();
}
```

`Collectors.toList()` is generic, so the target type `List<Collection<T>>`
propagates back and `mapToObj`'s `U` is inferred as `Collection<T>`.
`Stream.toList()` is not generic, so `U` is inferred solely from the lambda body
as `List<T>`, and `List<List<T>>` is not assignable to `List<Collection<T>>`.

The build has been broken on `main` since #1626 was merged. The `build` job on
the current `main` head fails with the error above, which also cancels the
`Test with JDK 17.0.12` and `Test with JDK 21.0.4` jobs.

The sibling PRs in the same series (#1627, #1628, #1629) compile fine: they all
assign a `List<X>` where a `Collection<X>` is expected, so there is no nested
generic mismatch. `CollectionUtils` is the only one where the stream element type
itself changes, which is where generic invariance bites. Fixing this one file is
enough to make the whole module build and test green again.

## :green_heart: How did you test it?

`./mvnw -pl spring-cloud-aws-sqs -am test` (JDK 17.0.19) fails on `main` with the
compile error above and passes with this change: **635 tests, 0 failures,
0 errors, 6 skipped**, spotless checks enabled.

## :pencil: Checklist

- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes

No new test: this is a compile-time regression, so the build itself is the test.
No documentation change needed.

## :crystal_ball: Next steps

Two things you may want to look at separately:

- Making the `build` job a required check, so a compile break cannot reach `main`
  again.
- `Collectors.toList()` returns a mutable list while `Stream.toList()` returns an
  unmodifiable one. The tests pass, so nothing in the codebase mutates those
  results today, but #1627/#1628/#1629 do hand unmodifiable lists to callers
  (including public API in `MessageHeaderUtils.getHeader`), which is an
  observable behaviour change for anyone downstream who mutates them.
