### PR TITLE
Backport SQS fixes to 3.4.x

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/AbstractOrderingAcknowledgementProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/AbstractOrderingAcknowledgementProcessor.java
@@ -64,7 +64,8 @@ public abstract class AbstractOrderingAcknowledgementProcessor<T>
 	private AsyncAcknowledgementResultCallback<T> acknowledgementResultCallback = new AsyncAcknowledgementResultCallback<T>() {
 	};
 
-	private boolean running;
+	// Written under lifecycleMonitor, but read without synchronization from the polling and scheduler threads
+	private volatile boolean running;
 
 	private String id;
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
@@ -78,6 +79,13 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 
 	private BlockingQueue<Message<T>> acks;
 
+	/**
+	 * Number of messages that have been received for acknowledgement but are not in {@link #acks} nor in the buffer yet.
+	 * Incremented before a message is offered to the queue and decremented after it has been added to the buffer, so a
+	 * message is always accounted for while the polling thread is holding it in between the two.
+	 */
+	private final AtomicInteger unbufferedAcks = new AtomicInteger();
+
 	private Integer ackThreshold;
 
 	private Duration ackInterval;
@@ -103,7 +111,9 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 
 	@Override
 	protected CompletableFuture<Void> doOnAcknowledge(Message<T> message) {
+		this.unbufferedAcks.incrementAndGet();
 		if (!this.acks.offer(message)) {
+			this.unbufferedAcks.decrementAndGet();
 			logger.warn("Acknowledgement queue full, dropping acknowledgement for message {}",
 					MessageHeaderUtils.getId(message));
 		}
@@ -128,6 +138,7 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 				() -> getClass().getSimpleName() + " cannot be used with Duration.ZERO and acknowledgement threshold 0."
 						+ "Consider using a " + ImmediateAcknowledgementProcessor.class + "instead");
 		this.acks = new LinkedBlockingQueue<>();
+		this.unbufferedAcks.set(0);
 		this.taskScheduler = createTaskScheduler();
 		this.acknowledgementProcessor = createAcknowledgementProcessor();
 		this.taskExecutor.execute(this.acknowledgementProcessor);
@@ -199,7 +210,12 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 				try {
 					Message<T> polledMessage = this.acks.poll(1, TimeUnit.SECONDS);
 					if (polledMessage != null) {
-						addMessageToBuffer(polledMessage);
+						try {
+							addMessageToBuffer(polledMessage);
+						}
+						finally {
+							this.parent.unbufferedAcks.decrementAndGet();
+						}
 						this.thresholdAcknowledgementExecution.checkAndExecute();
 					}
 				}
@@ -299,12 +315,18 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 			return unfinishedAcks > 0;
 		}
 
+		/**
+		 * Whether any acknowledgement is still unaccounted for. Uses {@link #unbufferedAcks} rather than the queue size
+		 * so that a message the polling thread has already taken off the queue but not yet added to the buffer still
+		 * counts - otherwise the shutdown wait can end while such a message is in flight, and it is then added to a
+		 * buffer that has already been cleared and never acknowledged.
+		 */
 		private boolean hasAcksLeft() {
-			int messagesInAcks = this.acks.size();
+			int unbufferedAcks = this.parent.unbufferedAcks.get();
 			int messagesInAcksBuffer = this.context.acksBuffer.size();
-			logger.trace("Acknowledgement queue has {} messages.", messagesInAcks);
-			logger.trace("Acknowledgement buffer has {} messages.", messagesInAcksBuffer);
-			return messagesInAcksBuffer > 0 || messagesInAcks > 0;
+			logger.trace("{} acknowledgements not buffered yet.", unbufferedAcks);
+			logger.trace("Acknowledgement buffer has {} message groups.", messagesInAcksBuffer);
+			return messagesInAcksBuffer > 0 || unbufferedAcks > 0;
 		}
 
 	}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
@@ -250,6 +250,7 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 					if (LocalDateTime.now().isAfter(endTime)) {
 						throw new TimeoutException();
 					}
+					flushRemainingAcks();
 					Thread.sleep(200);
 				}
 				logger.debug("All acknowledgements completed.");
@@ -266,6 +267,28 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 				logger.warn(
 						"Error thrown when waiting for acknowledgement tasks to finish in {}. Continuing with shutdown.",
 						this.parent.getId(), e);
+			}
+		}
+
+		/**
+		 * Flushes whatever is left in the buffer, so that messages below the acknowledgement threshold are acknowledged
+		 * on shutdown instead of being discarded when the buffer is cleared. Waits for the ack queue to drain first so
+		 * that batches are not needlessly split.
+		 *
+		 * This has to be retried on every iteration of the shutdown wait loop rather than executed once: the polling
+		 * thread may be holding a message it has already polled but not yet added to the buffer, in which case the
+		 * queue looks empty while the message is in neither the queue nor the buffer.
+		 */
+		private void flushRemainingAcks() {
+			if (!this.acks.isEmpty()) {
+				return;
+			}
+			this.context.lock();
+			try {
+				this.context.executeAllAcks();
+			}
+			finally {
+				this.context.unlock();
 			}
 		}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSource.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSource.java
