### PR TITLE
Pin LocalStack image in docker compose test resources

### DIFF
--- a/spring-cloud-aws-docker-compose/src/test/resources/docker-compose.yaml
+++ b/spring-cloud-aws-docker-compose/src/test/resources/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:4.4.0
     environment:
       AWS_ACCESS_KEY_ID: noop
       AWS_SECRET_ACCESS_KEY: noop


### PR DESCRIPTION
Since March 23, 2026 the `localstack:latest` community image requires a `LOCALSTACK_AUTH_TOKEN` and exits on startup without it, which currently fails CI on `3.4.x`. Pins the image to `4.4.0`, matching the branch's other LocalStack pins. See #1586; `main` was fixed in #1602.
