### PR TITLE
Enable parallel Maven reactor builds in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: ${{ matrix.version }}
           cache: maven
       - name: Build with Maven
-        run: ./mvnw -V -B verify -Pspring
+        run: ./mvnw -V -B -T 1C verify -Pspring
   docs:
     name: Validate Docs
     runs-on: ubuntu-latest
@@ -62,4 +62,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./mvnw -V -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Pcoverage,spring
+        run: ./mvnw -V -B -T 1C verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Pcoverage,spring


### PR DESCRIPTION
## Motivation

A full `verify` on CI currently takes ~15 minutes running the 49-module reactor sequentially, while the heavy modules (Kinesis, SQS, SNS, Autoconfigure) spend most of that time waiting on LocalStack interactions rather than using CPU. Five modules account for ~12 of those minutes, and they have no dependency on each other.

## Change

Add `-T 1C` to the Maven invocations in the `build` and `sonar` jobs, so independent modules build concurrently (one thread per core; the module remains the unit of parallelism: nothing changes within a module's lifecycle). Wall-clock drops to roughly the longest dependency chain in the reactor instead of the sum of all modules.

## Validation

- Full `clean verify -Pspring` compared sequential vs `-T 1C` locally: **~2.4× faster wall-clock**.
- JaCoCo instruments per-module (`@{argLine}` resolves per surefire fork), and the `sonar` goal runs once at the end of the reactor, so the coverage pipeline is unaffected by build threading.

## Notes

- Testcontainers handles concurrent LocalStack instances (random host ports, shared Ryuk); Docker deduplicates concurrent pulls of the same image.
- Known trade-off: module log output interleaves under `-T` with Maven 3.x, which makes CI failure logs a bit harder to scan. Properly buffered per-module output needs Maven 4.
- A failure in one module no longer stops unrelated modules mid-flight — you get more of the build's failures per run.
