### PR TITLE
Preserve generic SQS listener payload types

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -1782,8 +1782,12 @@ This allows payloads to be deserialized early in the message processing flow wit
 
 This enables accessing the deserialized payload in components such as `MessageInterceptor`, `ErrorHandler`, and `AcknowledgementResultCallback` without type headers.
 
-The inference supports simple types, generic types like `List<MyEvent>`, `Message<MyEvent>`, and `List<Message<MyEvent>>`.
+The inference supports simple types, generic types like `List<MyEvent>`, `Message<MyEvent>`,
+`List<Message<MyEvent>>`, `Wrapper<MyEvent>`, and `Message<List<MyEvent>>`.
 Parameters annotated with `@Payload` are explicitly recognized as the payload parameter.
+
+Generic type information is provided to payload converters through the `SmartMessageConverter` conversion hint.
+Custom payload converters that only implement `MessageConverter` continue to receive the inferred raw payload class.
 
 For polymorphic types (interfaces, `Object`, or `@SqsHandler` methods), a custom mapper is required.
 See <<Custom payload type mapping>>.

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/AbstractEndpoint.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/AbstractEndpoint.java
@@ -211,10 +211,10 @@ public abstract class AbstractEndpoint implements HandlerMethodEndpoint {
 
 		if (this.methodPayloadTypeInferrer != null
 				&& container instanceof AbstractMessageListenerContainer<?, ?, ?> amlc) {
-			Class<?> inferredType = this.methodPayloadTypeInferrer.inferPayloadType(this.method,
+			MethodPayloadMetadata payloadMetadata = this.methodPayloadTypeInferrer.inferPayloadMetadata(this.method,
 					this.argumentResolvers);
-			if (inferredType != null) {
-				amlc.setPayloadDeserializationType(inferredType);
+			if (payloadMetadata != null) {
+				amlc.setPayloadDeserializationType(payloadMetadata.payloadClass(), payloadMetadata.conversionHint());
 			}
 			disableDefaultPayloadTypeMapper(amlc);
 		}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/DefaultMethodPayloadTypeInferrer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/DefaultMethodPayloadTypeInferrer.java
@@ -49,7 +49,15 @@ public class DefaultMethodPayloadTypeInferrer implements MethodPayloadTypeInferr
 
 	@Override
 	@Nullable
-	public Class<?> inferPayloadType(Method method, List<HandlerMethodArgumentResolver> argumentResolvers) {
+	public Class<?> inferPayloadType(Method method, @Nullable List<HandlerMethodArgumentResolver> argumentResolvers) {
+		MethodPayloadMetadata metadata = inferPayloadMetadata(method, argumentResolvers);
+		return metadata != null ? metadata.payloadClass() : null;
+	}
+
+	@Override
+	@Nullable
+	public MethodPayloadMetadata inferPayloadMetadata(Method method,
+			@Nullable List<HandlerMethodArgumentResolver> argumentResolvers) {
 		if (argumentResolvers == null || argumentResolvers.isEmpty()) {
 			return null;
 		}
@@ -61,14 +69,14 @@ public class DefaultMethodPayloadTypeInferrer implements MethodPayloadTypeInferr
 			MethodParameter parameter = new MethodParameter(method, i);
 
 			if (parameter.hasParameterAnnotation(Payload.class)) {
-				return extractClass(parameter.getGenericParameterType());
+				return extractMetadata(parameter);
 			}
 
 			boolean supportedByNonPayloadResolver = nonPayloadResolvers.stream()
 					.anyMatch(resolver -> resolver.supportsParameter(parameter));
 
 			if (!supportedByNonPayloadResolver) {
-				return extractClass(parameter.getGenericParameterType());
+				return extractMetadata(parameter);
 			}
 		}
 
@@ -76,13 +84,14 @@ public class DefaultMethodPayloadTypeInferrer implements MethodPayloadTypeInferr
 	}
 
 	/**
-	 * Extract the target class for payload conversion from the inferred type. Handles generic types like
-	 * {@code List<CustomEvent>} by extracting the element type.
-	 * @param type the inferred payload type
-	 * @return the class to be used for payload conversion, or null if cannot be determined
+	 * Extract the target class and conversion hint from the inferred payload parameter. Collection parameters represent
+	 * batch listeners, so the conversion hint is nested to point at the payload of each individual message. Other
+	 * parameters retain the method parameter so smart converters can recover their generic type.
+	 * @param parameter the inferred payload method parameter
+	 * @return the metadata to be used for payload conversion
 	 */
-	@Nullable
-	private Class<?> extractClass(Type type) {
+	private MethodPayloadMetadata extractMetadata(MethodParameter parameter) {
+		Type type = parameter.getGenericParameterType();
 		ResolvableType resolvableType = ResolvableType.forType(type);
 		Class<?> rawClass = resolvableType.toClass();
 
@@ -91,18 +100,17 @@ public class DefaultMethodPayloadTypeInferrer implements MethodPayloadTypeInferr
 			Class<?> elementClass = resolvableType.getNested(2).toClass();
 			// If it's a Collection of Messages (e.g., List<Message<CustomEvent>>), go one level deeper
 			if (Message.class.isAssignableFrom(elementClass)) {
-				return resolvableType.getNested(3).toClass();
+				return new MethodPayloadMetadata(resolvableType.getNested(3).toClass(), parameter.nested().nested());
 			}
-			return elementClass;
+			return new MethodPayloadMetadata(elementClass, parameter.nested());
 		}
 
 		// If it's a Message<T>, unwrap to get T
 		if (Message.class.isAssignableFrom(rawClass)) {
-			return resolvableType.getNested(2).toClass();
+			return new MethodPayloadMetadata(resolvableType.getNested(2).toClass(), parameter);
 		}
 
-		// For simple types, return as-is
-		return rawClass;
+		return new MethodPayloadMetadata(rawClass, parameter);
 	}
 
 	private boolean isPayloadResolver(HandlerMethodArgumentResolver resolver) {

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/MethodPayloadMetadata.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/MethodPayloadMetadata.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.config;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Metadata inferred from a listener method payload parameter.
+ * @param payloadClass the raw class used as the message conversion target
+ * @param conversionHint an optional hint passed to a
+ * {@link org.springframework.messaging.converter.SmartMessageConverter}
+ * @author Bruno Augusto Garcia
+ * @since 4.1.0
+ */
+public record MethodPayloadMetadata(Class<?> payloadClass, @Nullable Object conversionHint) {
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/MethodPayloadTypeInferrer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/MethodPayloadTypeInferrer.java
@@ -40,4 +40,20 @@ public interface MethodPayloadTypeInferrer {
 	@Nullable
 	Class<?> inferPayloadType(Method method, @Nullable List<HandlerMethodArgumentResolver> argumentResolvers);
 
+	/**
+	 * Infer payload metadata from the given method and its argument resolvers.
+	 * <p>
+	 * The default implementation adapts existing {@link MethodPayloadTypeInferrer} implementations by returning the
+	 * inferred class without a conversion hint.
+	 * @param method the listener method
+	 * @param argumentResolvers the argument resolvers available for this method, may be null or empty
+	 * @return the inferred payload metadata, or null if it cannot be determined
+	 */
+	@Nullable
+	default MethodPayloadMetadata inferPayloadMetadata(Method method,
+			@Nullable List<HandlerMethodArgumentResolver> argumentResolvers) {
+		Class<?> payloadClass = inferPayloadType(method, argumentResolvers);
+		return payloadClass != null ? new MethodPayloadMetadata(payloadClass, null) : null;
+	}
+
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/MethodPayloadTypeInferrer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/config/MethodPayloadTypeInferrer.java
@@ -33,11 +33,29 @@ public interface MethodPayloadTypeInferrer {
 
 	/**
 	 * Infer the payload class from the given method and its argument resolvers.
+	 * @deprecated in favor of {@link #inferPayloadMetadata(Method, List)}
 	 * @param method the listener method
 	 * @param argumentResolvers the argument resolvers available for this method, may be null or empty
 	 * @return the inferred payload class, or null if it cannot be determined
 	 */
 	@Nullable
+	@Deprecated
 	Class<?> inferPayloadType(Method method, @Nullable List<HandlerMethodArgumentResolver> argumentResolvers);
+
+	/**
+	 * Infer payload metadata from the given method and its argument resolvers.
+	 * <p>
+	 * The default implementation adapts existing {@link MethodPayloadTypeInferrer} implementations by returning the
+	 * inferred class without a conversion hint.
+	 * @param method the listener method
+	 * @param argumentResolvers the argument resolvers available for this method, may be null or empty
+	 * @return the inferred payload metadata, or null if it cannot be determined
+	 */
+	@Nullable
+	default MethodPayloadMetadata inferPayloadMetadata(Method method,
+			@Nullable List<HandlerMethodArgumentResolver> argumentResolvers) {
+		Class<?> payloadClass = inferPayloadType(method, argumentResolvers);
+		return payloadClass != null ? new MethodPayloadMetadata(payloadClass, null) : null;
+	}
 
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
@@ -74,6 +74,9 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 	@Nullable
 	private Class<?> payloadDeserializationType;
 
+	@Nullable
+	private Object payloadConversionHint;
+
 	/**
 	 * Create an instance with the provided {@link ContainerOptions}
 	 * @param containerOptions the options instance.
@@ -190,6 +193,21 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 	 */
 	public void setPayloadDeserializationType(@Nullable Class<?> payloadDeserializationType) {
 		this.payloadDeserializationType = payloadDeserializationType;
+		this.payloadConversionHint = null;
+	}
+
+	/**
+	 * Set the target type and conversion hint for payload deserialization.
+	 * <p>
+	 * Since 4.0.0, the target type is typically inferred automatically from the {@code @SqsListener} method signature.
+	 * A conversion hint can additionally preserve generic type information from that method.
+	 * @param payloadDeserializationType the target type for deserialization
+	 * @param conversionHint an optional hint for a smart message converter
+	 */
+	public void setPayloadDeserializationType(@Nullable Class<?> payloadDeserializationType,
+			@Nullable Object conversionHint) {
+		setPayloadDeserializationType(payloadDeserializationType);
+		this.payloadConversionHint = payloadDeserializationType != null ? conversionHint : null;
 	}
 
 	/**
@@ -254,6 +272,15 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 	@Nullable
 	public Class<?> getPayloadDeserializationType() {
 		return this.payloadDeserializationType;
+	}
+
+	/**
+	 * Return the payload conversion hint, or null if not set.
+	 * @return the payload conversion hint.
+	 */
+	@Nullable
+	public Object getPayloadConversionHint() {
+		return this.payloadConversionHint;
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainer.java
@@ -74,6 +74,9 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 	@Nullable
 	private Class<?> payloadDeserializationType;
 
+	@Nullable
+	private Object payloadConversionHint;
+
 	/**
 	 * Create an instance with the provided {@link ContainerOptions}
 	 * @param containerOptions the options instance.
@@ -189,7 +192,21 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 	 * @see io.awspring.cloud.sqs.support.converter.AbstractMessagingMessageConverter
 	 */
 	public void setPayloadDeserializationType(@Nullable Class<?> payloadDeserializationType) {
+		setPayloadDeserializationType(payloadDeserializationType, null);
+	}
+
+	/**
+	 * Set the target type and conversion hint for payload deserialization.
+	 * <p>
+	 * Since 4.0.0, the target type is typically inferred automatically from the {@code @SqsListener} method signature.
+	 * A conversion hint can additionally preserve generic type information from that method.
+	 * @param payloadDeserializationType the target type for deserialization
+	 * @param conversionHint an optional hint for a smart message converter
+	 */
+	public void setPayloadDeserializationType(@Nullable Class<?> payloadDeserializationType,
+			@Nullable Object conversionHint) {
 		this.payloadDeserializationType = payloadDeserializationType;
+		this.payloadConversionHint = payloadDeserializationType != null ? conversionHint : null;
 	}
 
 	/**
@@ -254,6 +271,15 @@ public abstract class AbstractMessageListenerContainer<T, O extends ContainerOpt
 	@Nullable
 	public Class<?> getPayloadDeserializationType() {
 		return this.payloadDeserializationType;
+	}
+
+	/**
+	 * Return the payload conversion hint, or null if not set.
+	 * @return the payload conversion hint.
+	 */
+	@Nullable
+	public Object getPayloadConversionHint() {
+		return this.payloadConversionHint;
 	}
 
 	@Override

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractPipelineMessageListenerContainer.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/AbstractPipelineMessageListenerContainer.java
@@ -172,7 +172,7 @@ public abstract class AbstractPipelineMessageListenerContainer<T, O extends Cont
 						teac -> teac.setTaskExecutor(taskExecutor))
 				.acceptManyIfNotNullAndInstance(getPayloadDeserializationType(), this.messageSources,
 						AbstractMessageConvertingMessageSource.class,
-						(type, source) -> source.setPayloadDeserializationType(type));
+						(type, source) -> source.setPayloadDeserializationType(type, getPayloadConversionHint()));
 
 		doConfigureMessageSources(this.messageSources);
 	}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractMessageConvertingMessageSource.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractMessageConvertingMessageSource.java
@@ -90,12 +90,38 @@ public abstract class AbstractMessageConvertingMessageSource<T, S> implements Me
 	}
 
 	/**
+	 * Set the payload deserialization type and conversion hint.
+	 * @param payloadDeserializationType the target class
+	 * @param conversionHint an optional hint for a smart message converter
+	 */
+	public void setPayloadDeserializationType(@Nullable Class<?> payloadDeserializationType,
+			@Nullable Object conversionHint) {
+		ConfigUtils.INSTANCE.acceptBothIfNoneNull(payloadDeserializationType, this.messageConversionContext,
+				(payloadType, context) -> doConfigurePayloadTypeOnContext(payloadType, conversionHint, context));
+	}
+
+	/**
 	 * Hook method for subclasses to configure the payload type on their specific MessageConversionContext
 	 * implementation.
 	 * @param payloadType the payload type to configure
 	 * @param context the message conversion context
 	 */
 	protected void doConfigurePayloadTypeOnContext(Class<?> payloadType, MessageConversionContext context) {
+	}
+
+	/**
+	 * Hook method for subclasses to configure the payload type and conversion hint on their specific
+	 * {@link MessageConversionContext} implementation.
+	 * <p>
+	 * The default implementation delegates to {@link #doConfigurePayloadTypeOnContext(Class, MessageConversionContext)}
+	 * for backwards compatibility with existing subclasses.
+	 * @param payloadType the payload type to configure
+	 * @param conversionHint an optional hint for a smart message converter
+	 * @param context the message conversion context
+	 */
+	protected void doConfigurePayloadTypeOnContext(Class<?> payloadType, @Nullable Object conversionHint,
+			MessageConversionContext context) {
+		doConfigurePayloadTypeOnContext(payloadType, context);
 	}
 
 	@Nullable

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractMessageConvertingMessageSource.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractMessageConvertingMessageSource.java
@@ -85,8 +85,18 @@ public abstract class AbstractMessageConvertingMessageSource<T, S> implements Me
 	 * @param payloadDeserializationType the target class
 	 */
 	public void setPayloadDeserializationType(@Nullable Class<?> payloadDeserializationType) {
+		this.setPayloadDeserializationType(payloadDeserializationType, null);
+	}
+
+	/**
+	 * Set the payload deserialization type and conversion hint.
+	 * @param payloadDeserializationType the target class
+	 * @param conversionHint an optional hint for a smart message converter
+	 */
+	public void setPayloadDeserializationType(@Nullable Class<?> payloadDeserializationType,
+			@Nullable Object conversionHint) {
 		ConfigUtils.INSTANCE.acceptBothIfNoneNull(payloadDeserializationType, this.messageConversionContext,
-				this::doConfigurePayloadTypeOnContext);
+				(payloadType, context) -> doConfigurePayloadTypeOnContext(payloadType, conversionHint, context));
 	}
 
 	/**
@@ -96,6 +106,21 @@ public abstract class AbstractMessageConvertingMessageSource<T, S> implements Me
 	 * @param context the message conversion context
 	 */
 	protected void doConfigurePayloadTypeOnContext(Class<?> payloadType, MessageConversionContext context) {
+	}
+
+	/**
+	 * Hook method for subclasses to configure the payload type and conversion hint on their specific
+	 * {@link MessageConversionContext} implementation.
+	 * <p>
+	 * The default implementation delegates to {@link #doConfigurePayloadTypeOnContext(Class, MessageConversionContext)}
+	 * for backwards compatibility with existing subclasses.
+	 * @param payloadType the payload type to configure
+	 * @param conversionHint an optional hint for a smart message converter
+	 * @param context the message conversion context
+	 */
+	protected void doConfigurePayloadTypeOnContext(Class<?> payloadType, @Nullable Object conversionHint,
+			MessageConversionContext context) {
+		doConfigurePayloadTypeOnContext(payloadType, context);
 	}
 
 	@Nullable

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSource.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSource.java
@@ -56,9 +56,9 @@ import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
  * </p>
  *
  * <p>
- * Note that currently the payload is not converted here and is returned as String. The actual conversion to the
- * {@link io.awspring.cloud.sqs.annotation.SqsListener} argument type happens on
- * {@link org.springframework.messaging.handler.invocation.InvocableHandlerMethod} invocation.
+ * Payload conversion happens in the message source before the resulting message is emitted to the message sink and
+ * processing pipeline. When available, the inferred listener payload class and conversion hint are configured on the
+ * {@link SqsMessageConversionContext} and used by the messaging message converter during this step.
  * </p>
  *
  * @param <T> the {@link Message} payload type.
@@ -137,8 +137,16 @@ public abstract class AbstractSqsMessageSource<T> extends AbstractPollingMessage
 
 	@Override
 	protected void doConfigurePayloadTypeOnContext(Class<?> payloadType, MessageConversionContext context) {
-		ConfigUtils.INSTANCE.acceptIfInstance(context, SqsMessageConversionContext.class,
-				ctx -> ctx.setPayloadClass(payloadType));
+		doConfigurePayloadTypeOnContext(payloadType, null, context);
+	}
+
+	@Override
+	protected void doConfigurePayloadTypeOnContext(Class<?> payloadType, @Nullable Object conversionHint,
+			MessageConversionContext context) {
+		ConfigUtils.INSTANCE.acceptIfInstance(context, SqsMessageConversionContext.class, ctx -> {
+			ctx.setPayloadClass(payloadType);
+			ctx.setConversionHint(conversionHint);
+		});
 	}
 
 	// @formatter:off

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSource.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSource.java
@@ -56,9 +56,9 @@ import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
  * </p>
  *
  * <p>
- * Note that currently the payload is not converted here and is returned as String. The actual conversion to the
- * {@link io.awspring.cloud.sqs.annotation.SqsListener} argument type happens on
- * {@link org.springframework.messaging.handler.invocation.InvocableHandlerMethod} invocation.
+ * Payload conversion happens in the message source before the resulting message is emitted to the message sink and
+ * processing pipeline. When available, the inferred listener payload class and conversion hint are configured on the
+ * {@link SqsMessageConversionContext} and used by the messaging message converter during this step.
  * </p>
  *
  * @param <T> the {@link Message} payload type.
@@ -139,6 +139,14 @@ public abstract class AbstractSqsMessageSource<T> extends AbstractPollingMessage
 	protected void doConfigurePayloadTypeOnContext(Class<?> payloadType, MessageConversionContext context) {
 		ConfigUtils.INSTANCE.acceptIfInstance(context, SqsMessageConversionContext.class,
 				ctx -> ctx.setPayloadClass(payloadType));
+	}
+
+	@Override
+	protected void doConfigurePayloadTypeOnContext(Class<?> payloadType, @Nullable Object conversionHint,
+			MessageConversionContext context) {
+		doConfigurePayloadTypeOnContext(payloadType, context);
+		ConfigUtils.INSTANCE.acceptIfInstance(context, SqsMessageConversionContext.class,
+				ctx -> ctx.setConversionHint(conversionHint));
 	}
 
 	// @formatter:off

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/AbstractMessagingMessageConverter.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.converter.SmartMessageConverter;
 import org.springframework.messaging.converter.StringMessageConverter;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.Assert;
@@ -171,19 +172,23 @@ public abstract class AbstractMessagingMessageConverter<S> implements ContextAwa
 	private Object convertPayload(S message, MessageHeaders messageHeaders,
 			@Nullable MessageConversionContext context) {
 		Message<?> messagingMessage = MessageBuilder.createMessage(getPayloadToDeserialize(message), messageHeaders);
-		Class<?> targetType = getTargetType(messagingMessage, context);
-		return targetType != null
-				? Objects.requireNonNull(this.payloadMessageConverter.fromMessage(messagingMessage, targetType),
-						"payloadMessageConverter returned null payload")
+		Class<?> mappedTargetType = this.payloadTypeMapper.apply(messagingMessage);
+		if (mappedTargetType != null) {
+			return convertPayload(messagingMessage, mappedTargetType, null);
+		}
+
+		Class<?> inferredTargetType = context != null ? context.getPayloadClass() : null;
+		return inferredTargetType != null
+				? convertPayload(messagingMessage, inferredTargetType, context.getConversionHint())
 				: messagingMessage.getPayload();
 	}
 
-	@Nullable
-	private Class<?> getTargetType(Message<?> messagingMessage, @Nullable MessageConversionContext context) {
-		Class<?> classFromTypeMapper = this.payloadTypeMapper.apply(messagingMessage);
-		return classFromTypeMapper == null && context != null && context.getPayloadClass() != null
-				? context.getPayloadClass()
-				: classFromTypeMapper;
+	private Object convertPayload(Message<?> message, Class<?> targetType, @Nullable Object conversionHint) {
+		Object convertedPayload = conversionHint != null
+				&& this.payloadMessageConverter instanceof SmartMessageConverter smartMessageConverter
+						? smartMessageConverter.fromMessage(message, targetType, conversionHint)
+						: this.payloadMessageConverter.fromMessage(message, targetType);
+		return Objects.requireNonNull(convertedPayload, "payloadMessageConverter returned null payload");
 	}
 
 	protected abstract Object getPayloadToDeserialize(S message);

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessageConversionContext.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/MessageConversionContext.java
@@ -33,4 +33,13 @@ public interface MessageConversionContext {
 	@Nullable
 	Class<?> getPayloadClass();
 
+	/**
+	 * An optional hint to be used by the payload conversion process.
+	 * @return the conversion hint.
+	 */
+	@Nullable
+	default Object getConversionHint() {
+		return null;
+	}
+
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessageConversionContext.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/support/converter/SqsMessageConversionContext.java
@@ -48,6 +48,9 @@ public class SqsMessageConversionContext
 	@Nullable
 	private Class<?> payloadClass;
 
+	@Nullable
+	private Object conversionHint;
+
 	@Override
 	public void setQueueAttributes(QueueAttributes queueAttributes) {
 		this.queueAttributes = queueAttributes;
@@ -65,6 +68,10 @@ public class SqsMessageConversionContext
 
 	public void setPayloadClass(Class<?> payloadClass) {
 		this.payloadClass = payloadClass;
+	}
+
+	public void setConversionHint(@Nullable Object conversionHint) {
+		this.conversionHint = conversionHint;
 	}
 
 	@Nullable
@@ -86,5 +93,11 @@ public class SqsMessageConversionContext
 	@Nullable
 	public Class<?> getPayloadClass() {
 		return this.payloadClass;
+	}
+
+	@Nullable
+	@Override
+	public Object getConversionHint() {
+		return this.conversionHint;
 	}
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/config/AbstractEndpointTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/config/AbstractEndpointTest.java
@@ -122,6 +122,21 @@ class AbstractEndpointTest {
 	}
 
 	@Test
+	void shouldConfigurePayloadDeserializationMetadataOnContainer() throws Exception {
+		Method method = TestListener.class.getMethod("handleMessage", String.class);
+		MethodParameter conversionHint = new MethodParameter(method, 0);
+		MethodPayloadMetadata metadata = new MethodPayloadMetadata(String.class, conversionHint);
+		endpoint.setMethod(method);
+		endpoint.setMethodPayloadTypeInferrer(inferrer);
+
+		when(inferrer.inferPayloadMetadata(any(Method.class), any())).thenReturn(metadata);
+
+		endpoint.setupContainer(container);
+
+		verify(container).setPayloadDeserializationType(String.class, conversionHint);
+	}
+
+	@Test
 	@SuppressWarnings("unchecked")
 	void shouldNotOverrideCustomMapper() throws Exception {
 		Method method = TestListener.class.getMethod("handleMessage", String.class);

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/config/DefaultMethodPayloadTypeInferrerTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/config/DefaultMethodPayloadTypeInferrerTest.java
@@ -257,6 +257,86 @@ class DefaultMethodPayloadTypeInferrerTest {
 		assertThat(result).isEqualTo(CustomEvent.class);
 	}
 
+	@Test
+	void shouldPreserveMethodParameterAsConversionHintForGenericWrapper() throws Exception {
+		Method method = TestMethods.class.getMethod("genericWrapperOfCustomEvent", GenericWrapper.class);
+
+		MethodPayloadMetadata metadata = inferrer.inferPayloadMetadata(method, createNonSupportingResolvers());
+
+		assertThat(metadata).isNotNull();
+		assertThat(metadata.payloadClass()).isEqualTo(GenericWrapper.class);
+		assertThat(metadata.conversionHint()).isInstanceOfSatisfying(MethodParameter.class, methodParameter -> {
+			assertThat(methodParameter.getMethod()).isEqualTo(method);
+			assertThat(methodParameter.getParameterIndex()).isZero();
+			assertThat(methodParameter.getGenericParameterType()).isEqualTo(method.getGenericParameterTypes()[0]);
+		});
+	}
+
+	@Test
+	void shouldPreserveMethodParameterAsConversionHintForMessageWithGenericCollectionPayload() throws Exception {
+		Method method = TestMethods.class.getMethod("messageOfListOfCustomEvents", Message.class);
+
+		MethodPayloadMetadata metadata = inferrer.inferPayloadMetadata(method, createNonSupportingResolvers());
+
+		assertThat(metadata).isNotNull();
+		assertThat(metadata.payloadClass()).isEqualTo(List.class);
+		assertThat(metadata.conversionHint()).isInstanceOfSatisfying(MethodParameter.class, methodParameter -> {
+			assertThat(methodParameter.getMethod()).isEqualTo(method);
+			assertThat(methodParameter.getParameterIndex()).isZero();
+			assertThat(methodParameter.getGenericParameterType()).isEqualTo(method.getGenericParameterTypes()[0]);
+		});
+	}
+
+	@Test
+	void shouldNestConversionHintForBatchGenericWrapper() throws Exception {
+		Method method = TestMethods.class.getMethod("listOfGenericWrapperOfCustomEvent", List.class);
+
+		MethodPayloadMetadata metadata = inferrer.inferPayloadMetadata(method, createNonSupportingResolvers());
+
+		assertThat(metadata).isNotNull();
+		assertThat(metadata.payloadClass()).isEqualTo(GenericWrapper.class);
+		assertThat(metadata.conversionHint()).isInstanceOfSatisfying(MethodParameter.class, methodParameter -> {
+			assertThat(methodParameter.getNestingLevel()).isEqualTo(2);
+			assertThat(methodParameter.getNestedGenericParameterType().getTypeName())
+					.isEqualTo(GenericWrapper.class.getName() + "<" + CustomEvent.class.getName() + ">");
+		});
+	}
+
+	@Test
+	void shouldNestConversionHintPastMessageForBatchGenericWrapper() throws Exception {
+		Method method = TestMethods.class.getMethod("listOfMessageOfGenericWrapperOfCustomEvent", List.class);
+
+		MethodPayloadMetadata metadata = inferrer.inferPayloadMetadata(method, createNonSupportingResolvers());
+
+		assertThat(metadata).isNotNull();
+		assertThat(metadata.payloadClass()).isEqualTo(GenericWrapper.class);
+		assertThat(metadata.conversionHint()).isInstanceOfSatisfying(MethodParameter.class, methodParameter -> {
+			assertThat(methodParameter.getNestingLevel()).isEqualTo(3);
+			assertThat(methodParameter.getNestedGenericParameterType().getTypeName())
+					.isEqualTo(GenericWrapper.class.getName() + "<" + CustomEvent.class.getName() + ">");
+		});
+	}
+
+	@Test
+	void shouldAdaptCustomInferrerToPayloadMetadataWithoutConversionHint() throws Exception {
+		Method method = TestMethods.class.getMethod("customEventPayload", CustomEvent.class);
+		MethodPayloadTypeInferrer customInferrer = (listenerMethod, argumentResolvers) -> CustomEvent.class;
+
+		MethodPayloadMetadata metadata = customInferrer.inferPayloadMetadata(method, createNonSupportingResolvers());
+
+		assertThat(metadata).isEqualTo(new MethodPayloadMetadata(CustomEvent.class, null));
+	}
+
+	@Test
+	void shouldReturnNullMetadataWhenCustomInferrerCannotInferPayloadType() throws Exception {
+		Method method = TestMethods.class.getMethod("customEventPayload", CustomEvent.class);
+		MethodPayloadTypeInferrer customInferrer = (listenerMethod, argumentResolvers) -> null;
+
+		MethodPayloadMetadata metadata = customInferrer.inferPayloadMetadata(method, createNonSupportingResolvers());
+
+		assertThat(metadata).isNull();
+	}
+
 	// ========== Various Payload Type Tests ==========
 
 	@Test
@@ -438,6 +518,20 @@ class DefaultMethodPayloadTypeInferrerTest {
 		return createStandardResolvers();
 	}
 
+	private List<HandlerMethodArgumentResolver> createNonSupportingResolvers() {
+		return List.of(new HandlerMethodArgumentResolver() {
+			@Override
+			public boolean supportsParameter(MethodParameter parameter) {
+				return false;
+			}
+
+			@Override
+			public Object resolveArgument(MethodParameter parameter, Message<?> message) {
+				return null;
+			}
+		});
+	}
+
 	private List<HandlerMethodArgumentResolver> createMixedResolvers() {
 		List<HandlerMethodArgumentResolver> resolvers = createStandardResolvers();
 
@@ -548,12 +642,38 @@ class DefaultMethodPayloadTypeInferrerTest {
 		public void collectionOfMessageOfCustomEvent(Collection<Message<CustomEvent>> messages) {
 		}
 
+		public void genericWrapperOfCustomEvent(GenericWrapper<CustomEvent> event) {
+		}
+
+		public void messageOfListOfCustomEvents(Message<List<CustomEvent>> message) {
+		}
+
+		public void listOfGenericWrapperOfCustomEvent(List<GenericWrapper<CustomEvent>> events) {
+		}
+
+		public void listOfMessageOfGenericWrapperOfCustomEvent(List<Message<GenericWrapper<CustomEvent>>> messages) {
+		}
+
 		// Message parameter
 		public void messageParameter(Message<?> message) {
 		}
 
 		// Only payload
 		public void onlyPayload(CustomEvent payload) {
+		}
+
+	}
+
+	static class GenericWrapper<T> {
+
+		private T value;
+
+		public T getValue() {
+			return this.value;
+		}
+
+		public void setValue(T value) {
+			this.value = value;
 		}
 
 	}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsPayloadTypeInferenceIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsPayloadTypeInferenceIntegrationTests.java
@@ -92,6 +92,14 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 
 	static final String ERROR_HANDLER_TEST_QUEUE = "error_handler_type_inference_queue";
 
+	static final String INFERS_MESSAGE_LIST_PAYLOAD_QUEUE = "infers_message_list_payload_queue";
+
+	static final String INFERS_GENERIC_WRAPPER_PAYLOAD_QUEUE = "infers_generic_outer_payload_queue";
+
+	static final String INFERS_BATCH_GENERIC_WRAPPER_PAYLOAD_QUEUE = "infers_batch_generic_outer_payload_queue";
+
+	static final String INFERS_BATCH_MESSAGE_GENERIC_WRAPPER_PAYLOAD_QUEUE = "infers_batch_message_generic_outer_payload_queue";
+
 	static final String MANUAL_ACK_FACTORY = "manualAckFactory";
 
 	static final String CUSTOM_CONVERTER_FACTORY = "customConverterFactory";
@@ -105,7 +113,10 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 				createQueue(client, ASYNC_LISTENER_QUEUE), createQueue(client, BATCH_MESSAGE_WRAPPER_QUEUE),
 				createQueue(client, IGNORES_TYPE_HEADER_QUEUE), createQueue(client, EXPLICIT_PAYLOAD_ANNOTATION_QUEUE),
 				createQueue(client, STRING_PAYLOAD_QUEUE), createQueue(client, CUSTOM_CONVERTER_QUEUE),
-				createQueue(client, ERROR_HANDLER_TEST_QUEUE)).join();
+				createQueue(client, ERROR_HANDLER_TEST_QUEUE), createQueue(client, INFERS_MESSAGE_LIST_PAYLOAD_QUEUE),
+				createQueue(client, INFERS_GENERIC_WRAPPER_PAYLOAD_QUEUE),
+				createQueue(client, INFERS_BATCH_GENERIC_WRAPPER_PAYLOAD_QUEUE),
+				createQueue(client, INFERS_BATCH_MESSAGE_GENERIC_WRAPPER_PAYLOAD_QUEUE)).join();
 	}
 
 	@Autowired
@@ -327,6 +338,93 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 		errorHandlerPayloadTypeCollector.assertPayloadsForQueueContains(ERROR_HANDLER_TEST_QUEUE, event);
 	}
 
+	@Test
+	void shouldInferListPayloadTypeFromMessageWrapper() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(1);
+		ackCallbackPayloadTypeCollector.registerLatch(INFERS_MESSAGE_LIST_PAYLOAD_QUEUE, ackLatch);
+
+		List<TestEvent> testEvents = List.of(new TestEvent("test-message-list-pojo-id-1", "test-payload-1"),
+				new TestEvent("test-message-list-pojo-id-2", "test-payload-2"));
+		Message<List<TestEvent>> message = MessageBuilder.withPayload(testEvents).build();
+		sqsTemplate.send(INFERS_MESSAGE_LIST_PAYLOAD_QUEUE, message);
+		logger.debug("Sent message with List<TestEvent> payload to queue {}: {}", INFERS_MESSAGE_LIST_PAYLOAD_QUEUE,
+				message);
+
+		assertThat(latchContainer.infersMessageListPayloadLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedMessageListPayloads).hasSize(1);
+		List<?> receivedPayload = pojoCollector.receivedMessageListPayloads.get(0).getPayload();
+		assertThat(receivedPayload).allSatisfy(element -> assertThat(element).isInstanceOf(TestEvent.class));
+		assertThat(receivedPayload).isEqualTo(testEvents);
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_MESSAGE_LIST_PAYLOAD_QUEUE, testEvents);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_MESSAGE_LIST_PAYLOAD_QUEUE, testEvents);
+	}
+
+	@Test
+	void shouldInferTestEventTypeFromGenericWrapper() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(1);
+		ackCallbackPayloadTypeCollector.registerLatch(INFERS_GENERIC_WRAPPER_PAYLOAD_QUEUE, ackLatch);
+
+		GenericWrapperEvent<TestEvent> event = new GenericWrapperEvent<>(new TestEvent("event-id", "event-payload"));
+		sqsTemplate.send(INFERS_GENERIC_WRAPPER_PAYLOAD_QUEUE, event);
+		logger.debug("Sent message GenericWrapperEvent");
+
+		assertThat(latchContainer.infersGenericWrapperPayloadLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedGenericWrapperPayload).hasSize(1);
+		GenericWrapperEvent<?> receivedPayload = pojoCollector.receivedGenericWrapperPayload.get(0);
+		Object genericPayload = receivedPayload.testEvent();
+		assertThat(genericPayload).isInstanceOf(TestEvent.class);
+		assertThat(receivedPayload).isEqualTo(event);
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_GENERIC_WRAPPER_PAYLOAD_QUEUE, event);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_GENERIC_WRAPPER_PAYLOAD_QUEUE, event);
+
+	}
+
+	@Test
+	void shouldInferTestEventTypeFromBatchOfGenericWrappers() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(2);
+		ackCallbackPayloadTypeCollector.registerLatch(INFERS_BATCH_GENERIC_WRAPPER_PAYLOAD_QUEUE, ackLatch);
+		List<GenericWrapperEvent<TestEvent>> events = List.of(
+				new GenericWrapperEvent<>(new TestEvent("batch-wrapper-id-1", "batch-wrapper-payload-1")),
+				new GenericWrapperEvent<>(new TestEvent("batch-wrapper-id-2", "batch-wrapper-payload-2")));
+
+		sqsTemplate.sendMany(INFERS_BATCH_GENERIC_WRAPPER_PAYLOAD_QUEUE,
+				events.stream().map(event -> MessageBuilder.withPayload(event).build()).toList());
+
+		assertThat(latchContainer.infersBatchGenericWrapperPayloadLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedBatchGenericWrapperPayload).containsExactlyInAnyOrderElementsOf(events)
+				.allSatisfy(wrapper -> assertThat(wrapper.testEvent()).isInstanceOf(TestEvent.class));
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContainsAll(INFERS_BATCH_GENERIC_WRAPPER_PAYLOAD_QUEUE,
+				events);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContainsAll(INFERS_BATCH_GENERIC_WRAPPER_PAYLOAD_QUEUE,
+				events);
+	}
+
+	@Test
+	void shouldInferTestEventTypeFromBatchOfMessagesWithGenericWrappers() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(2);
+		ackCallbackPayloadTypeCollector.registerLatch(INFERS_BATCH_MESSAGE_GENERIC_WRAPPER_PAYLOAD_QUEUE, ackLatch);
+		List<GenericWrapperEvent<TestEvent>> events = List.of(
+				new GenericWrapperEvent<>(
+						new TestEvent("batch-message-wrapper-id-1", "batch-message-wrapper-payload-1")),
+				new GenericWrapperEvent<>(
+						new TestEvent("batch-message-wrapper-id-2", "batch-message-wrapper-payload-2")));
+
+		sqsTemplate.sendMany(INFERS_BATCH_MESSAGE_GENERIC_WRAPPER_PAYLOAD_QUEUE,
+				events.stream().map(event -> MessageBuilder.withPayload(event).build()).toList());
+
+		assertThat(latchContainer.infersBatchMessageGenericWrapperPayloadLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedBatchMessageGenericWrapperPayload).containsExactlyInAnyOrderElementsOf(events)
+				.allSatisfy(wrapper -> assertThat(wrapper.testEvent()).isInstanceOf(TestEvent.class));
+		interceptorPayloadTypeCollector
+				.assertPayloadsForQueueContainsAll(INFERS_BATCH_MESSAGE_GENERIC_WRAPPER_PAYLOAD_QUEUE, events);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector
+				.assertPayloadsForQueueContainsAll(INFERS_BATCH_MESSAGE_GENERIC_WRAPPER_PAYLOAD_QUEUE, events);
+	}
+
 	static class InfersSimplePojoListener {
 
 		@Autowired
@@ -403,6 +501,72 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 			latchContainer.infersNestedGenericLatch.countDown();
 		}
 
