### PR TITLE
Speed up the Kinesis test suite

### DIFF
--- a/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/LocalstackContainerTest.java
+++ b/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/LocalstackContainerTest.java
@@ -15,6 +15,9 @@
  */
 package io.awspring.cloud.kinesis;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.localstack.LocalStackContainer;
@@ -23,12 +26,15 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.core.waiters.WaiterResponse;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClient;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamResponse;
+import software.amazon.awssdk.services.kinesis.model.ResourceInUseException;
 
 /**
  * The base contract for JUnit tests based on the container for Localstack. The Testcontainers 'reuse' option must be
@@ -46,9 +52,53 @@ public interface LocalstackContainerTest {
 	LocalStackContainer LOCAL_STACK_CONTAINER = new LocalStackContainer(
 			DockerImageName.parse("localstack/localstack:4.4.0"));
 
+	Semaphore STREAM_CREATION = new Semaphore(3);
+
 	@BeforeAll
 	static void startContainer() {
-		LOCAL_STACK_CONTAINER.start();
+		synchronized (LOCAL_STACK_CONTAINER) {
+			LOCAL_STACK_CONTAINER.start();
+		}
+	}
+
+	/**
+	 * Creates a stream and waits until it exists, at most three at a time. Test classes run concurrently and AWS only
+	 * allows a few streams to be in the 'CREATING' state at once, which the concurrent creations were exceeding.
+	 */
+	static CompletableFuture<WaiterResponse<DescribeStreamResponse>> createStream(KinesisAsyncClient client,
+			String streamName, int shardCount) {
+		STREAM_CREATION.acquireUninterruptibly();
+		try {
+			return client.createStream(request -> request.streamName(streamName).shardCount(shardCount))
+					// A slow CreateStream can exceed the client's read timeout, and the SDK retries it. The
+					// stream is created either way, so the retry answers 'already exists', which is the state
+					// this method is asking for.
+					.exceptionally(throwable -> {
+						if (hasCause(throwable, ResourceInUseException.class)) {
+							return null;
+						}
+						throw throwable instanceof CompletionException ? (CompletionException) throwable
+								: new CompletionException(throwable);
+					})
+					.thenCompose(
+							result -> client.waiter().waitUntilStreamExists(request -> request.streamName(streamName)))
+					.whenComplete((result, throwable) -> STREAM_CREATION.release());
+		}
+		catch (RuntimeException ex) {
+			// The release is attached to the future, so a throw before it exists would lose the permit and
+			// eventually block every later creation.
+			STREAM_CREATION.release();
+			throw ex;
+		}
+	}
+
+	private static boolean hasCause(Throwable throwable, Class<? extends Throwable> type) {
+		for (Throwable current = throwable; current != null; current = current.getCause()) {
+			if (type.isInstance(current)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	static KinesisAsyncClient kinesisClient() {

--- a/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/DynamoDbStreamToKclIntegrationTests.java
+++ b/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/DynamoDbStreamToKclIntegrationTests.java
@@ -169,9 +169,12 @@ class DynamoDbStreamToKclIntegrationTests implements LocalstackContainerTest {
 			adapter.setMetricsLevel(MetricsLevel.NONE);
 			adapter.setLeaseManagementConfigCustomizer(
 					leaseManagementConfig -> leaseManagementConfig.maxLeasesForWorker(10).shardSyncIntervalMillis(0)
+							.failoverTimeMillis(1000).leaseAssignmentIntervalMillis(1000L)
 							.workerUtilizationAwareAssignmentConfig().disableWorkerMetrics(true));
+			adapter.setLifecycleConfigCustomizer(lifecycleConfig -> lifecycleConfig.taskBackoffTimeMillis(100L));
 			adapter.setCoordinatorConfigCustomizer(
-					coordinatorConfig -> coordinatorConfig.shardConsumerDispatchPollIntervalMillis(500L));
+					coordinatorConfig -> coordinatorConfig.shardConsumerDispatchPollIntervalMillis(500L)
+							.parentShardPollIntervalMillis(1000L).schedulerInitializationBackoffTimeMillis(200L));
 			adapter.setPollingMaxRecords(3);
 			adapter.setGracefulShutdownTimeout(100);
 			return adapter;

--- a/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KclMessageDrivenChannelAdapterMultiStreamTests.java
+++ b/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KclMessageDrivenChannelAdapterMultiStreamTests.java
@@ -69,15 +69,9 @@ class KclMessageDrivenChannelAdapterMultiStreamTests implements LocalstackContai
 		DYNAMO_DB = LocalstackContainerTest.dynamoDbClient();
 		CLOUD_WATCH = LocalstackContainerTest.cloudWatchClient();
 
-		CompletableFuture<?> completableFuture1 = AMAZON_KINESIS
-				.createStream(request -> request.streamName(TEST_STREAM1).shardCount(1))
-				.thenCompose(result -> AMAZON_KINESIS.waiter()
-						.waitUntilStreamExists(request -> request.streamName(TEST_STREAM1)));
+		CompletableFuture<?> completableFuture1 = LocalstackContainerTest.createStream(AMAZON_KINESIS, TEST_STREAM1, 1);
 
-		CompletableFuture<?> completableFuture2 = AMAZON_KINESIS
-				.createStream(request -> request.streamName(TEST_STREAM2).shardCount(1))
-				.thenCompose(result -> AMAZON_KINESIS.waiter()
-						.waitUntilStreamExists(request -> request.streamName(TEST_STREAM2)));
+		CompletableFuture<?> completableFuture2 = LocalstackContainerTest.createStream(AMAZON_KINESIS, TEST_STREAM2, 1);
 
 		CompletableFuture.allOf(completableFuture1, completableFuture2).join();
 	}
@@ -132,7 +126,12 @@ class KclMessageDrivenChannelAdapterMultiStreamTests implements LocalstackContai
 			adapter.setMetricsLevel(MetricsLevel.NONE);
 			adapter.setLeaseManagementConfigCustomizer(
 					leaseManagementConfig -> leaseManagementConfig.maxLeasesForWorker(10).shardSyncIntervalMillis(0)
+							.failoverTimeMillis(1000).leaseAssignmentIntervalMillis(1000L)
 							.workerUtilizationAwareAssignmentConfig().disableWorkerMetrics(true));
+			adapter.setLifecycleConfigCustomizer(lifecycleConfig -> lifecycleConfig.taskBackoffTimeMillis(100L));
+			adapter.setCoordinatorConfigCustomizer(
+					coordinatorConfig -> coordinatorConfig.shardConsumerDispatchPollIntervalMillis(500L)
+							.parentShardPollIntervalMillis(1000L).schedulerInitializationBackoffTimeMillis(200L));
 			return adapter;
 		}
 

--- a/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KclMessageDrivenChannelAdapterTests.java
+++ b/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KclMessageDrivenChannelAdapterTests.java
@@ -187,9 +187,12 @@ public class KclMessageDrivenChannelAdapterTests implements LocalstackContainerT
 			adapter.setMetricsLevel(MetricsLevel.NONE);
 			adapter.setLeaseManagementConfigCustomizer(
 					leaseManagementConfig -> leaseManagementConfig.maxLeasesForWorker(10).shardSyncIntervalMillis(0)
+							.failoverTimeMillis(1000).leaseAssignmentIntervalMillis(1000L)
 							.workerUtilizationAwareAssignmentConfig().disableWorkerMetrics(true));
+			adapter.setLifecycleConfigCustomizer(lifecycleConfig -> lifecycleConfig.taskBackoffTimeMillis(100L));
 			adapter.setCoordinatorConfigCustomizer(
-					coordinatorConfig -> coordinatorConfig.shardConsumerDispatchPollIntervalMillis(500L));
+					coordinatorConfig -> coordinatorConfig.shardConsumerDispatchPollIntervalMillis(500L)
+							.parentShardPollIntervalMillis(1000L).schedulerInitializationBackoffTimeMillis(200L));
 			adapter.setBindSourceRecord(true);
 			adapter.setEmptyRecordList(true);
 			adapter.setPollingMaxRecords(99);
@@ -205,8 +208,7 @@ public class KclMessageDrivenChannelAdapterTests implements LocalstackContainerT
 	}
 
 	private static CompletableFuture<WaiterResponse<DescribeStreamResponse>> initializeStream(String streamName) {
-		return AMAZON_KINESIS.createStream(request -> request.streamName(streamName).shardCount(1)).thenCompose(
-				result -> AMAZON_KINESIS.waiter().waitUntilStreamExists(request -> request.streamName(streamName)));
+		return LocalstackContainerTest.createStream(AMAZON_KINESIS, streamName, 1);
 	}
 
 	/**

--- a/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KinesisIntegrationTests.java
+++ b/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KinesisIntegrationTests.java
@@ -73,10 +73,7 @@ class KinesisIntegrationTests implements LocalstackContainerTest {
 	@BeforeAll
 	static void setup() {
 		AMAZON_KINESIS_ASYNC = LocalstackContainerTest.kinesisClient();
-		AMAZON_KINESIS_ASYNC.createStream(request -> request.streamName(TEST_STREAM).shardCount(1))
-				.thenCompose(result -> AMAZON_KINESIS_ASYNC.waiter()
-						.waitUntilStreamExists(request -> request.streamName(TEST_STREAM)))
-				.join();
+		LocalstackContainerTest.createStream(AMAZON_KINESIS_ASYNC, TEST_STREAM, 1).join();
 	}
 
 	@Test

--- a/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KinesisMessageHandlerIntegrationTests.java
+++ b/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KinesisMessageHandlerIntegrationTests.java
@@ -66,11 +66,8 @@ class KinesisMessageHandlerIntegrationTests implements LocalstackContainerTest {
 	@BeforeAll
 	static void setup() {
 		AMAZON_KINESIS = LocalstackContainerTest.kinesisClient();
-		WaiterResponse<DescribeStreamResponse> describeStreamResponse = AMAZON_KINESIS
-				.createStream(request -> request.streamName(TEST_STREAM).shardCount(1))
-				.thenCompose(result -> AMAZON_KINESIS.waiter()
-						.waitUntilStreamExists(request -> request.streamName(TEST_STREAM)))
-				.join();
+		WaiterResponse<DescribeStreamResponse> describeStreamResponse = LocalstackContainerTest
+				.createStream(AMAZON_KINESIS, TEST_STREAM, 1).join();
 
 		StreamDescription streamDescription = describeStreamResponse.matched().response().get().streamDescription();
 		TEST_STREAM_SHARD_ID = streamDescription.shards().get(0).shardId();

--- a/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KplIntegrationTests.java
+++ b/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KplIntegrationTests.java
@@ -68,9 +68,7 @@ class KplIntegrationTests implements LocalstackContainerTest {
 		AMAZON_KINESIS = LocalstackContainerTest.kinesisClient();
 		CLOUD_WATCH = LocalstackContainerTest.cloudWatchClient();
 
-		AMAZON_KINESIS.createStream(request -> request.streamName(TEST_STREAM).shardCount(1)).thenCompose(
-				result -> AMAZON_KINESIS.waiter().waitUntilStreamExists(request -> request.streamName(TEST_STREAM)))
-				.join();
+		LocalstackContainerTest.createStream(AMAZON_KINESIS, TEST_STREAM, 1).join();
 	}
 
 	@Test

--- a/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KplKclIntegrationTests.java
+++ b/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KplKclIntegrationTests.java
@@ -92,9 +92,7 @@ class KplKclIntegrationTests implements LocalstackContainerTest {
 		DYNAMO_DB = LocalstackContainerTest.dynamoDbClient();
 		CLOUD_WATCH = LocalstackContainerTest.cloudWatchClient();
 
-		AMAZON_KINESIS.createStream(request -> request.streamName(TEST_STREAM).shardCount(1)).thenCompose(
-				result -> AMAZON_KINESIS.waiter().waitUntilStreamExists(request -> request.streamName(TEST_STREAM)))
-				.join();
+		LocalstackContainerTest.createStream(AMAZON_KINESIS, TEST_STREAM, 1).join();
 
 		initializeLeaseTable();
 	}
@@ -203,7 +201,12 @@ class KplKclIntegrationTests implements LocalstackContainerTest {
 			adapter.setMetricsLevel(MetricsLevel.NONE);
 			adapter.setLeaseManagementConfigCustomizer(
 					leaseManagementConfig -> leaseManagementConfig.maxLeasesForWorker(10).shardSyncIntervalMillis(0)
+							.failoverTimeMillis(1000).leaseAssignmentIntervalMillis(1000L)
 							.workerUtilizationAwareAssignmentConfig().disableWorkerMetrics(true));
+			adapter.setLifecycleConfigCustomizer(lifecycleConfig -> lifecycleConfig.taskBackoffTimeMillis(100L));
+			adapter.setCoordinatorConfigCustomizer(
+					coordinatorConfig -> coordinatorConfig.shardConsumerDispatchPollIntervalMillis(500L)
+							.parentShardPollIntervalMillis(1000L).schedulerInitializationBackoffTimeMillis(200L));
 			return adapter;
 		}
 

--- a/spring-cloud-aws-kinesis/src/test/resources/junit-platform.properties
+++ b/spring-cloud-aws-kinesis/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.classes.default = concurrent
+junit.jupiter.execution.parallel.mode.default = same_thread


### PR DESCRIPTION

## Motivation

Follow-up to #1665, which enabled parallel reactor builds and brought CI from about 15 minutes to about 9.

With modules now building concurrently, wall clock is set by the longest dependency chain. The two Kinesis modules are the slowest in the reactor. This covers `spring-cloud-aws-kinesis`; the binder is a separate change.

Test code only. Test counts are unchanged.

## Changes

**Run the integration test classes concurrently.** The module had no parallel execution configured, so its classes ran one after another even though each uses its own streams, tables and consumer group. Enable concurrent classes and keep methods on the same thread.

The shared Localstack container start is now guarded, since Testcontainers does not document `start()` as thread safe and several `@BeforeAll` methods can reach it at once.

**Gate stream creation.** Concurrent `CreateStream` calls can exceed the limit for streams being created at the same time. Creation goes through a helper that allows three at once, which is why the callers now route through it. Creating one at a time was measured and costs about 50 seconds.

**Shorten the KCL startup intervals.** The KCL classes are single test fixtures whose time is spent in scheduler startup, and they ran with the library defaults for parent shard polling of 10 seconds, failover of 10 seconds, scheduler initialization backoff of 1 second and task backoff of 500 milliseconds. A single worker against Localstack has no fleet to coordinate with, so those intervals are latency with nothing to buy.

## Result

Measured on CI against current main.

| JDK | Before | After |
|---|---|---|
| 17 | 4:33 | 1:46 |
| 21 | 4:50 | 1:59 |
| 24 | 4:34 | 2:00 |

Green on all three JDKs.
