### PR TITLE
Account for acknowledgements not yet added to the buffer on shutdown

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
@@ -78,6 +79,13 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 
 	private BlockingQueue<Message<T>> acks;
 
+	/**
+	 * Number of messages that have been received for acknowledgement but are not in {@link #acks} nor in the buffer yet.
+	 * Incremented before a message is offered to the queue and decremented after it has been added to the buffer, so a
+	 * message is always accounted for while the polling thread is holding it in between the two.
+	 */
+	private final AtomicInteger unbufferedAcks = new AtomicInteger();
+
 	private Integer ackThreshold;
 
 	private Duration ackInterval;
@@ -103,7 +111,9 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 
 	@Override
 	protected CompletableFuture<Void> doOnAcknowledge(Message<T> message) {
+		this.unbufferedAcks.incrementAndGet();
 		if (!this.acks.offer(message)) {
+			this.unbufferedAcks.decrementAndGet();
 			logger.warn("Acknowledgement queue full, dropping acknowledgement for message {}",
 					MessageHeaderUtils.getId(message));
 		}
@@ -128,6 +138,7 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 				() -> getClass().getSimpleName() + " cannot be used with Duration.ZERO and acknowledgement threshold 0."
 						+ "Consider using a " + ImmediateAcknowledgementProcessor.class + "instead");
 		this.acks = new LinkedBlockingQueue<>();
+		this.unbufferedAcks.set(0);
 		this.taskScheduler = createTaskScheduler();
 		this.acknowledgementProcessor = createAcknowledgementProcessor();
 		this.taskExecutor.execute(this.acknowledgementProcessor);
@@ -199,7 +210,12 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 				try {
 					Message<T> polledMessage = this.acks.poll(1, TimeUnit.SECONDS);
 					if (polledMessage != null) {
-						addMessageToBuffer(polledMessage);
+						try {
+							addMessageToBuffer(polledMessage);
+						}
+						finally {
+							this.parent.unbufferedAcks.decrementAndGet();
+						}
 						this.thresholdAcknowledgementExecution.checkAndExecute();
 					}
 				}
@@ -299,12 +315,18 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 			return unfinishedAcks > 0;
 		}
 
+		/**
+		 * Whether any acknowledgement is still unaccounted for. Uses {@link #unbufferedAcks} rather than the queue size
+		 * so that a message the polling thread has already taken off the queue but not yet added to the buffer still
+		 * counts - otherwise the shutdown wait can end while such a message is in flight, and it is then added to a
+		 * buffer that has already been cleared and never acknowledged.
+		 */
 		private boolean hasAcksLeft() {
-			int messagesInAcks = this.acks.size();
+			int unbufferedAcks = this.parent.unbufferedAcks.get();
 			int messagesInAcksBuffer = this.context.acksBuffer.size();
-			logger.trace("Acknowledgement queue has {} messages.", messagesInAcks);
-			logger.trace("Acknowledgement buffer has {} messages.", messagesInAcksBuffer);
-			return messagesInAcksBuffer > 0 || messagesInAcks > 0;
+			logger.trace("{} acknowledgements not buffered yet.", unbufferedAcks);
+			logger.trace("Acknowledgement buffer has {} message groups.", messagesInAcksBuffer);
+			return messagesInAcksBuffer > 0 || unbufferedAcks > 0;
 		}
 
 	}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
@@ -238,6 +238,51 @@ class BatchingAcknowledgementProcessorTests {
 		assertThat(acknowledgedMessages).containsExactlyInAnyOrderElementsOf(messages);
 	}
 