+	}
+
+	static class InfersMessageListPayloadListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = INFERS_MESSAGE_LIST_PAYLOAD_QUEUE, id = "infers-message-list-payload")
+		void listen(Message<List<TestEvent>> message) {
+			logger.debug("Received message with List<TestEvent> payload: {}", message);
+			pojoCollector.receivedMessageListPayloads.add(message);
+			latchContainer.infersMessageListPayloadLatch.countDown();
+		}
+
+	}
+
+	static class InfersGenericWrapperPayloadListener {
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = INFERS_GENERIC_WRAPPER_PAYLOAD_QUEUE, id = "infers-generic-wrapper-payload")
+		void listen(GenericWrapperEvent<TestEvent> message) {
+			logger.debug("Received message with GenericWrapperEvent<TestEvent> payload: {}", message);
+			pojoCollector.receivedGenericWrapperPayload.add(message);
+			latchContainer.infersGenericWrapperPayloadLatch.countDown();
+		}
+	}
+
+	static class InfersBatchGenericWrapperPayloadListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = INFERS_BATCH_GENERIC_WRAPPER_PAYLOAD_QUEUE, id = "infers-batch-generic-wrapper-payload")
+		void listen(List<GenericWrapperEvent<TestEvent>> messages) {
+			logger.debug("Received {} GenericWrapperEvent<TestEvent> payloads", messages.size());
+			pojoCollector.receivedBatchGenericWrapperPayload.addAll(messages);
+			messages.forEach(message -> latchContainer.infersBatchGenericWrapperPayloadLatch.countDown());
+		}
+	}
+
+	static class InfersBatchMessageGenericWrapperPayloadListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = INFERS_BATCH_MESSAGE_GENERIC_WRAPPER_PAYLOAD_QUEUE, id = "infers-batch-message-generic-wrapper-payload")
+		void listen(List<Message<GenericWrapperEvent<TestEvent>>> messages) {
+			logger.debug("Received {} messages with GenericWrapperEvent<TestEvent> payloads", messages.size());
+			messages.forEach(message -> {
+				pojoCollector.receivedBatchMessageGenericWrapperPayload.add(message.getPayload());
+				latchContainer.infersBatchMessageGenericWrapperPayloadLatch.countDown();
+			});
+		}
 	}
 
 	static class AsyncListener {
@@ -544,6 +708,17 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 
 		final List<SnakeCaseEvent> receivedCustomConverterPojos = Collections.synchronizedList(new ArrayList<>());
 
+		final List<Message<List<TestEvent>>> receivedMessageListPayloads = Collections
+				.synchronizedList(new ArrayList<>());
+
+		final List<GenericWrapperEvent<?>> receivedGenericWrapperPayload = Collections
+				.synchronizedList(new ArrayList<>());
+
+		final List<GenericWrapperEvent<?>> receivedBatchGenericWrapperPayload = Collections
+				.synchronizedList(new ArrayList<>());
+
+		final List<GenericWrapperEvent<?>> receivedBatchMessageGenericWrapperPayload = Collections
+				.synchronizedList(new ArrayList<>());
 	}
 
 	/**
@@ -658,6 +833,13 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 
 		final CountDownLatch customConverterLatch = new CountDownLatch(1);
 
+		final CountDownLatch infersMessageListPayloadLatch = new CountDownLatch(1);
+
+		final CountDownLatch infersGenericWrapperPayloadLatch = new CountDownLatch(1);
+
+		final CountDownLatch infersBatchGenericWrapperPayloadLatch = new CountDownLatch(2);
+
+		final CountDownLatch infersBatchMessageGenericWrapperPayloadLatch = new CountDownLatch(2);
 	}
 
 	@Import(SqsBootstrapConfiguration.class)
@@ -885,6 +1067,26 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 					.configureDefaultConverter(AbstractMessagingMessageConverter::doNotSendPayloadTypeHeader).build();
 		}
 
+		@Bean
+		InfersMessageListPayloadListener infersMessageListPayloadListener() {
+			return new InfersMessageListPayloadListener();
+		}
+
+		@Bean
+		InfersGenericWrapperPayloadListener infersGenericWrapperPayloadListener() {
+			return new InfersGenericWrapperPayloadListener();
+		}
+
+		@Bean
+		InfersBatchGenericWrapperPayloadListener infersBatchGenericWrapperPayloadListener() {
+			return new InfersBatchGenericWrapperPayloadListener();
+		}
+
+		@Bean
+		InfersBatchMessageGenericWrapperPayloadListener infersBatchMessageGenericWrapperPayloadListener() {
+			return new InfersBatchMessageGenericWrapperPayloadListener();
+		}
+
 	}
 
 	static class TestEvent {
@@ -1041,6 +1243,10 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 			return "SnakeCaseEvent{" + "eventId='" + eventId + '\'' + ", eventPayload='" + eventPayload + '\'' + '}';
 		}
 
+	}
+
+	record GenericWrapperEvent<T>(T testEvent)
+	{
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsPayloadTypeInferenceIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsPayloadTypeInferenceIntegrationTests.java
@@ -92,6 +92,14 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 
 	static final String ERROR_HANDLER_TEST_QUEUE = "error_handler_type_inference_queue";
 
+	static final String INFERS_MESSAGE_LIST_PAYLOAD_QUEUE = "infers_message_list_payload_queue";
+
+	static final String INFERS_GENERIC_WRAPPER_PAYLOAD_QUEUE = "infers_generic_outer_payload_queue";
+
+	static final String INFERS_BATCH_GENERIC_WRAPPER_PAYLOAD_QUEUE = "infers_batch_generic_outer_payload_queue";
+
+	static final String INFERS_BATCH_MESSAGE_GENERIC_WRAPPER_PAYLOAD_QUEUE = "infers_batch_message_generic_outer_payload_queue";
+
 	static final String MANUAL_ACK_FACTORY = "manualAckFactory";
 
 	static final String CUSTOM_CONVERTER_FACTORY = "customConverterFactory";
@@ -105,7 +113,10 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 				createQueue(client, ASYNC_LISTENER_QUEUE), createQueue(client, BATCH_MESSAGE_WRAPPER_QUEUE),
 				createQueue(client, IGNORES_TYPE_HEADER_QUEUE), createQueue(client, EXPLICIT_PAYLOAD_ANNOTATION_QUEUE),
 				createQueue(client, STRING_PAYLOAD_QUEUE), createQueue(client, CUSTOM_CONVERTER_QUEUE),
-				createQueue(client, ERROR_HANDLER_TEST_QUEUE)).join();
+				createQueue(client, ERROR_HANDLER_TEST_QUEUE), createQueue(client, INFERS_MESSAGE_LIST_PAYLOAD_QUEUE),
+				createQueue(client, INFERS_GENERIC_WRAPPER_PAYLOAD_QUEUE),
+				createQueue(client, INFERS_BATCH_GENERIC_WRAPPER_PAYLOAD_QUEUE),
+				createQueue(client, INFERS_BATCH_MESSAGE_GENERIC_WRAPPER_PAYLOAD_QUEUE)).join();
 	}
 
 	@Autowired
@@ -327,6 +338,93 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 		errorHandlerPayloadTypeCollector.assertPayloadsForQueueContains(ERROR_HANDLER_TEST_QUEUE, event);
 	}
 
+	@Test
+	void shouldInferListPayloadTypeFromMessageWrapper() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(1);
+		ackCallbackPayloadTypeCollector.registerLatch(INFERS_MESSAGE_LIST_PAYLOAD_QUEUE, ackLatch);
+
+		List<TestEvent> testEvents = List.of(new TestEvent("test-message-list-pojo-id-1", "test-payload-1"),
+				new TestEvent("test-message-list-pojo-id-2", "test-payload-2"));
+		Message<List<TestEvent>> message = MessageBuilder.withPayload(testEvents).build();
+		sqsTemplate.send(INFERS_MESSAGE_LIST_PAYLOAD_QUEUE, message);
+		logger.debug("Sent message with List<TestEvent> payload to queue {}: {}", INFERS_MESSAGE_LIST_PAYLOAD_QUEUE,
+				message);
+
+		assertThat(latchContainer.infersMessageListPayloadLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedMessageListPayloads).hasSize(1);
+		List<?> receivedPayload = pojoCollector.receivedMessageListPayloads.get(0).getPayload();
+		assertThat(receivedPayload).allSatisfy(element -> assertThat(element).isInstanceOf(TestEvent.class));
+		assertThat(receivedPayload).isEqualTo(testEvents);
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_MESSAGE_LIST_PAYLOAD_QUEUE, testEvents);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_MESSAGE_LIST_PAYLOAD_QUEUE, testEvents);
+	}
+
+	@Test
+	void shouldInferTestEventTypeFromGenericWrapper() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(1);
+		ackCallbackPayloadTypeCollector.registerLatch(INFERS_GENERIC_WRAPPER_PAYLOAD_QUEUE, ackLatch);
+
+		GenericWrapperEvent<TestEvent> event = new GenericWrapperEvent<>(new TestEvent("event-id", "event-payload"));
+		sqsTemplate.send(INFERS_GENERIC_WRAPPER_PAYLOAD_QUEUE, event);
+		logger.debug("Sent message GenericWrapperEvent");
+
+		assertThat(latchContainer.infersGenericWrapperPayloadLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedGenericWrapperPayload).hasSize(1);
+		GenericWrapperEvent<?> receivedPayload = pojoCollector.receivedGenericWrapperPayload.get(0);
+		Object genericPayload = receivedPayload.testEvent();
+		assertThat(genericPayload).isInstanceOf(TestEvent.class);
+		assertThat(receivedPayload).isEqualTo(event);
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_GENERIC_WRAPPER_PAYLOAD_QUEUE, event);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_GENERIC_WRAPPER_PAYLOAD_QUEUE, event);
+
+	}
+
+	@Test
+	void shouldInferTestEventTypeFromBatchOfGenericWrappers() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(2);
+		ackCallbackPayloadTypeCollector.registerLatch(INFERS_BATCH_GENERIC_WRAPPER_PAYLOAD_QUEUE, ackLatch);
+		List<GenericWrapperEvent<TestEvent>> events = List.of(
+				new GenericWrapperEvent<>(new TestEvent("batch-wrapper-id-1", "batch-wrapper-payload-1")),
+				new GenericWrapperEvent<>(new TestEvent("batch-wrapper-id-2", "batch-wrapper-payload-2")));
+
+		sqsTemplate.sendMany(INFERS_BATCH_GENERIC_WRAPPER_PAYLOAD_QUEUE,
+				events.stream().map(event -> MessageBuilder.withPayload(event).build()).toList());
+
+		assertThat(latchContainer.infersBatchGenericWrapperPayloadLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedBatchGenericWrapperPayload).containsExactlyInAnyOrderElementsOf(events)
+				.allSatisfy(wrapper -> assertThat(wrapper.testEvent()).isInstanceOf(TestEvent.class));
+		interceptorPayloadTypeCollector.assertPayloadsForQueueContainsAll(INFERS_BATCH_GENERIC_WRAPPER_PAYLOAD_QUEUE,
+				events);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContainsAll(INFERS_BATCH_GENERIC_WRAPPER_PAYLOAD_QUEUE,
+				events);
+	}
+
+	@Test
+	void shouldInferTestEventTypeFromBatchOfMessagesWithGenericWrappers() throws Exception {
+		CountDownLatch ackLatch = new CountDownLatch(2);
+		ackCallbackPayloadTypeCollector.registerLatch(INFERS_BATCH_MESSAGE_GENERIC_WRAPPER_PAYLOAD_QUEUE, ackLatch);
+		List<GenericWrapperEvent<TestEvent>> events = List.of(
+				new GenericWrapperEvent<>(
+						new TestEvent("batch-message-wrapper-id-1", "batch-message-wrapper-payload-1")),
+				new GenericWrapperEvent<>(
+						new TestEvent("batch-message-wrapper-id-2", "batch-message-wrapper-payload-2")));
+
+		sqsTemplate.sendMany(INFERS_BATCH_MESSAGE_GENERIC_WRAPPER_PAYLOAD_QUEUE,
+				events.stream().map(event -> MessageBuilder.withPayload(event).build()).toList());
+
+		assertThat(latchContainer.infersBatchMessageGenericWrapperPayloadLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pojoCollector.receivedBatchMessageGenericWrapperPayload).containsExactlyInAnyOrderElementsOf(events)
+				.allSatisfy(wrapper -> assertThat(wrapper.testEvent()).isInstanceOf(TestEvent.class));
+		interceptorPayloadTypeCollector
+				.assertPayloadsForQueueContainsAll(INFERS_BATCH_MESSAGE_GENERIC_WRAPPER_PAYLOAD_QUEUE, events);
+		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ackCallbackPayloadTypeCollector
+				.assertPayloadsForQueueContainsAll(INFERS_BATCH_MESSAGE_GENERIC_WRAPPER_PAYLOAD_QUEUE, events);
+	}
+
 	static class InfersSimplePojoListener {
 
 		@Autowired
@@ -403,6 +501,72 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 			latchContainer.infersNestedGenericLatch.countDown();
 		}
 
+	}
+
+	static class InfersMessageListPayloadListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = INFERS_MESSAGE_LIST_PAYLOAD_QUEUE, id = "infers-message-list-payload")
+		void listen(Message<List<TestEvent>> message) {
+			logger.debug("Received message with List<TestEvent> payload: {}", message);
+			pojoCollector.receivedMessageListPayloads.add(message);
+			latchContainer.infersMessageListPayloadLatch.countDown();
+		}
+
+	}
+
+	static class InfersGenericWrapperPayloadListener {
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = INFERS_GENERIC_WRAPPER_PAYLOAD_QUEUE, id = "infers-generic-wrapper-payload")
+		void listen(GenericWrapperEvent<TestEvent> message) {
+			logger.debug("Received message with GenericWrapperEvent<TestEvent> payload: {}", message);
+			pojoCollector.receivedGenericWrapperPayload.add(message);
+			latchContainer.infersGenericWrapperPayloadLatch.countDown();
+		}
+	}
+
+	static class InfersBatchGenericWrapperPayloadListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = INFERS_BATCH_GENERIC_WRAPPER_PAYLOAD_QUEUE, id = "infers-batch-generic-wrapper-payload")
+		void listen(List<GenericWrapperEvent<TestEvent>> messages) {
+			logger.debug("Received {} GenericWrapperEvent<TestEvent> payloads", messages.size());
+			pojoCollector.receivedBatchGenericWrapperPayload.addAll(messages);
+			messages.forEach(message -> latchContainer.infersBatchGenericWrapperPayloadLatch.countDown());
+		}
+	}
+
+	static class InfersBatchMessageGenericWrapperPayloadListener {
+
+		@Autowired
+		LatchContainer latchContainer;
+
+		@Autowired
+		PojoCollector pojoCollector;
+
+		@SqsListener(queueNames = INFERS_BATCH_MESSAGE_GENERIC_WRAPPER_PAYLOAD_QUEUE, id = "infers-batch-message-generic-wrapper-payload")
+		void listen(List<Message<GenericWrapperEvent<TestEvent>>> messages) {
+			logger.debug("Received {} messages with GenericWrapperEvent<TestEvent> payloads", messages.size());
+			messages.forEach(message -> {
+				pojoCollector.receivedBatchMessageGenericWrapperPayload.add(message.getPayload());
+				latchContainer.infersBatchMessageGenericWrapperPayloadLatch.countDown();
+			});
+		}
 	}
 
 	static class AsyncListener {
@@ -544,6 +708,17 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 
 		final List<SnakeCaseEvent> receivedCustomConverterPojos = Collections.synchronizedList(new ArrayList<>());
 
+		final List<Message<List<TestEvent>>> receivedMessageListPayloads = Collections
+				.synchronizedList(new ArrayList<>());
+
+		final List<GenericWrapperEvent<?>> receivedGenericWrapperPayload = Collections
+				.synchronizedList(new ArrayList<>());
+
+		final List<GenericWrapperEvent<?>> receivedBatchGenericWrapperPayload = Collections
+				.synchronizedList(new ArrayList<>());
+
+		final List<GenericWrapperEvent<?>> receivedBatchMessageGenericWrapperPayload = Collections
+				.synchronizedList(new ArrayList<>());
 	}
 
 	/**
@@ -658,6 +833,13 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 
 		final CountDownLatch customConverterLatch = new CountDownLatch(1);
 
+		final CountDownLatch infersMessageListPayloadLatch = new CountDownLatch(1);
+
+		final CountDownLatch infersGenericWrapperPayloadLatch = new CountDownLatch(1);
+
+		final CountDownLatch infersBatchGenericWrapperPayloadLatch = new CountDownLatch(2);
+
+		final CountDownLatch infersBatchMessageGenericWrapperPayloadLatch = new CountDownLatch(2);
 	}
 
 	@Import(SqsBootstrapConfiguration.class)
@@ -881,6 +1063,26 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 					.configureDefaultConverter(AbstractMessagingMessageConverter::doNotSendPayloadTypeHeader).build();
 		}
 
+		@Bean
+		InfersMessageListPayloadListener infersMessageListPayloadListener() {
+			return new InfersMessageListPayloadListener();
+		}
+
+		@Bean
+		InfersGenericWrapperPayloadListener infersGenericWrapperPayloadListener() {
+			return new InfersGenericWrapperPayloadListener();
+		}
+
+		@Bean
+		InfersBatchGenericWrapperPayloadListener infersBatchGenericWrapperPayloadListener() {
+			return new InfersBatchGenericWrapperPayloadListener();
+		}
+
+		@Bean
+		InfersBatchMessageGenericWrapperPayloadListener infersBatchMessageGenericWrapperPayloadListener() {
+			return new InfersBatchMessageGenericWrapperPayloadListener();
+		}
+
 	}
 
 	static class TestEvent {
@@ -1037,6 +1239,10 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 			return "SnakeCaseEvent{" + "eventId='" + eventId + '\'' + ", eventPayload='" + eventPayload + '\'' + '}';
 		}
 
+	}
+
+	record GenericWrapperEvent<T>(T testEvent)
+	{
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainerTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/AbstractMessageListenerContainerTests.java
@@ -106,4 +106,53 @@ class AbstractMessageListenerContainerTests {
 
 	}
 
+	@Test
+	void shouldDelegatePayloadTypeOnlySetterToConversionHintAwareOverload() {
+		RecordingMessageListenerContainer container = new RecordingMessageListenerContainer(
+				SqsContainerOptions.builder().build());
+
+		container.setPayloadDeserializationType(String.class);
+
+		assertThat(container.payloadType).isEqualTo(String.class);
+		assertThat(container.conversionHint).isNull();
+		assertThat(container.conversionHintAwareSetterInvocations).isEqualTo(1);
+	}
+
+	@Test
+	void shouldClearConversionHintWhenPayloadTypeIsCleared() {
+		AbstractMessageListenerContainer<Object, SqsContainerOptions, SqsContainerOptionsBuilder> container = new AbstractMessageListenerContainer<>(
+				SqsContainerOptions.builder().build()) {
+		};
+		Object conversionHint = new Object();
+		container.setPayloadDeserializationType(String.class, conversionHint);
+
+		container.setPayloadDeserializationType(null, conversionHint);
+
+		assertThat(container.getPayloadDeserializationType()).isNull();
+		assertThat(container.getPayloadConversionHint()).isNull();
+	}
+
+	private static class RecordingMessageListenerContainer
+			extends AbstractMessageListenerContainer<Object, SqsContainerOptions, SqsContainerOptionsBuilder> {
+
+		private int conversionHintAwareSetterInvocations;
+
+		private Class<?> payloadType;
+
+		private Object conversionHint;
+
+		RecordingMessageListenerContainer(SqsContainerOptions containerOptions) {
+			super(containerOptions);
+		}
+
+		@Override
+		public void setPayloadDeserializationType(Class<?> payloadType, Object conversionHint) {
+			this.conversionHintAwareSetterInvocations++;
+			this.payloadType = payloadType;
+			this.conversionHint = conversionHint;
+			super.setPayloadDeserializationType(payloadType, conversionHint);
+		}
+
+	}
+
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainerTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/SqsMessageListenerContainerTests.java
@@ -32,10 +32,13 @@ import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
 import io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor;
 import io.awspring.cloud.sqs.listener.pipeline.MessageProcessingPipeline;
 import io.awspring.cloud.sqs.listener.sink.MessageSink;
+import io.awspring.cloud.sqs.listener.source.AbstractMessageConvertingMessageSource;
 import io.awspring.cloud.sqs.listener.source.MessageSource;
 import io.awspring.cloud.sqs.support.observation.AbstractListenerObservation;
 import io.awspring.cloud.sqs.support.observation.SqsListenerObservation;
 import io.micrometer.observation.ObservationRegistry;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -43,6 +46,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.core.MethodParameter;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
@@ -125,6 +129,36 @@ class SqsMessageListenerContainerTests {
 		assertThat(container.getAcknowledgementResultCallback()).isEqualTo(callback);
 		assertThat(container.getMessageInterceptors()).containsExactly(interceptor1, interceptor2);
 		assertThat(container.getPhase()).isEqualTo(MessageListenerContainer.DEFAULT_PHASE);
+	}
+
+	@Test
+	void shouldPropagatePayloadClassAndConversionHintToMessageSource() throws Exception {
+		Method listenerMethod = GenericListener.class.getDeclaredMethod("listen", GenericWrapper.class);
+		MethodParameter conversionHint = new MethodParameter(listenerMethod, 0);
+		RecordingMessageSource messageSource = new RecordingMessageSource();
+		TestSqsMessageListenerContainer container = new TestSqsMessageListenerContainer(mock(SqsAsyncClient.class),
+				SqsContainerOptions.builder().build());
+		container.setId("test-container");
+		container.setPayloadDeserializationType(GenericWrapper.class, conversionHint);
+
+		container.configureMessageSource(messageSource);
+
+		assertThat(messageSource.payloadClass).isEqualTo(GenericWrapper.class);
+		assertThat(messageSource.conversionHint).isSameAs(conversionHint);
+	}
+
+	@Test
+	void shouldClearConversionHintWhenPayloadDeserializationTypeIsSetWithoutHint() throws Exception {
+		Method listenerMethod = GenericListener.class.getDeclaredMethod("listen", GenericWrapper.class);
+		MethodParameter conversionHint = new MethodParameter(listenerMethod, 0);
+		TestSqsMessageListenerContainer container = new TestSqsMessageListenerContainer(mock(SqsAsyncClient.class),
+				SqsContainerOptions.builder().build());
+		container.setPayloadDeserializationType(GenericWrapper.class, conversionHint);
+
+		container.setPayloadDeserializationType(String.class);
+
+		assertThat(container.getPayloadDeserializationType()).isEqualTo(String.class);
+		assertThat(container.getPayloadConversionHint()).isNull();
 	}
 
 	@Test
@@ -308,10 +342,31 @@ class SqsMessageListenerContainerTests {
 			return this.createdMessageSink;
 		}
 
+		void configureMessageSource(MessageSource<Object> messageSource) {
+			try {
+				Field field = AbstractPipelineMessageListenerContainer.class.getDeclaredField("messageSources");
+				field.setAccessible(true);
+				field.set(this, List.of(messageSource));
+				configureMessageSources(new ContainerComponentFactory<>() {
+					@Override
+					public MessageSource<Object> createMessageSource(SqsContainerOptions options) {
+						return messageSource;
+					}
+
+					@Override
+					public MessageSink<Object> createMessageSink(SqsContainerOptions options) {
+						return (messages, context) -> CompletableFuture.completedFuture(null);
+					}
+				});
+			}
+			catch (ReflectiveOperationException e) {
+				throw new IllegalStateException("Could not configure test message source", e);
+			}
+		}
+
 		private MessageSink<Object> getMessageSink() {
 			try {
-				java.lang.reflect.Field field = AbstractPipelineMessageListenerContainer.class
-						.getDeclaredField("messageSink");
+				Field field = AbstractPipelineMessageListenerContainer.class.getDeclaredField("messageSink");
 				field.setAccessible(true);
 				return (MessageSink<Object>) field.get(this);
 			}
@@ -319,6 +374,39 @@ class SqsMessageListenerContainerTests {
 				throw new RuntimeException("Could not access messageSink field", e);
 			}
 		}
+	}
+
+	private static class RecordingMessageSource extends AbstractMessageConvertingMessageSource<Object, Object> {
+
+		private Class<?> payloadClass;
+
+		private Object conversionHint;
+
+		@Override
+		public void setPayloadDeserializationType(Class<?> payloadDeserializationType) {
+			this.payloadClass = payloadDeserializationType;
+		}
+
+		@Override
+		public void setPayloadDeserializationType(Class<?> payloadDeserializationType, Object conversionHint) {
+			this.payloadClass = payloadDeserializationType;
+			this.conversionHint = conversionHint;
+		}
+
+		@Override
+		public void setMessageSink(MessageSink<Object> messageSink) {
+		}
+
+	}
+
+	static class GenericListener {
+
+		void listen(GenericWrapper<String> payload) {
+		}
+
+	}
+
+	static class GenericWrapper<T> {
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractMessageConvertingMessageSourceTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractMessageConvertingMessageSourceTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2013-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.awspring.cloud.sqs.listener.SqsContainerOptions;
+import io.awspring.cloud.sqs.listener.sink.MessageSink;
+import io.awspring.cloud.sqs.support.converter.MessageConversionContext;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link AbstractMessageConvertingMessageSource}.
+ *
+ * @author Bruno Augusto Garcia
+ */
+class AbstractMessageConvertingMessageSourceTests {
+
+	@Test
+	void shouldDelegatePayloadTypeOnlySetterToConversionHintAwareHook() {
+		ConversionHintHookRecordingMessageSource source = new ConversionHintHookRecordingMessageSource();
+		source.configure(SqsContainerOptions.builder().build());
+
+		source.setPayloadDeserializationType(String.class);
+
+		assertThat(source.payloadType).isEqualTo(String.class);
+		assertThat(source.conversionHint).isNull();
+		assertThat(source.context).isSameAs(source.getMessageConversionContext());
+	}
+
+	@Test
+	void shouldInvokeLegacyHookFromConversionHintAwareSetter() {
+		LegacyHookRecordingMessageSource source = new LegacyHookRecordingMessageSource();
+		source.configure(SqsContainerOptions.builder().build());
+		Object conversionHint = new Object();
+
+		source.setPayloadDeserializationType(String.class, conversionHint);
+
+		assertThat(source.payloadType).isEqualTo(String.class);
+		assertThat(source.context).isSameAs(source.getMessageConversionContext());
+	}
+
+	private abstract static class TestMessageSource extends AbstractMessageConvertingMessageSource<Object, Object> {
+
+		@Override
+		public void setMessageSink(MessageSink<Object> messageSink) {
+		}
+
+	}
+
+	private static class ConversionHintHookRecordingMessageSource extends TestMessageSource {
+
+		private Class<?> payloadType;
+
+		private Object conversionHint;
+
+		private MessageConversionContext context;
+
+		@Override
+		protected void doConfigurePayloadTypeOnContext(Class<?> payloadType, Object conversionHint,
+				MessageConversionContext context) {
+			this.payloadType = payloadType;
+			this.conversionHint = conversionHint;
+			this.context = context;
+		}
+
+	}
+
+	private static class LegacyHookRecordingMessageSource extends TestMessageSource {
+
+		private Class<?> payloadType;
+
+		private MessageConversionContext context;
+
+		@Override
+		protected void doConfigurePayloadTypeOnContext(Class<?> payloadType, MessageConversionContext context) {
+			this.payloadType = payloadType;
+			this.context = context;
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSourceTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSourceTests.java
@@ -22,6 +22,9 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
+import io.awspring.cloud.sqs.listener.SqsContainerOptions;
+import io.awspring.cloud.sqs.support.converter.SqsMessageConversionContext;
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
@@ -30,6 +33,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.core.MethodParameter;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
@@ -92,8 +96,34 @@ class AbstractSqsMessageSourceTests {
 		assertThat(requests.get(10)).extracting(ReceiveMessageRequest::maxNumberOfMessages).isEqualTo(1);
 	}
 
+	@Test
+	void shouldConfigurePayloadClassAndConversionHintOnContext() throws Exception {
+		Method listenerMethod = GenericListener.class.getDeclaredMethod("listen", GenericWrapper.class);
+		MethodParameter conversionHint = new MethodParameter(listenerMethod, 0);
+		AbstractSqsMessageSource<Object> source = new StandardSqsMessageSource<>();
+		source.configure(SqsContainerOptions.builder().build());
+
+		source.setPayloadDeserializationType(GenericWrapper.class, conversionHint);
+
+		assertThat(source.getMessageConversionContext()).isInstanceOfSatisfying(SqsMessageConversionContext.class,
+				context -> {
+					assertThat(context.getPayloadClass()).isEqualTo(GenericWrapper.class);
+					assertThat(context.getConversionHint()).isSameAs(conversionHint);
+				});
+	}
+
 	private List<Message> getHundredMessages(List<Message> batch) {
 		return IntStream.range(0, 10).mapToObj(index -> batch).flatMap(Collection::stream).collect(Collectors.toList());
+	}
+
+	static class GenericListener {
+
+		void listen(GenericWrapper<String> payload) {
+		}
+
+	}
+
+	static class GenericWrapper<T> {
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSourceTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractSqsMessageSourceTests.java
@@ -22,6 +22,10 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
+import io.awspring.cloud.sqs.listener.SqsContainerOptions;
+import io.awspring.cloud.sqs.support.converter.MessageConversionContext;
+import io.awspring.cloud.sqs.support.converter.SqsMessageConversionContext;
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
@@ -30,6 +34,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.core.MethodParameter;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
@@ -92,8 +97,79 @@ class AbstractSqsMessageSourceTests {
 		assertThat(requests.get(10)).extracting(ReceiveMessageRequest::maxNumberOfMessages).isEqualTo(1);
 	}
 
+	@Test
+	void shouldConfigurePayloadClassAndConversionHintOnContext() throws Exception {
+		Method listenerMethod = GenericListener.class.getDeclaredMethod("listen", GenericWrapper.class);
+		MethodParameter conversionHint = new MethodParameter(listenerMethod, 0);
+		AbstractSqsMessageSource<Object> source = new StandardSqsMessageSource<>();
+		source.configure(SqsContainerOptions.builder().build());
+
+		source.setPayloadDeserializationType(GenericWrapper.class, conversionHint);
+
+		assertThat(source.getMessageConversionContext()).isInstanceOfSatisfying(SqsMessageConversionContext.class,
+				context -> {
+					assertThat(context.getPayloadClass()).isEqualTo(GenericWrapper.class);
+					assertThat(context.getConversionHint()).isSameAs(conversionHint);
+				});
+	}
+
+	@Test
+	void shouldInvokeLegacyPayloadConfigurationHookFromConversionHintAwareSetter() {
+		LegacyHookRecordingSqsMessageSource<Object> source = new LegacyHookRecordingSqsMessageSource<>();
+		source.configure(SqsContainerOptions.builder().build());
+		Object conversionHint = new Object();
+
+		source.setPayloadDeserializationType(String.class, conversionHint);
+
+		assertThat(source.legacyHookInvoked).isTrue();
+		assertThat(source.getMessageConversionContext()).isInstanceOfSatisfying(SqsMessageConversionContext.class,
+				context -> {
+					assertThat(context.getPayloadClass()).isEqualTo(String.class);
+					assertThat(context.getConversionHint()).isSameAs(conversionHint);
+				});
+	}
+
+	@Test
+	void shouldClearConversionHintWhenPayloadTypeIsReconfiguredThroughLegacySetter() throws Exception {
+		Method listenerMethod = GenericListener.class.getDeclaredMethod("listen", GenericWrapper.class);
+		MethodParameter conversionHint = new MethodParameter(listenerMethod, 0);
+		AbstractSqsMessageSource<Object> source = new StandardSqsMessageSource<>();
+		source.configure(SqsContainerOptions.builder().build());
+		source.setPayloadDeserializationType(GenericWrapper.class, conversionHint);
+
+		source.setPayloadDeserializationType(String.class);
+
+		assertThat(source.getMessageConversionContext()).isInstanceOfSatisfying(SqsMessageConversionContext.class,
+				context -> {
+					assertThat(context.getPayloadClass()).isEqualTo(String.class);
+					assertThat(context.getConversionHint()).isNull();
+				});
+	}
+
 	private List<Message> getHundredMessages(List<Message> batch) {
 		return IntStream.range(0, 10).mapToObj(index -> batch).flatMap(Collection::stream).collect(Collectors.toList());
+	}
+
+	static class GenericListener {
+
+		void listen(GenericWrapper<String> payload) {
+		}
+
+	}
+
+	static class GenericWrapper<T> {
+	}
+
+	private static class LegacyHookRecordingSqsMessageSource<T> extends StandardSqsMessageSource<T> {
+
+		private boolean legacyHookInvoked;
+
+		@Override
+		protected void doConfigurePayloadTypeOnContext(Class<?> payloadType, MessageConversionContext context) {
+			this.legacyHookInvoked = true;
+			super.doConfigurePayloadTypeOnContext(payloadType, context);
+		}
+
 	}
 
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/LegacyJackson2SqsMessagingMessageConverterTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/LegacyJackson2SqsMessagingMessageConverterTests.java
@@ -24,10 +24,13 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.sqs.support.converter.legacy.LegacyJackson2SqsMessagingMessageConverter;
+import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.support.MessageBuilder;
@@ -156,9 +159,78 @@ class LegacyJackson2SqsMessagingMessageConverterTests {
 		assertThat(converter.isUsingDefaultPayloadTypeMapper()).isFalse();
 	}
 
+	@Test
+	void shouldDeserializeGenericWrapperUsingListenerMethodConversionHint() throws Exception {
+		Method listenerMethod = GenericListener.class.getDeclaredMethod("listen", GenericWrapper.class);
+		MethodParameter conversionHint = new MethodParameter(listenerMethod, 0);
+		LegacyJackson2SqsMessagingMessageConverter converter = new LegacyJackson2SqsMessagingMessageConverter();
+		SqsMessageConversionContext context = new SqsMessageConversionContext();
+		context.setPayloadClass(GenericWrapper.class);
+		context.setConversionHint(conversionHint);
+		Message message = Message.builder().body("""
+				{"value":{"myProperty":"nested-value"}}
+				""").messageId(UUID.randomUUID().toString()).build();
+
+		org.springframework.messaging.Message<?> result = converter.toMessagingMessage(message, context);
+
+		assertThat(result.getPayload()).isInstanceOfSatisfying(GenericWrapper.class,
+				wrapper -> assertThat(wrapper.getValue()).isInstanceOfSatisfying(MyPojo.class,
+						pojo -> assertThat(pojo.getMyProperty()).isEqualTo("nested-value")));
+	}
+
+	@Test
+	void shouldDeserializeNestedGenericWrapperUsingListenerMethodConversionHint() throws Exception {
+		Method listenerMethod = GenericListener.class.getDeclaredMethod("listenToNestedWrapper", GenericWrapper.class);
+		MethodParameter conversionHint = new MethodParameter(listenerMethod, 0);
+		LegacyJackson2SqsMessagingMessageConverter converter = new LegacyJackson2SqsMessagingMessageConverter();
+		SqsMessageConversionContext context = new SqsMessageConversionContext();
+		context.setPayloadClass(GenericWrapper.class);
+		context.setConversionHint(conversionHint);
+		Message message = Message.builder().body("""
+				{"value":[{"myProperty":"first"},{"myProperty":"second"}]}
+				""").messageId(UUID.randomUUID().toString()).build();
+
+		org.springframework.messaging.Message<?> result = converter.toMessagingMessage(message, context);
+
+		assertThat(result.getPayload()).isInstanceOfSatisfying(GenericWrapper.class,
+				wrapper -> assertThat(wrapper.getValue())
+						.isEqualTo(List.of(new MyPojo("first"), new MyPojo("second"))));
+	}
+
+	static class GenericListener {
+
+		void listen(GenericWrapper<MyPojo> payload) {
+		}
+
+		void listenToNestedWrapper(GenericWrapper<List<MyPojo>> payload) {
+		}
+
+	}
+
+	static class GenericWrapper<T> {
+
+		private T value;
+
+		public T getValue() {
+			return this.value;
+		}
+
+		public void setValue(T value) {
+			this.value = value;
+		}
+
+	}
+
 	static class MyPojo {
 
 		private String myProperty = "myValue";
+
+		MyPojo() {
+		}
+
+		MyPojo(String myProperty) {
+			this.myProperty = myProperty;
+		}
 
 		public String getMyProperty() {
 			return this.myProperty;

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverterTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/support/converter/SqsMessagingMessageConverterTests.java
@@ -19,11 +19,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
+import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.CompositeMessageConverter;
 import org.springframework.messaging.converter.JacksonJsonMessageConverter;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.converter.SmartMessageConverter;
 import software.amazon.awssdk.services.sqs.model.Message;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -75,6 +81,206 @@ class SqsMessagingMessageConverterTests {
 		org.springframework.messaging.Message<?> resultMessage = converter.toMessagingMessage(message);
 
 		assertThat(resultMessage.getPayload()).isEqualTo(myPojo);
+	}
+
+	@Test
+	void shouldPassConversionHintToSmartPayloadConverter() throws Exception {
+		Method listenerMethod = GenericListener.class.getDeclaredMethod("listen", GenericWrapper.class);
+		MethodParameter conversionHint = new MethodParameter(listenerMethod, 0);
+		RecordingSmartMessageConverter payloadConverter = new RecordingSmartMessageConverter();
+		SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+		converter.setPayloadMessageConverter(payloadConverter);
+		SqsMessageConversionContext context = createConversionContext(GenericWrapper.class, conversionHint);
+		Message message = Message.builder().body("{}").messageId(UUID.randomUUID().toString()).build();
+
+		converter.toMessagingMessage(message, context);
+
+		assertThat(payloadConverter.targetClass).isEqualTo(GenericWrapper.class);
+		assertThat(payloadConverter.conversionHint).isSameAs(conversionHint);
+		assertThat(payloadConverter.smartOverloadInvoked).isTrue();
+	}
+
+	@Test
+	void shouldNotUseInferredConversionHintWhenCustomPayloadTypeMapperTakesPrecedence() throws Exception {
+		Method listenerMethod = GenericListener.class.getDeclaredMethod("listen", GenericWrapper.class);
+		MethodParameter conversionHint = new MethodParameter(listenerMethod, 0);
+		RecordingSmartMessageConverter payloadConverter = new RecordingSmartMessageConverter();
+		SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+		converter.setPayloadMessageConverter(payloadConverter);
+		converter.setPayloadTypeMapper(message -> String.class);
+		SqsMessageConversionContext context = createConversionContext(GenericWrapper.class, conversionHint);
+		Message message = Message.builder().body("{}").messageId(UUID.randomUUID().toString()).build();
+
+		converter.toMessagingMessage(message, context);
+
+		assertThat(payloadConverter.targetClass).isEqualTo(String.class);
+		assertThat(payloadConverter.conversionHint).isNull();
+		assertThat(payloadConverter.smartOverloadInvoked).isFalse();
+	}
+
+	@Test
+	void shouldFallBackToRegularPayloadConverterWhenConversionHintIsPresent() throws Exception {
+		Method listenerMethod = GenericListener.class.getDeclaredMethod("listen", GenericWrapper.class);
+		MethodParameter conversionHint = new MethodParameter(listenerMethod, 0);
+		RecordingMessageConverter payloadConverter = new RecordingMessageConverter();
+		SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+		converter.setPayloadMessageConverter(payloadConverter);
+		SqsMessageConversionContext context = createConversionContext(GenericWrapper.class, conversionHint);
+		Message message = Message.builder().body("{}").messageId(UUID.randomUUID().toString()).build();
+
+		converter.toMessagingMessage(message, context);
+
+		assertThat(payloadConverter.targetClass).isEqualTo(GenericWrapper.class);
+	}
+
+	@Test
+	void shouldDeserializeGenericWrapperUsingListenerMethodConversionHint() throws Exception {
+		Method listenerMethod = GenericListener.class.getDeclaredMethod("listen", GenericWrapper.class);
+		MethodParameter conversionHint = new MethodParameter(listenerMethod, 0);
+		SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+		SqsMessageConversionContext context = createConversionContext(GenericWrapper.class, conversionHint);
+		Message message = Message.builder().body("""
+				{"value":{"name":"nested-value"}}
+				""").messageId(UUID.randomUUID().toString()).build();
+
+		org.springframework.messaging.Message<?> result = converter.toMessagingMessage(message, context);
+
+		assertThat(result.getPayload()).isInstanceOfSatisfying(GenericWrapper.class,
+				wrapper -> assertThat(wrapper.value()).isEqualTo(new NestedPojo("nested-value")));
+	}
+
+	@Test
+	void shouldDeserializeMessageWithGenericCollectionPayloadUsingListenerMethodConversionHint() throws Exception {
+		Method listenerMethod = GenericListener.class.getDeclaredMethod("listenToMessage",
+				org.springframework.messaging.Message.class);
+		MethodParameter conversionHint = new MethodParameter(listenerMethod, 0);
+		SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+		SqsMessageConversionContext context = createConversionContext(List.class, conversionHint);
+		Message message = Message.builder().body("""
+				[{"name":"first"},{"name":"second"}]
+				""").messageId(UUID.randomUUID().toString()).build();
+
+		org.springframework.messaging.Message<?> result = converter.toMessagingMessage(message, context);
+
+		assertThat(result.getPayload()).isEqualTo(List.of(new NestedPojo("first"), new NestedPojo("second")));
+	}
+
+	@Test
+	void shouldDeserializeGenericWrapperFromBatchElementConversionHint() throws Exception {
+		Method listenerMethod = GenericListener.class.getDeclaredMethod("listenToBatch", List.class);
+		MethodParameter conversionHint = new MethodParameter(listenerMethod, 0).nested();
+		SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+		SqsMessageConversionContext context = createConversionContext(GenericWrapper.class, conversionHint);
+		Message message = Message.builder().body("""
+				{"value":{"name":"batch-value"}}
+				""").messageId(UUID.randomUUID().toString()).build();
+
+		org.springframework.messaging.Message<?> result = converter.toMessagingMessage(message, context);
+
+		assertThat(result.getPayload()).isInstanceOfSatisfying(GenericWrapper.class,
+				wrapper -> assertThat(wrapper.value()).isEqualTo(new NestedPojo("batch-value")));
+	}
+
+	@Test
+	void shouldDeserializeNestedGenericWrapperUsingListenerMethodConversionHint() throws Exception {
+		Method listenerMethod = GenericListener.class.getDeclaredMethod("listenToNestedWrapper", GenericWrapper.class);
+		MethodParameter conversionHint = new MethodParameter(listenerMethod, 0);
+		SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+		SqsMessageConversionContext context = createConversionContext(GenericWrapper.class, conversionHint);
+		Message message = Message.builder().body("""
+				{"value":[{"name":"first"},{"name":"second"}]}
+				""").messageId(UUID.randomUUID().toString()).build();
+
+		org.springframework.messaging.Message<?> result = converter.toMessagingMessage(message, context);
+
+		assertThat(result.getPayload()).isInstanceOfSatisfying(GenericWrapper.class,
+				wrapper -> assertThat(wrapper.value())
+						.isEqualTo(List.of(new NestedPojo("first"), new NestedPojo("second"))));
+	}
+
+	private SqsMessageConversionContext createConversionContext(Class<?> payloadClass, Object conversionHint) {
+		SqsMessageConversionContext context = new SqsMessageConversionContext();
+		context.setPayloadClass(payloadClass);
+		context.setConversionHint(conversionHint);
+		return context;
+	}
+
+	static class GenericListener {
+
+		void listen(GenericWrapper<NestedPojo> payload) {
+		}
+
+		void listenToMessage(org.springframework.messaging.Message<List<NestedPojo>> message) {
+		}
+
+		void listenToBatch(List<GenericWrapper<NestedPojo>> payload) {
+		}
+
+		void listenToNestedWrapper(GenericWrapper<List<NestedPojo>> payload) {
+		}
+
+	}
+
+	record GenericWrapper<T>(T value)
+	{
+	}
+
+	record NestedPojo(String name) {
+	}
+
+	static class RecordingSmartMessageConverter implements SmartMessageConverter {
+
+		private Class<?> targetClass;
+
+		private Object conversionHint;
+
+		private boolean smartOverloadInvoked;
+
+		@Override
+		public Object fromMessage(org.springframework.messaging.Message<?> message, Class<?> targetClass) {
+			this.targetClass = targetClass;
+			this.conversionHint = null;
+			this.smartOverloadInvoked = false;
+			return "converted";
+		}
+
+		@Override
+		public Object fromMessage(org.springframework.messaging.Message<?> message, Class<?> targetClass,
+				Object conversionHint) {
+			this.targetClass = targetClass;
+			this.conversionHint = conversionHint;
+			this.smartOverloadInvoked = true;
+			return "converted";
+		}
+
+		@Override
+		public org.springframework.messaging.Message<?> toMessage(Object payload, MessageHeaders headers) {
+			return null;
+		}
+
+		@Override
+		public org.springframework.messaging.Message<?> toMessage(Object payload, MessageHeaders headers,
+				Object conversionHint) {
+			return null;
+		}
+
+	}
+
+	static class RecordingMessageConverter implements MessageConverter {
+
+		private Class<?> targetClass;
+
+		@Override
+		public Object fromMessage(org.springframework.messaging.Message<?> message, Class<?> targetClass) {
+			this.targetClass = targetClass;
+			return "converted";
+		}
+
+		@Override
+		public org.springframework.messaging.Message<?> toMessage(Object payload, MessageHeaders headers) {
+			return null;
+		}
+
 	}
 
 	static class MyPojo {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description

This PR fixes generic payload deserialization for `@SqsListener` methods.

Previously, payload type inference retained only the raw `Class<?>`. Types such as `GenericWrapper<TestEvent>` and `Message<List<TestEvent>>` were therefore reduced to `GenericWrapper.class` and `List.class`. Without the complete generic type, Jackson deserialized nested values as `LinkedHashMap` instances.

This change:

- Introduces `MethodPayloadMetadata`, containing the raw payload class and an optional conversion hint.
- Preserves the listener's `MethodParameter` as the `SmartMessageConverter` conversion hint.
- Propagates the payload class and conversion hint through the endpoint, listener container, message source, and `MessageConversionContext`.
- Uses `SmartMessageConverter#fromMessage(Message, Class, Object)` when a conversion hint is available.
- Falls back to the regular `MessageConverter` contract for converters that do not implement `SmartMessageConverter`.
- Preserves custom payload type mapper precedence over inferred listener metadata.
- Supports nested generic payloads and batch elements, including:
  - `GenericWrapper<TestEvent>`
  - `GenericWrapper<List<TestEvent>>`
  - `Message<List<TestEvent>>`
  - `List<GenericWrapper<TestEvent>>`
  - `List<Message<GenericWrapper<TestEvent>>>`
- Keeps existing `MethodPayloadTypeInferrer` implementations source-compatible through a default metadata adaptation method.
- Updates the reference documentation and the `MessageSource` Javadoc to describe where payload conversion occurs.


## :bulb: Motivation and Context

`@SqsListener` payload deserialization currently loses generic type information because the inferred listener type is transported only as a raw `Class<?>`.

As a result, Jackson cannot determine the concrete type of generic fields or collection elements and falls back to `LinkedHashMap`.

The problem is also visible before listener invocation because SQS payload conversion happens at the `MessageSource` level. Therefore, interceptors, error handlers, and acknowledgement callbacks may also receive incorrectly typed generic values.

Spring's `SmartMessageConverter` already supports a conversion hint. Its base converters can use a `MethodParameter` hint to recover the complete generic `Type`, so this PR propagates that existing Spring metadata instead of introducing custom Jackson-specific type resolution.

Fixes #1597


## :green_heart: How did you test it?

Added and executed focused tests covering:

- Payload metadata inference for simple, wrapper, message, collection, and batch listener parameters.
- Backwards compatibility for custom `MethodPayloadTypeInferrer` implementations.
- Propagation through endpoint, container, message source, and conversion context.
- `SmartMessageConverter` hint invocation and regular `MessageConverter` fallback.
- Custom payload type mapper precedence.
- Conversion hint cleanup when the payload type is reconfigured.
- Generic and nested generic deserialization with both Jackson 3 and the legacy Jackson 2 converter.
- LocalStack integration scenarios for wrappers, nested collections, message wrappers, batches, interceptors, and acknowledgement callbacks.

Validation results:

- Unit and converter tests passed.
- All `SqsPayloadTypeInferenceIntegrationTests` passed with LocalStack.
- Spotless validation for all changed Java files passed.
- The complete SQS module suite executed 658 tests. 

Commands used:
`./mvnw -pl spring-cloud-aws-sqs -am test` Full module: Tests run: 658, Failures: 0, Errors: 0, Skipped: 5



## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Subject to maintainer feedback, a separate follow-up PR could expand generic payload inference for listener methods inherited from generic superclasses.

For example:

```java
abstract class GenericListener<T> {

    @SqsListener("events")
    void listen(GenericWrapper<T> event) {
    }
}

class TestEventListener extends GenericListener<TestEvent> {
} 
```

When Spring discovers the listener method, its original declaration still describes the payload as GenericWrapper<T>. To deserialize it as GenericWrapper<TestEvent>, the MethodParameter must also be resolved against the concrete listener class (TestEventListener). This allows Spring's type resolution infrastructure to substitute T with TestEvent before passing the conversion hint to the SmartMessageConverter.
I have already explored and implemented this extension in a separate branch, including tests for inherited generic listener methods and nested or batch generic payload shapes. It is deliberately not included in this PR so that the initial fix remains focused and easier to review.
We can open a discussion about the expected scope and compatibility requirements for inherited generic listeners. If the maintainers agree with the direction, the existing implementation can be refined and submitted as a separate follow-up PR.