### PR TITLE
Add unit tests for Jitter strategies and context

### DIFF
--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/JitterContextTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/JitterContextTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.errorhandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Jitter.Context}.
+ *
+ * @author Tomaz Fernandes
+ */
+class JitterContextTest {
+
+	@Test
+	void shouldCreateContextWithValidParameters() {
+		// Given
+		int timeout = 10;
+		Supplier<Random> randomSupplier = ThreadLocalRandom::current;
+
+		// When
+		Jitter.Context context = new Jitter.Context(timeout, randomSupplier);
+
+		// Then
+		assertThat(context.getTimeout()).isEqualTo(timeout);
+		assertThat(context.getRandomSupplier()).isEqualTo(randomSupplier);
+	}
+
+	@Test
+	void shouldThrowExceptionWhenTimeoutIsZero() {
+		// Given
+		int timeout = 0;
+		Supplier<Random> randomSupplier = ThreadLocalRandom::current;
+
+		// When & Then
+		assertThatThrownBy(() -> new Jitter.Context(timeout, randomSupplier))
+				.isInstanceOf(IllegalArgumentException.class).hasMessage("Timeout must be >= 1, but was 0");
+	}
+
+	@Test
+	void shouldThrowExceptionWhenTimeoutIsNegative() {
+		// Given
+		int timeout = -1;
+		Supplier<Random> randomSupplier = ThreadLocalRandom::current;
+
+		// When & Then
+		assertThatThrownBy(() -> new Jitter.Context(timeout, randomSupplier))
+				.isInstanceOf(IllegalArgumentException.class).hasMessage("Timeout must be >= 1, but was -1");
+	}
+
+	@Test
+	@SuppressWarnings("null")
+	void shouldThrowExceptionWhenRandomSupplierIsNull() {
+		// Given
+		int timeout = 10;
+		Supplier<Random> nullSupplier = null;
+
+		// When & Then
+		assertThatThrownBy(() -> new Jitter.Context(timeout, nullSupplier)).isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Random supplier cannot be null");
+	}
+
+	@Test
+	void shouldAcceptMinimumValidTimeout() {
+		// Given
+		int timeout = 1;
+		Supplier<Random> randomSupplier = ThreadLocalRandom::current;
+
+		// When
+		Jitter.Context context = new Jitter.Context(timeout, randomSupplier);
+
+		// Then
+		assertThat(context.getTimeout()).isEqualTo(1);
+		assertThat(context.getRandomSupplier()).isEqualTo(randomSupplier);
+	}
+
+	@Test
+	void shouldAcceptLargeTimeout() {
+		// Given
+		int timeout = Integer.MAX_VALUE;
+		Supplier<Random> randomSupplier = ThreadLocalRandom::current;
+
+		// When
+		Jitter.Context context = new Jitter.Context(timeout, randomSupplier);
+
+		// Then
+		assertThat(context.getTimeout()).isEqualTo(Integer.MAX_VALUE);
+		assertThat(context.getRandomSupplier()).isEqualTo(randomSupplier);
+	}
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/JitterStrategiesTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/errorhandler/JitterStrategiesTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.listener.errorhandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Jitter} strategies.
+ *
+ * @author Tomaz Fernandes
+ */
+class JitterStrategiesTest {
+
+	private final Supplier<Random> randomSupplier = ThreadLocalRandom::current;
+
+	@Test
+	void shouldReturnOriginalTimeoutForNoneJitter() {
+		// Given
+		int timeout = 100;
+		Jitter.Context context = new Jitter.Context(timeout, randomSupplier);
+
+		// When
+		int result = Jitter.NONE.applyJitter(context);
+
+		// Then
+		assertThat(result).isEqualTo(timeout);
+	}
+
+	@Test
+	void shouldReturnValueBetweenZeroAndTimeoutForFullJitter() {
+		// Given
+		int timeout = 100;
+		Jitter.Context context = new Jitter.Context(timeout, randomSupplier);
+
+		// When
+		int result = Jitter.FULL.applyJitter(context);
+
+		// Then
+		assertThat(result).isGreaterThanOrEqualTo(1);
+		assertThat(result).isLessThanOrEqualTo(timeout);
+	}
+
+	@Test
+	void shouldReturnValueBetweenHalfAndTimeoutForHalfJitter() {
+		// Given
+		int timeout = 100;
+		Jitter.Context context = new Jitter.Context(timeout, randomSupplier);
+
+		// When
+		int result = Jitter.HALF.applyJitter(context);
+
+		// Then
+		int expectedLowerBound = (int) Math.ceil(timeout / 2.0);
+		assertThat(result).isGreaterThanOrEqualTo(expectedLowerBound);
+		assertThat(result).isLessThanOrEqualTo(timeout);
+	}
+
+	@Test
+	void shouldHandleOddTimeoutForHalfJitter() {
+		// Given
+		int timeout = 101; // Odd number
+		Jitter.Context context = new Jitter.Context(timeout, randomSupplier);
+
+		// When
+		int result = Jitter.HALF.applyJitter(context);
+
+		// Then
+		int expectedLowerBound = (int) Math.ceil(timeout / 2.0); // Should be 51
+		assertThat(result).isGreaterThanOrEqualTo(expectedLowerBound);
+		assertThat(result).isLessThanOrEqualTo(timeout);
+	}
+
+	@Test
+	void shouldHandleMinimumTimeoutForAllStrategies() {
+		// Given
+		int timeout = 1;
+		Jitter.Context context = new Jitter.Context(timeout, randomSupplier);
+
+		// When & Then
+		assertThat(Jitter.NONE.applyJitter(context)).isEqualTo(1);
+		assertThat(Jitter.FULL.applyJitter(context)).isEqualTo(1);
+		assertThat(Jitter.HALF.applyJitter(context)).isEqualTo(1);
+	}
+
+	@Test
+	void shouldEnsureMinimumValueOfOneForAllStrategies() {
+		// Given
+		int timeout = 2;
+		Jitter.Context context = new Jitter.Context(timeout, randomSupplier);
+
+		// When
+		int noneResult = Jitter.NONE.applyJitter(context);
+		int fullResult = Jitter.FULL.applyJitter(context);
+		int halfResult = Jitter.HALF.applyJitter(context);
+
+		// Then
+		assertThat(noneResult).isGreaterThanOrEqualTo(1);
+		assertThat(fullResult).isGreaterThanOrEqualTo(1);
+		assertThat(halfResult).isGreaterThanOrEqualTo(1);
+	}
+
+	@Test
+	void shouldProduceDifferentResultsForMultipleCalls() {
+		// Given
+		int timeout = 100;
+		Jitter.Context context = new Jitter.Context(timeout, randomSupplier);
+
+		// When
+		int result1 = Jitter.FULL.applyJitter(context);
+		int result2 = Jitter.FULL.applyJitter(context);
+		int result3 = Jitter.FULL.applyJitter(context);
+
+		// Then
+		// While it's theoretically possible for all results to be the same,
+		// it's extremely unlikely with a good random number generator
+		// We'll just verify they're all within the expected range
+		assertThat(result1).isBetween(1, timeout);
+		assertThat(result2).isBetween(1, timeout);
+		assertThat(result3).isBetween(1, timeout);
+	}
+}


### PR DESCRIPTION
## Motivation

`Jitter` is currently covered only through the error handler tests, which exercise it indirectly.

## Changes

`JitterStrategiesTest` covers the three strategies directly: `NONE` returning the timeout unchanged, `FULL` staying within 1 and the timeout, and `HALF` respecting its ceiling-based lower bound, including for odd timeouts where the rounding matters. It also covers the minimum value of 1 that all three enforce.

`JitterContextTest` covers `Jitter.Context` construction and validation: zero, negative, and null arguments with their messages, plus the boundaries at 1 and `Integer.MAX_VALUE`.

## Result

13 tests, 82 milliseconds, no sleeps or containers.