+	@Test
+	void givenMessagePolledButNotBufferedYet_whenStopped_shouldAcknowledgeIt() throws Exception {
+		Message<String> message = MessageBuilder.withPayload("0").build();
+		Collection<Message<String>> acknowledgedMessages = Collections.synchronizedList(new ArrayList<>());
+		CountDownLatch pollingThreadInsideBufferAdd = new CountDownLatch(1);
+		CountDownLatch releasePollingThread = new CountDownLatch(1);
+
+		BatchingAcknowledgementProcessor<String> processor = new BatchingAcknowledgementProcessor<>();
+		processor.configure(SqsContainerOptions.builder().acknowledgementInterval(ACK_INTERVAL_THIRTY_SECONDS)
+				.acknowledgementThreshold(ACK_THRESHOLD_TEN)
+				.acknowledgementOrdering(AcknowledgementOrdering.ORDERED_BY_GROUP)
+				.acknowledgementShutdownTimeout(Duration.ofSeconds(10)).build());
+		// The grouping function is applied while adding the message to the buffer, so blocking in it parks the polling
+		// thread at exactly the point where the message is in neither the queue nor the buffer.
+		processor.setMessageGroupingFunction(messageToGroup -> {
+			pollingThreadInsideBufferAdd.countDown();
+			try {
+				releasePollingThread.await(10, TimeUnit.SECONDS);
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			return "group";
+		});
+		processor.setTaskExecutor(new SimpleAsyncTaskExecutor());
+		processor.setAcknowledgementExecutor(messagesToAck -> {
+			acknowledgedMessages.addAll(messagesToAck);
+			return CompletableFuture.completedFuture(null);
+		});
+		processor.setMaxAcknowledgementsPerBatch(MAX_ACKNOWLEDGEMENTS_PER_BATCH_TEN);
+		processor.setId(ID);
+		processor.start();
+
+		processor.doOnAcknowledge(message);
+		assertThat(pollingThreadInsideBufferAdd.await(10, TimeUnit.SECONDS)).isTrue();
+
+		CompletableFuture<Void> stopping = CompletableFuture.runAsync(processor::stop);
+		// Give the shutdown wait loop, which polls every 200ms, several chances to observe the in-flight message
+		Thread.sleep(1000);
+		releasePollingThread.countDown();
+		stopping.get(30, TimeUnit.SECONDS);
+
+		assertThat(acknowledgedMessages).containsExactly(message);
+	}
+
 	private static List<Message<String>> buildMessages(int count) {
 		return IntStream.range(0, count).mapToObj(index -> MessageBuilder.withPayload(String.valueOf(index)).build())
 				.collect(Collectors.toList());


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description

Follow-up to #1663, for the window we discussed there:

> Yes, let's squash this one as well. It's a narrow window that can only affect one
> message per shutdown, but as you said under contention it widens up.

`hasAcksLeft()` decided whether the shutdown wait was done by looking at the ack
queue and the buffer. A message the polling thread has already taken off the queue
but not yet added to the buffer is in neither of them, so the wait could end while
such a message was in flight.

## :bulb: Motivation and Context

```java
Message<T> polledMessage = this.acks.poll(1, TimeUnit.SECONDS);   // removed from acks
if (polledMessage != null) {
    addMessageToBuffer(polledMessage);                            // not in the buffer yet
```

If the wait loop sampled in between, it saw nothing left and returned.
`waitAcknowledgementsToFinish()` then set `isTimeoutElapsed` and cleared the
buffer, and the polling thread added the message to a buffer nothing would ever
flush.

Unlike the case fixed in #1663, this one produces **no warning at all** — the wait
loop exits normally rather than timing out, so there is nothing in the logs to
suggest a message was dropped. In the test below the unfixed run finishes in 1.6 s
instead of spinning the 10 s shutdown timeout.

At most one message per shutdown can be in this window, since the polling thread
handles one at a time. It widens whenever `addMessageToBuffer()` has to wait on the
buffer lock, which happens while an execution is being dispatched — and for
`AcknowledgementOrdering.ORDERED` that dispatch takes the ordered execution lock
while holding the buffer lock.

The fix tracks the messages that have been received but are in neither the queue
nor the buffer, and includes them in `hasAcksLeft()`. The counter is incremented
before the message is offered to the queue and decremented after it has been added
to the buffer, so it is never undercounted. It is briefly double counted while the
message sits in the buffer, which only makes the wait more conservative.

`hasAcksLeft()` now uses the counter in place of `acks.size()`, since the counter
is always greater than or equal to it.

I left `flushRemainingAcks()` gated on `acks.isEmpty()` as it is. Its purpose is to
avoid splitting batches, not to decide when the wait is over, and if it does flush
while a message is in flight that message is simply picked up by the next iteration
now that `hasAcksLeft()` accounts for it.

## :green_heart: How did you test it?

`givenMessagePolledButNotBufferedYet_whenStopped_shouldAcknowledgeIt` reproduces
the window deterministically through a public extension point rather than by
reaching into internals. The message grouping function is applied inside
`addMessageToBuffer()` while the buffer lock is held, so a grouping function that
blocks parks the polling thread at exactly the point where the message is in
neither the queue nor the buffer. The test then calls `stop()` from another thread,
gives the wait loop several 200 ms iterations to sample, and releases the polling
thread.

Measured on JDK 17.0.19, 15 consecutive runs each:

| | result |
| --- | --- |
| with this change | 15/15 pass |
| `main` | 15/15 reproduce the bug |

On `main` the assertion shows no acknowledgement was executed at all:

```
Expecting actual:
  []
to contain exactly (and in same order):
  [GenericMessage [payload=0, ...]]
```

Full module: `./mvnw -pl spring-cloud-aws-sqs -am test` gives **637 tests, 0
failures, 0 errors, 6 skipped**, spotless checks enabled, including the LocalStack
integration tests.

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes

No documentation change needed: this restores the documented behaviour rather than
changing it.

## :crystal_ball: Next steps

Nothing further from me on this path. The remaining structural asymmetry is that
the polling thread's lifetime is bounded by `isTimeoutElapsed`, which is only set
after the wait loop has already decided it is finished — so correctness relies on
the wait loop accounting for everything the polling thread might still be holding,
rather than on the polling thread having demonstrably stopped. Making the wait join
the polling thread would remove that reliance, but it is a bigger change than this
one and I did not want to fold it in.
