### PR TITLE
Run SQS test classes named after Abstract* production classes

### DIFF
--- a/spring-cloud-aws-sqs/pom.xml
+++ b/spring-cloud-aws-sqs/pom.xml
@@ -109,4 +109,20 @@
 
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<!-- spring-cloud-build excludes '**/Abstract*.java' assuming such classes are test base
+						classes. In this module several concrete test classes are named after the Abstract*
+						production classes they test and were silently skipped. Clear the exclusion; actual
+						abstract base classes are not executable by JUnit anyway. -->
+					<excludes combine.self="override" />
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>


### PR DESCRIPTION
## Problem

`spring-cloud-build` configures surefire with an `**/Abstract*.java` exclude, on the assumption that classes with that prefix are test base classes. This module has nine concrete test classes named after the `Abstract*` production classes they cover, so surefire skipped all of them. They pass in the IDE, which is why the gap went unnoticed.

None of them have subclasses, so nothing was running their assertions. That includes `AbstractPollingMessageSourceTests`, which covers the adaptive throughput back pressure path.

## Change

Clear the exclude for this module. Abstract base classes are not executable by JUnit, so they remain effectively excluded without the pattern.

## Result

The module now runs 683 tests, 33 of which were previously skipped. All pass, and module build time is unchanged.