@@ -343,7 +343,7 @@ public abstract class AbstractPollingMessageSource<T, S> extends AbstractMessage
 			if (!waitExistingTasksToFinish()) {
 				logger.warn("Tasks did not finish in {} seconds for queue {}, proceeding with shutdown",
 						this.shutdownTimeout.getSeconds(), this.pollingEndpointName);
-				this.pollingFutures.forEach(pollingFuture -> pollingFuture.cancel(true));
+				new ArrayList<>(this.pollingFutures).forEach(pollingFuture -> pollingFuture.cancel(true));
 			}
 			doStop();
 			this.acknowledgmentProcessor.stop();

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
@@ -238,6 +238,51 @@ class BatchingAcknowledgementProcessorTests {
 		assertThat(acknowledgedMessages).containsExactlyInAnyOrderElementsOf(messages);
 	}
 
+	@Test
+	void givenMessagePolledButNotBufferedYet_whenStopped_shouldAcknowledgeIt() throws Exception {
+		Message<String> message = MessageBuilder.withPayload("0").build();
+		Collection<Message<String>> acknowledgedMessages = Collections.synchronizedList(new ArrayList<>());
+		CountDownLatch pollingThreadInsideBufferAdd = new CountDownLatch(1);
+		CountDownLatch releasePollingThread = new CountDownLatch(1);
+
+		BatchingAcknowledgementProcessor<String> processor = new BatchingAcknowledgementProcessor<>();
+		processor.configure(SqsContainerOptions.builder().acknowledgementInterval(ACK_INTERVAL_THIRTY_SECONDS)
+				.acknowledgementThreshold(ACK_THRESHOLD_TEN)
+				.acknowledgementOrdering(AcknowledgementOrdering.ORDERED_BY_GROUP)
+				.acknowledgementShutdownTimeout(Duration.ofSeconds(10)).build());
+		// The grouping function is applied while adding the message to the buffer, so blocking in it parks the polling
+		// thread at exactly the point where the message is in neither the queue nor the buffer.
+		processor.setMessageGroupingFunction(messageToGroup -> {
+			pollingThreadInsideBufferAdd.countDown();
+			try {
+				releasePollingThread.await(10, TimeUnit.SECONDS);
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			return "group";
+		});
+		processor.setTaskExecutor(new SimpleAsyncTaskExecutor());
+		processor.setAcknowledgementExecutor(messagesToAck -> {
+			acknowledgedMessages.addAll(messagesToAck);
+			return CompletableFuture.completedFuture(null);
+		});
+		processor.setMaxAcknowledgementsPerBatch(MAX_ACKNOWLEDGEMENTS_PER_BATCH_TEN);
+		processor.setId(ID);
+		processor.start();
+
+		processor.doOnAcknowledge(message);
+		assertThat(pollingThreadInsideBufferAdd.await(10, TimeUnit.SECONDS)).isTrue();
+
+		CompletableFuture<Void> stopping = CompletableFuture.runAsync(processor::stop);
+		// Give the shutdown wait loop, which polls every 200ms, several chances to observe the in-flight message
+		Thread.sleep(1000);
+		releasePollingThread.countDown();
+		stopping.get(30, TimeUnit.SECONDS);
+
+		assertThat(acknowledgedMessages).containsExactly(message);
+	}
+
 	private static List<Message<String>> buildMessages(int count) {
 		return IntStream.range(0, count).mapToObj(index -> MessageBuilder.withPayload(String.valueOf(index)).build())
 				.collect(Collectors.toList());

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
@@ -68,6 +68,8 @@ class BatchingAcknowledgementProcessorTests {
 
 	private static final Duration ACK_INTERVAL_ZERO = Duration.ZERO;
 
+	private static final Duration ACK_INTERVAL_THIRTY_SECONDS = Duration.ofSeconds(30);
+
 	private static final int MAX_ACKNOWLEDGEMENTS_PER_BATCH_TEN = 10;
 
 	private static final Integer ACK_THRESHOLD_TEN = 10;
@@ -187,6 +189,71 @@ class BatchingAcknowledgementProcessorTests {
 		processor.stop();
 		logger.debug("Processor stopped, waiting on latch");
 		assertThat(ackLatch.await(1, TimeUnit.SECONDS)).isEqualTo(shouldWaitAllAcks);
+	}
+
+	@Test
+	void givenScheduledAcknowledgement_whenStoppedWithRemainderBelowThreshold_shouldAcknowledgeRemainingMessages()
+			throws Exception {
+		List<Message<String>> messages = buildMessages(ACK_THRESHOLD_TEN + 5);
+		List<Message<String>> thresholdBatch = messages.subList(0, ACK_THRESHOLD_TEN);
+		List<Message<String>> remainder = messages.subList(ACK_THRESHOLD_TEN, messages.size());
+		Collection<Message<String>> acknowledgedMessages = Collections.synchronizedList(new ArrayList<>());
+		CountDownLatch thresholdFlushLatch = new CountDownLatch(1);
+
+		// The interval outlasts the test, so the remainder can only be flushed by the shutdown drain and never by a
+		// scheduled execution. A scheduled execution does exist here, unlike in the interval ZERO scenario below.
+		BatchingAcknowledgementProcessor<String> processor = createProcessor(ACK_INTERVAL_THIRTY_SECONDS,
+				messagesToAck -> {
+					acknowledgedMessages.addAll(messagesToAck);
+					thresholdFlushLatch.countDown();
+					return CompletableFuture.completedFuture(null);
+				});
+		processor.start();
+
+		processor.doOnAcknowledge(thresholdBatch);
+		assertThat(thresholdFlushLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		processor.doOnAcknowledge(remainder);
+		processor.stop();
+
+		assertThat(acknowledgedMessages).containsExactlyInAnyOrderElementsOf(messages);
+	}
+
+	@Test
+	void givenZeroIntervalAndThreshold_whenStoppedWithRemainderBelowThreshold_shouldAcknowledgeRemainingMessages()
+			throws Exception {
+		List<Message<String>> messages = buildMessages(ACK_THRESHOLD_TEN + 5);
+		Collection<Message<String>> acknowledgedMessages = Collections.synchronizedList(new ArrayList<>());
+
+		// No scheduled execution is ever created with interval ZERO, so the shutdown drain is the only thing that can
+		// flush the remainder.
+		BatchingAcknowledgementProcessor<String> processor = createProcessor(ACK_INTERVAL_ZERO, messagesToAck -> {
+			acknowledgedMessages.addAll(messagesToAck);
+			return CompletableFuture.completedFuture(null);
+		});
+		processor.start();
+
+		processor.doOnAcknowledge(messages);
+		processor.stop();
+
+		assertThat(acknowledgedMessages).containsExactlyInAnyOrderElementsOf(messages);
+	}
+
+	private static List<Message<String>> buildMessages(int count) {
+		return IntStream.range(0, count).mapToObj(index -> MessageBuilder.withPayload(String.valueOf(index)).build())
+				.collect(Collectors.toList());
+	}
+
+	private static BatchingAcknowledgementProcessor<String> createProcessor(Duration acknowledgementInterval,
+			AcknowledgementExecutor<String> acknowledgementExecutor) {
+		BatchingAcknowledgementProcessor<String> processor = new BatchingAcknowledgementProcessor<>();
+		processor.configure(SqsContainerOptions.builder().acknowledgementInterval(acknowledgementInterval)
+				.acknowledgementThreshold(ACK_THRESHOLD_TEN).acknowledgementOrdering(AcknowledgementOrdering.PARALLEL)
+				.acknowledgementShutdownTimeout(Duration.ofSeconds(10)).build());
+		processor.setTaskExecutor(new SimpleAsyncTaskExecutor());
+		processor.setAcknowledgementExecutor(acknowledgementExecutor);
+		processor.setMaxAcknowledgementsPerBatch(MAX_ACKNOWLEDGEMENTS_PER_BATCH_TEN);
+		processor.setId(ID);
+		return processor;
 	}
 
 	@Test

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSourceTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSourceTests.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.sqs.listener.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -392,6 +393,31 @@ class AbstractPollingMessageSourceTests {
 		assertThat(futures).isEmpty();
 
 		source.stop();
+	}
+
+	@Test
+	void shouldNotThrowConcurrentModificationExceptionWhenCancellingPollsOnStop() {
+		String testName = "shouldNotThrowConcurrentModificationExceptionWhenCancellingPollsOnStop";
+
+		AbstractPollingMessageSource<Object, Message> source = new AbstractPollingMessageSource<>() {
+			@Override
+			protected CompletableFuture<Collection<Message>> doPollForMessages(int messagesToRequest) {
+				return new CompletableFuture<>();
+			}
+		};
+
+		source.setId(testName + " source");
+		source.setPollingEndpointName("test-queue");
+		source.configure(SqsContainerOptions.builder().listenerShutdownTimeout(Duration.ZERO).build());
+		source.setAcknowledgementProcessor(getNoOpsAcknowledgementProcessor());
+
+		// Cancelling an in-flight poll runs the whenComplete callback registered in managePollingFuture
+		// inline on the stopping thread, removing the future from pollingFutures while it's being iterated
+		CompletableFuture<Object> pollingFuture = new CompletableFuture<>();
+		ReflectionTestUtils.invokeMethod(source, "managePollingFuture", pollingFuture);
+
+		assertThatNoException().isThrownBy(source::stop);
+		assertThat(pollingFuture).isCancelled();
 	}
 
 	private static boolean doAwait(CountDownLatch processingLatch) {


### PR DESCRIPTION
Cherry-picks the following SQS fixes from `main` onto `3.4.x`:

- #1663 Flush buffered acknowledgements from the shutdown wait
- #1664 Account for acknowledgements not yet added to the buffer on shutdown
- #1632 Prevent `ConcurrentModificationException` on container stop

All three are unmodified cherry-picks (`-x`) of the original commits. Verified locally by running the test classes the picks touch.
