### PR TITLE
Flush buffered acknowledgements from the shutdown wait

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/AbstractOrderingAcknowledgementProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/AbstractOrderingAcknowledgementProcessor.java
@@ -64,7 +64,8 @@ public abstract class AbstractOrderingAcknowledgementProcessor<T>
 	private AsyncAcknowledgementResultCallback<T> acknowledgementResultCallback = new AsyncAcknowledgementResultCallback<T>() {
 	};
 
-	private boolean running;
+	// Written under lifecycleMonitor, but read without synchronization from the polling and scheduler threads
+	private volatile boolean running;
 
 	private String id;
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
@@ -250,6 +250,7 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 					if (LocalDateTime.now().isAfter(endTime)) {
 						throw new TimeoutException();
 					}
+					flushRemainingAcks();
 					Thread.sleep(200);
 				}
 				logger.debug("All acknowledgements completed.");
@@ -266,6 +267,28 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 				logger.warn(
 						"Error thrown when waiting for acknowledgement tasks to finish in {}. Continuing with shutdown.",
 						this.parent.getId(), e);
+			}
+		}
+
+		/**
+		 * Flushes whatever is left in the buffer, so that messages below the acknowledgement threshold are acknowledged
+		 * on shutdown instead of being discarded when the buffer is cleared. Waits for the ack queue to drain first so
+		 * that batches are not needlessly split.
+		 *
+		 * This has to be retried on every iteration of the shutdown wait loop rather than executed once: the polling
+		 * thread may be holding a message it has already polled but not yet added to the buffer, in which case the
+		 * queue looks empty while the message is in neither the queue nor the buffer.
+		 */
+		private void flushRemainingAcks() {
+			if (!this.acks.isEmpty()) {
+				return;
+			}
+			this.context.lock();
+			try {
+				this.context.executeAllAcks();
+			}
+			finally {
+				this.context.unlock();
 			}
 		}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
@@ -68,6 +68,8 @@ class BatchingAcknowledgementProcessorTests {
 
 	private static final Duration ACK_INTERVAL_ZERO = Duration.ZERO;
 
+	private static final Duration ACK_INTERVAL_THIRTY_SECONDS = Duration.ofSeconds(30);
+
 	private static final int MAX_ACKNOWLEDGEMENTS_PER_BATCH_TEN = 10;
 
 	private static final Integer ACK_THRESHOLD_TEN = 10;
@@ -187,6 +189,71 @@ class BatchingAcknowledgementProcessorTests {
 		processor.stop();
 		logger.debug("Processor stopped, waiting on latch");
 		assertThat(ackLatch.await(1, TimeUnit.SECONDS)).isEqualTo(shouldWaitAllAcks);
+	}
+
+	@Test
+	void givenScheduledAcknowledgement_whenStoppedWithRemainderBelowThreshold_shouldAcknowledgeRemainingMessages()
+			throws Exception {
+		List<Message<String>> messages = buildMessages(ACK_THRESHOLD_TEN + 5);
+		List<Message<String>> thresholdBatch = messages.subList(0, ACK_THRESHOLD_TEN);
+		List<Message<String>> remainder = messages.subList(ACK_THRESHOLD_TEN, messages.size());
+		Collection<Message<String>> acknowledgedMessages = Collections.synchronizedList(new ArrayList<>());
+		CountDownLatch thresholdFlushLatch = new CountDownLatch(1);
+
+		// The interval outlasts the test, so the remainder can only be flushed by the shutdown drain and never by a
+		// scheduled execution. A scheduled execution does exist here, unlike in the interval ZERO scenario below.
+		BatchingAcknowledgementProcessor<String> processor = createProcessor(ACK_INTERVAL_THIRTY_SECONDS,
+				messagesToAck -> {
+					acknowledgedMessages.addAll(messagesToAck);
+					thresholdFlushLatch.countDown();
+					return CompletableFuture.completedFuture(null);
+				});
+		processor.start();
+
+		processor.doOnAcknowledge(thresholdBatch);
+		assertThat(thresholdFlushLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		processor.doOnAcknowledge(remainder);
+		processor.stop();
+
+		assertThat(acknowledgedMessages).containsExactlyInAnyOrderElementsOf(messages);
+	}
+
+	@Test
+	void givenZeroIntervalAndThreshold_whenStoppedWithRemainderBelowThreshold_shouldAcknowledgeRemainingMessages()
+			throws Exception {
+		List<Message<String>> messages = buildMessages(ACK_THRESHOLD_TEN + 5);
+		Collection<Message<String>> acknowledgedMessages = Collections.synchronizedList(new ArrayList<>());
+
+		// No scheduled execution is ever created with interval ZERO, so the shutdown drain is the only thing that can
+		// flush the remainder.
+		BatchingAcknowledgementProcessor<String> processor = createProcessor(ACK_INTERVAL_ZERO, messagesToAck -> {
+			acknowledgedMessages.addAll(messagesToAck);
+			return CompletableFuture.completedFuture(null);
+		});
+		processor.start();
+
+		processor.doOnAcknowledge(messages);
+		processor.stop();
+
+		assertThat(acknowledgedMessages).containsExactlyInAnyOrderElementsOf(messages);
+	}
+
+	private static List<Message<String>> buildMessages(int count) {
+		return IntStream.range(0, count).mapToObj(index -> MessageBuilder.withPayload(String.valueOf(index)).build())
+				.collect(Collectors.toList());
+	}
+
+	private static BatchingAcknowledgementProcessor<String> createProcessor(Duration acknowledgementInterval,
+			AcknowledgementExecutor<String> acknowledgementExecutor) {
+		BatchingAcknowledgementProcessor<String> processor = new BatchingAcknowledgementProcessor<>();
+		processor.configure(SqsContainerOptions.builder().acknowledgementInterval(acknowledgementInterval)
+				.acknowledgementThreshold(ACK_THRESHOLD_TEN).acknowledgementOrdering(AcknowledgementOrdering.PARALLEL)
+				.acknowledgementShutdownTimeout(Duration.ofSeconds(10)).build());
+		processor.setTaskExecutor(new SimpleAsyncTaskExecutor());
+		processor.setAcknowledgementExecutor(acknowledgementExecutor);
+		processor.setMaxAcknowledgementsPerBatch(MAX_ACKNOWLEDGEMENTS_PER_BATCH_TEN);
+		processor.setId(ID);
+		return processor;
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description

Fixes #1661.

Messages left in the acknowledgement buffer below `acknowledgementThreshold` are
never flushed on shutdown. The processor spins for the whole
`acknowledgementShutdownTimeout`, logs

```
Acknowledgements did not finish in 20000 ms. Proceeding with shutdown.
```

and then clears the buffer, so those messages are never deleted from SQS and are
redelivered once the visibility timeout expires.

The buffer is now drained from the shutdown wait loop:

```java
private void flushRemainingAcks() {
    if (!this.acks.isEmpty()) {
        return;
    }
    this.context.lock();
    try {
        this.context.executeAllAcks();
    }
    finally {
        this.context.unlock();
    }
}
```

`running` in `AbstractOrderingAcknowledgementProcessor` is also made `volatile`.

## :bulb: Motivation and Context

There are two independent ways to lose the remainder, and draining from the
shutdown wait covers both:

**With a scheduled execution.** `AbstractOrderingAcknowledgementProcessor.stop()`
sets `running = false` before calling `doStop()`, so `scheduleNextExecution()`
refuses to arm the next execution. The polling thread keeps running until the
shutdown timeout elapses (`shouldKeepPollingAcks()`), so it goes on moving
messages into the buffer, and each threshold execution pushes
`lastAcknowledgement` forward. The one already-armed execution then fires with
`lastAcknowledgement` newer than the time it was armed, skips the flush because
`now` is not after `lastAcknowledgement + ackInterval`, and cannot re-arm.

**With no scheduled execution at all.** `ScheduledAcknowledgementExecution.start()`
only arms anything when `ackInterval != Duration.ZERO`. With
`acknowledgementInterval = ZERO` and a positive threshold — a configuration
`doStart()` explicitly allows — the threshold path is the only flush mechanism,
so a sub-threshold remainder is lost on *every* shutdown.

Making the drain part of the shutdown path itself covers both, instead of
depending on a scheduled execution existing and being armed.

Two details in the implementation:

- The flush waits for the ack queue to drain, so batches are not needlessly split.
- It is retried on every iteration of the wait loop rather than executed once. The
  polling thread may be holding a message it has already polled but not yet added
  to the buffer, in which case the queue looks empty while the message is in
  neither the queue nor the buffer.

`running` was written under `lifecycleMonitor` but read unsynchronized from the
polling and scheduler threads via `isRunning()`, so neither thread had any
guarantee of observing `stop()`.

This is load-dependent in the scheduled case, which is why it is easy to miss. It
needs the threshold path to be the dominant flush path, i.e. messages arriving
faster than one `acknowledgementInterval` per batch. We hit it in production after
a scaling change raised per-pod throughput several-fold: pod terminations started
leaving a small number of messages undeleted, visible as a gap between
`NumberOfMessagesReceived` and `NumberOfMessagesDeleted` and as a spike in
`ApproximateAgeOfOldestMessage` matching the visibility timeout.

## :green_heart: How did you test it?

Two new tests, one per loss path. Both are behaviour-only and do not reach into
internals:

- `givenScheduledAcknowledgement_whenStoppedWithRemainderBelowThreshold_...` acks
  exactly `acknowledgementThreshold` messages, waits on a latch in the
  acknowledgement executor so the threshold flush is known to have completed, then
  acks a sub-threshold remainder and stops. The interval outlasts the shutdown
  timeout, so a scheduled execution exists but provably cannot fire during the
  test.
- `givenZeroIntervalAndThreshold_whenStoppedWithRemainderBelowThreshold_...` uses
  `acknowledgementInterval = ZERO`, where no scheduled execution exists.

Both fail on `main` and pass with this change. Measured on JDK 17.0.19, 15
consecutive runs each:

| | result |
| --- | --- |
| with this change | 15/15 pass |
| `main` + `volatile` only | 15/15 reproduce the bug |
| `main` unchanged | 15/15 reproduce the bug |

On failure each test spins the full 10 s shutdown timeout and loses exactly the
5-message remainder.

The three existing shutdown tests could not catch either path: they all use
`acknowledgementInterval(Duration.ZERO)` so no scheduled execution is ever
created, and they use exactly 100 messages against a threshold of 10, so no
remainder is ever left in the buffer.

Full module: `./mvnw -pl spring-cloud-aws-sqs -am test` gives **636 tests, 0
failures, 0 errors, 6 skipped**, spotless checks enabled, including the LocalStack
integration tests.

Rebased onto `main` after #1662 landed, and re-verified with no local patches
applied.

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes

No documentation change needed: this restores the documented behaviour rather
than changing it.

## :crystal_ball: Next steps

Users who cannot wait for a release can switch to an
`ImmediateAcknowledgementProcessor`, which has no buffer and no scheduler, by
setting `acknowledgementInterval(Duration.ZERO)` and leaving
`acknowledgementThreshold` unset — `StandardSqsComponentFactory` selects it when
the interval is `ZERO` and the threshold is `null` or `0`. Anyone who has
explicitly configured a positive threshold needs to set it back to `0` as well,
otherwise they still get the batching processor and the second path above.

