### PR TITLE
Improve SQS tests resilience under concurrent load

### DIFF
--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SnsNotificationIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SnsNotificationIntegrationTests.java
@@ -18,7 +18,6 @@ package io.awspring.cloud.sqs.integration;
 import static io.awspring.cloud.sqs.integration.SnsNotificationIntegrationTests.SNS_NOTIFICATION_JSON_QUEUE_NAME;
 import static io.awspring.cloud.sqs.integration.SnsNotificationIntegrationTests.SNS_NOTIFICATION_STRING_QUEUE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.sqs.annotation.SqsListener;
@@ -81,7 +80,7 @@ class SnsNotificationIntegrationTests extends BaseSqsIntegrationTest {
 	}
 
 	@Test
-	void shouldReceiveSnsNotificationWithRequiredFieldsOnly() {
+	void shouldReceiveSnsNotificationWithRequiredFieldsOnly() throws Exception {
 		String type = "Notification";
 		String messageId = "message-id-required-only";
 		String topicArn = "topic-arn";
@@ -99,8 +98,7 @@ class SnsNotificationIntegrationTests extends BaseSqsIntegrationTest {
 				}""".formatted(type, messageId, topicArn, messageContent, timestamp);
 
 		sqsTemplate.send(SNS_NOTIFICATION_STRING_QUEUE_NAME, snsJson);
-		await().atMost(Duration.ofSeconds(10)).untilAsserted(
-				() -> assertThat(latchContainer.requiredFieldsLatch.await(10, TimeUnit.SECONDS)).isTrue());
+		assertThat(latchContainer.requiredFieldsLatch.await(60, TimeUnit.SECONDS)).isTrue();
 
 		SnsNotification<String> receivedNotification = (SnsNotification<String>) latchContainer
 				.getNotification(messageId);
@@ -122,7 +120,7 @@ class SnsNotificationIntegrationTests extends BaseSqsIntegrationTest {
 	}
 
 	@Test
-	void shouldReceiveSnsNotificationWithAllFields() {
+	void shouldReceiveSnsNotificationWithAllFields() throws Exception {
 		String type = "Notification";
 		String messageId = "message-id-all-fields";
 		String sequenceNumber = "10000000000000003000";
@@ -159,8 +157,7 @@ class SnsNotificationIntegrationTests extends BaseSqsIntegrationTest {
 				subject, signatureVersion, signature, signingCertURL);
 
 		sqsTemplate.send(SNS_NOTIFICATION_STRING_QUEUE_NAME, snsJson);
-		await().atMost(Duration.ofSeconds(10))
-				.untilAsserted(() -> assertThat(latchContainer.allFieldsLatch.await(10, TimeUnit.SECONDS)).isTrue());
+		assertThat(latchContainer.allFieldsLatch.await(60, TimeUnit.SECONDS)).isTrue();
 
 		SnsNotification<String> receivedNotification = (SnsNotification<String>) latchContainer
 				.getNotification(messageId);
@@ -218,8 +215,7 @@ class SnsNotificationIntegrationTests extends BaseSqsIntegrationTest {
 				timestamp, unsubscribeUrl, subject);
 
 		sqsTemplate.send(SNS_NOTIFICATION_JSON_QUEUE_NAME, snsJson);
-		await().atMost(Duration.ofSeconds(10))
-				.untilAsserted(() -> assertThat(latchContainer.jsonPayloadLatch.await(10, TimeUnit.SECONDS)).isTrue());
+		assertThat(latchContainer.jsonPayloadLatch.await(60, TimeUnit.SECONDS)).isTrue();
 
 		SnsNotification<String> receivedNotification = (SnsNotification<String>) latchContainer
 				.getNotification(messageId);

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsAnnotationAcknowledgementIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsAnnotationAcknowledgementIntegrationTests.java
@@ -109,7 +109,7 @@ public class SqsAnnotationAcknowledgementIntegrationTests extends BaseSqsIntegra
 		sqsTemplate.send(ANNOTATION_ALWAYS_ACK_SUCCESS_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", ANNOTATION_ALWAYS_ACK_SUCCESS_QUEUE_NAME,
 				messageBody);
-		assertThat(latchContainer.annotationAlwaysAckSuccessLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.annotationAlwaysAckSuccessLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -118,7 +118,7 @@ public class SqsAnnotationAcknowledgementIntegrationTests extends BaseSqsIntegra
 		sqsTemplate.send(ANNOTATION_ALWAYS_ACK_ERROR_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", ANNOTATION_ALWAYS_ACK_ERROR_QUEUE_NAME,
 				messageBody);
-		assertThat(latchContainer.annotationAlwaysAckErrorLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.annotationAlwaysAckErrorLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -127,7 +127,7 @@ public class SqsAnnotationAcknowledgementIntegrationTests extends BaseSqsIntegra
 		sqsTemplate.send(ANNOTATION_ON_SUCCESS_ACK_SUCCESS_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", ANNOTATION_ON_SUCCESS_ACK_SUCCESS_QUEUE_NAME,
 				messageBody);
-		assertThat(latchContainer.annotationOnSuccessAckSuccessLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.annotationOnSuccessAckSuccessLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -136,8 +136,8 @@ public class SqsAnnotationAcknowledgementIntegrationTests extends BaseSqsIntegra
 		sqsTemplate.send(ANNOTATION_ON_SUCCESS_ACK_ERROR_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", ANNOTATION_ON_SUCCESS_ACK_ERROR_QUEUE_NAME,
 				messageBody);
-		assertThat(latchContainer.annotationOnSuccessAckErrorLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(latchContainer.annotationOnSuccessAckErrorCallbackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.annotationOnSuccessAckErrorLatch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.annotationOnSuccessAckErrorCallbackLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -145,7 +145,7 @@ public class SqsAnnotationAcknowledgementIntegrationTests extends BaseSqsIntegra
 		String messageBody = "annotationManualAck-payload";
 		sqsTemplate.send(ANNOTATION_MANUAL_ACK_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", ANNOTATION_MANUAL_ACK_QUEUE_NAME, messageBody);
-		assertThat(latchContainer.annotationManualAckLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.annotationManualAckLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.annotationManualAckLatchCallback.await(10, TimeUnit.SECONDS)).isFalse();
 	}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsBackPressureIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsBackPressureIntegrationTests.java
@@ -100,7 +100,7 @@ class SqsBackPressureIntegrationTests extends BaseSqsIntegrationTest {
 
 		@Override
 		public boolean drain(Duration timeout) {
-			Duration drainingTimeout = Duration.ofSeconds(10L);
+			Duration drainingTimeout = Duration.ofSeconds(60L);
 			Duration drainingPollingIntervalCheck = Duration.ofMillis(50L);
 			draining.set(true);
 			limit.set(0);
@@ -147,7 +147,7 @@ class SqsBackPressureIntegrationTests extends BaseSqsIntegrationTest {
 					concurrentRequest.decrementAndGet();
 				}).build();
 		container.start();
-		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(maxConcurrentRequest.get()).isLessThanOrEqualTo(expectedMaxConcurrentRequests);
 		container.stop();
 	}
@@ -215,7 +215,7 @@ class SqsBackPressureIntegrationTests extends BaseSqsIntegrationTest {
 								opt -> limiter, BackPressureHandlerFactories.concurrencyLimiterBackPressureHandler())))
 				.messageListener(msg -> {
 					try {
-						if (!controlSemaphore.tryAcquire(5, TimeUnit.SECONDS) && !isDraining.get()) {
+						if (!controlSemaphore.tryAcquire(30, TimeUnit.SECONDS) && !isDraining.get()) {
 							processingFailed.set(true);
 							throw new IllegalStateException("Failed to wait for control semaphore");
 						}
@@ -270,7 +270,7 @@ class SqsBackPressureIntegrationTests extends BaseSqsIntegrationTest {
 			}
 
 			void waitForAdvance(int permits) throws InterruptedException {
-				assertThat(advanceSemaphore.tryAcquire(permits, 5, TimeUnit.SECONDS))
+				assertThat(advanceSemaphore.tryAcquire(permits, 30, TimeUnit.SECONDS))
 						.withFailMessage(() -> "Waiting for %d permits timed out. Only %d permits available"
 								.formatted(permits, advanceSemaphore.availablePermits()))
 						.isTrue();
@@ -319,7 +319,7 @@ class SqsBackPressureIntegrationTests extends BaseSqsIntegrationTest {
 			controller.updateLimit(6);
 
 			controller.waitForAdvance(50);
-			assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+			assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
 			assertThat(controller.maxConcurrentRequest.get()).isLessThanOrEqualTo(5);
 			assertThat(processingFailed.get()).isFalse();
 		}
@@ -491,7 +491,7 @@ class SqsBackPressureIntegrationTests extends BaseSqsIntegrationTest {
 			}
 			eventsCsvWriter.write(Path.of("target/stats-%s.csv".formatted(queueName)));
 			assertThat(maxConcurrentRqSum).isLessThanOrEqualTo(limitsSum);
-			assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+			assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
 		}
 		finally {
 			container.stop();

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsErrorHandlerIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsErrorHandlerIntegrationTests.java
@@ -126,7 +126,7 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		logger.debug("Sent message to queue {} with messageBody {}", SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_QUEUE_NAME,
 				messageBody);
 
-		assertThat(latchContainer.receivesRetryMessageQuicklyLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.receivesRetryMessageQuicklyLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -137,7 +137,7 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		logger.debug("Sent message to queue {} with messageBody {}",
 				SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_BATCH_QUEUE_NAME, messages);
 
-		assertThat(latchContainer.receivesRetryBatchMessageQuicklyLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.receivesRetryBatchMessageQuicklyLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsFifoIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsFifoIntegrationTests.java
@@ -276,7 +276,7 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 		String messageDeduplicationId = MessageHeaderUtils.getHeaderAsString(sendResult.message(),
 				SqsHeaders.MessageSystemAttributes.SQS_MESSAGE_DEDUPLICATION_ID_HEADER);
 		logger.debug("Sent message to queue {} with messageBody {}", OBSERVES_MESSAGE_FIFO_QUEUE_NAME, messageBody);
-		assertThat(latchContainer.observesFifoMessageLatch.await(10, TimeUnit.MINUTES)).isTrue();
+		assertThat(latchContainer.observesFifoMessageLatch.await(30, TimeUnit.SECONDS)).isTrue();
 		await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> TestObservationRegistryAssert.then(observationRegistry)
 				.hasNumberOfObservationsEqualTo(3).hasHandledContextsThatSatisfy(contexts -> {
 					ObservationContextAssert.then(contexts.get(0)).hasNameEqualTo("spring.aws.sqs.template")

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
@@ -199,9 +199,9 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		String messageBody = "receivesMessage-payload";
 		sqsTemplate.send(RECEIVES_MESSAGE_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", RECEIVES_MESSAGE_QUEUE_NAME, messageBody);
-		assertThat(latchContainer.receivesMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(latchContainer.invocableHandlerMethodLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(latchContainer.acknowledgementCallbackSuccessLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.receivesMessageLatch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.invocableHandlerMethodLatch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.acknowledgementCallbackSuccessLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -220,7 +220,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		logger.debug("Sent message to queue {} with messageBody {}", RECEIVES_MESSAGE_MULTI_METHOD_QUEUE_NAME,
 				message3);
 
-		assertThat(latchContainer.receivesMessageMultiMethodLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.receivesMessageMultiMethodLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -229,7 +229,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		SendResult<Object> sendResult = sqsTemplate
 				.send(to -> to.queue(OBSERVES_MESSAGE_QUEUE_NAME).payload(messageBody));
 		logger.debug("Sent message to queue {} with messageBody {}", OBSERVES_MESSAGE_QUEUE_NAME, messageBody);
-		assertThat(latchContainer.observesMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.observesMessageLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> TestObservationRegistryAssert.then(observationRegistry)
 				.hasHandledContextsThatSatisfy(contexts -> {
 					ObservationContextAssert
@@ -308,7 +308,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		String messageBody = "observesMessage-payload";
 		sqsTemplate.send(to -> to.queue(OBSERVES_ERROR_QUEUE_NAME).payload(messageBody));
 		logger.debug("Sent message to queue {} with messageBody {}", OBSERVES_ERROR_QUEUE_NAME, messageBody);
-		assertThat(latchContainer.observesErrorLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.observesErrorLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> TestObservationRegistryAssert.then(observationRegistry)
 				.hasHandledContextsThatSatisfy(contexts -> {
 					ObservationContextAssert
@@ -343,7 +343,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 			// ensure that first batch was processed more than once
 			assertThat(latchContainer.receivesMessageBatchLatch.getCount()).isLessThan(10);
 		});
-		assertThat(latchContainer.acknowledgementCallbackBatchLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.acknowledgementCallbackBatchLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -351,7 +351,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		String messageBody = "receivesMessageAsync-payload";
 		sqsTemplate.send(RECEIVES_MESSAGE_ASYNC_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", RECEIVES_MESSAGE_ASYNC_QUEUE_NAME, messageBody);
-		assertThat(latchContainer.receivesMessageAsyncLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.receivesMessageAsyncLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -359,8 +359,8 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		String messageBody = "doesNotAckOnError-payload";
 		sqsTemplate.send(DOES_NOT_ACK_ON_ERROR_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", DOES_NOT_ACK_ON_ERROR_QUEUE_NAME, messageBody);
-		assertThat(latchContainer.doesNotAckLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(latchContainer.acknowledgementCallbackErrorLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.doesNotAckLatch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.acknowledgementCallbackErrorLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -369,7 +369,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.send(DOES_NOT_ACK_ON_ERROR_ASYNC_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", DOES_NOT_ACK_ON_ERROR_ASYNC_QUEUE_NAME,
 				messageBody);
-		assertThat(latchContainer.doesNotAckAsyncLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.doesNotAckAsyncLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -379,7 +379,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 				.map(payload -> MessageBuilder.withPayload(payload).build()).collect(Collectors.toList());
 		sqsTemplate.sendManyAsync(DOES_NOT_ACK_ON_ERROR_BATCH_QUEUE_NAME, messages);
 		logger.debug("Sent messages to queue {} with messages {}", DOES_NOT_ACK_ON_ERROR_BATCH_QUEUE_NAME, messages);
-		assertThat(latchContainer.doesNotAckBatchLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.doesNotAckBatchLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -390,7 +390,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.sendManyAsync(DOES_NOT_ACK_ON_ERROR_BATCH_ASYNC_QUEUE_NAME, messages);
 		logger.debug("Sent messages to queue {} with messages {}", DOES_NOT_ACK_ON_ERROR_BATCH_ASYNC_QUEUE_NAME,
 				messages);
-		assertThat(latchContainer.doesNotAckBatchAsyncLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.doesNotAckBatchAsyncLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -398,8 +398,8 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		String messageBody = "many-parameter-types-payload";
 		sqsTemplate.send(RESOLVES_PARAMETER_TYPES_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_PARAMETER_TYPES_QUEUE_NAME, messageBody);
-		assertThat(latchContainer.manyParameterTypesLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(latchContainer.manyParameterTypesSecondLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.manyParameterTypesLatch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.manyParameterTypesSecondLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -407,7 +407,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		String messageBody = "Testing manually creates container";
 		sqsTemplate.send(MANUALLY_CREATE_CONTAINER_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", MANUALLY_CREATE_CONTAINER_QUEUE_NAME, messageBody);
-		assertThat(latchContainer.manuallyCreatedContainerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.manuallyCreatedContainerLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -418,7 +418,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		inactiveMessageListenerContainer.start();
 		logger.debug("Sent message to queue {} with messageBody {}", MANUALLY_CREATE_INACTIVE_CONTAINER_QUEUE_NAME,
 				messageBody);
-		assertThat(latchContainer.manuallyInactiveCreatedContainerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.manuallyInactiveCreatedContainerLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		inactiveMessageListenerContainer.stop();
 	}
 
@@ -438,7 +438,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		String messageBody1 = "MyTest";
 		sqsTemplate.send(MANUALLY_START_CONTAINER, messageBody1);
 		logger.debug("Sent message to queue {} with messageBody {}", MANUALLY_START_CONTAINER, messageBody1);
-		assertThat(latchContainer.manuallyStartedContainerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.manuallyStartedContainerLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		container.stop();
 		container.setMessageListener(msg -> latchContainer.manuallyStartedContainerLatch2.countDown());
 		SqsContainerOptionsBuilder builder = container.getContainerOptions().toBuilder();
@@ -448,7 +448,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		String messageBody2 = "MyTest2";
 		sqsTemplate.send(MANUALLY_START_CONTAINER, messageBody2);
 		logger.debug("Sent message to queue {} with messageBody {}", MANUALLY_START_CONTAINER, messageBody2);
-		assertThat(latchContainer.manuallyStartedContainerLatch2.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.manuallyStartedContainerLatch2.await(60, TimeUnit.SECONDS)).isTrue();
 		container.stop();
 	}
 	// @formatter:on
@@ -458,9 +458,9 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		String messageBody = "Testing manually creates factory";
 		sqsTemplate.send(MANUALLY_CREATE_FACTORY_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", MANUALLY_CREATE_FACTORY_QUEUE_NAME, messageBody);
-		assertThat(latchContainer.manuallyCreatedFactoryLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(latchContainer.manuallyCreatedFactorySourceFactoryLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(latchContainer.manuallyCreatedFactorySinkLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.manuallyCreatedFactoryLatch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.manuallyCreatedFactorySourceFactoryLatch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.manuallyCreatedFactorySinkLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -476,7 +476,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 						.pollTimeout(Duration.ofSeconds(1)).maxConcurrentMessages(1).maxMessagesPerPoll(1))
 				.messageListener(msg -> latch.countDown()).build();
 		container.start();
-		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
 		container.stop();
 	}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
@@ -319,6 +319,10 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 							.filter(context -> context.getContextualName() != null
 									&& context.getContextualName().equals("observes_error_test_queue receive"))
 							.toList();
+					// The second context is the redelivery, which arrives after the visibility timeout. Assert
+					// on its presence first: 'untilAsserted' only retries AssertionError, so indexing straight
+					// into the list would escape the wait with an ArrayIndexOutOfBoundsException instead.
+					assertThat(receivingContexts).hasSize(2);
 					ObservationContextAssert.then(receivingContexts.get(0)).hasNameEqualTo("spring.aws.sqs.listener")
 							.isInstanceOf(AbstractListenerObservation.Context.class).doesNotHaveParentObservation()
 							.assertThatError().isInstanceOf(RuntimeException.class)

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
@@ -493,7 +493,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.sendManyAsync(MAX_CONCURRENT_MESSAGES_QUEUE_NAME, messages2);
 		logger.debug("Sent messages to queue {} with messages {} and {}", MAX_CONCURRENT_MESSAGES_QUEUE_NAME, messages1,
 				messages2);
-		assertDoesNotThrow(() -> latchContainer.maxConcurrentMessagesBarrier.await(10, TimeUnit.SECONDS));
+		assertDoesNotThrow(() -> latchContainer.maxConcurrentMessagesBarrier.await(60, TimeUnit.SECONDS));
 	}
 
 	static class ReceivesMessageListener {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsInterceptorIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsInterceptorIntegrationTests.java
@@ -106,8 +106,8 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void shouldInvokeErrorHandlerAndAfterProcessingInterceptorWhenInterceptorThrows() throws Exception {
 		sqsTemplate.send(INTERCEPTOR_THROWS_QUEUE_NAME, "any-payload");
-		assertThat(latchContainer.interceptorThrowsErrorHandlerLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(latchContainer.interceptorThrowsAfterProcessingLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.interceptorThrowsErrorHandlerLatch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.interceptorThrowsAfterProcessingLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.interceptorThrowsException.get().getCause())
 				.isInstanceOf(InterceptorExecutionFailedException.class);
 		assertThat(latchContainer.interceptorThrowsAfterProcessingException.get().getCause())
@@ -117,8 +117,8 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void shouldInvokeErrorHandlerAndAfterProcessingInterceptorWhenInterceptorThrowsBatch() throws Exception {
 		sqsTemplate.send(INTERCEPTOR_THROWS_BATCH_QUEUE_NAME, "any-payload");
-		assertThat(latchContainer.interceptorThrowsBatchErrorHandlerLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(latchContainer.interceptorThrowsBatchAfterProcessingLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.interceptorThrowsBatchErrorHandlerLatch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.interceptorThrowsBatchAfterProcessingLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.interceptorThrowsBatchException.get().getCause())
 				.isInstanceOf(InterceptorExecutionFailedException.class);
 		assertThat(latchContainer.interceptorThrowsBatchAfterProcessingException.get().getCause())
@@ -128,8 +128,8 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 	@Test
 	void shouldAcknowledgeAndNotProcessWhenErrorHandlerRecoversInterceptorException() throws Exception {
 		sqsTemplate.send(INTERCEPTOR_THROWS_RECOVERS_QUEUE_NAME, "any-payload");
-		assertThat(latchContainer.interceptorThrowsRecoversAckLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(latchContainer.interceptorThrowsRecoversAfterProcessingLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.interceptorThrowsRecoversAckLatch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.interceptorThrowsRecoversAfterProcessingLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchContainer.interceptorThrowsRecoversAfterProcessingException.get()).isNull();
 		assertThat(latchContainer.interceptorThrowsRecoversListenerCalled).isFalse();
 	}
@@ -139,7 +139,7 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.send(RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME, SHOULD_CHANGE_PAYLOAD);
 		logger.debug("Sent message to queue {} with messageBody {}", RECEIVES_CHANGED_MESSAGE_ON_COMPONENTS_QUEUE_NAME,
 				SHOULD_CHANGE_PAYLOAD);
-		assertThat(latchContainer.receivesChangedMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.receivesChangedMessageLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(receivesChangedPayloadListener.receivedMessages).containsExactly(CHANGED_PAYLOAD);
 	}
 
@@ -148,7 +148,7 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.send(RECEIVES_CHANGED_MESSAGE_ON_ERROR_QUEUE_NAME, SHOULD_CHANGE_PAYLOAD);
 		logger.debug("Sent message to queue {} with messageBody {}", RECEIVES_CHANGED_MESSAGE_ON_ERROR_QUEUE_NAME,
 				SHOULD_CHANGE_PAYLOAD);
-		assertThat(latchContainer.receivesChangedMessageOnErrorLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.receivesChangedMessageOnErrorLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	static class ReceivesChangedPayloadListener {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
@@ -104,7 +104,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 		MyPojo messageBody = new MyPojo("pojoParameterType", "secondValue");
 		sqsTemplate.send(RESOLVES_POJO_TYPES_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_TYPES_QUEUE_NAME, messageBody);
-		assertThat(latchContainer.resolvesPojoLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.resolvesPojoLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -112,7 +112,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 		MyPojo messageBody = new MyPojo("resolvesPojoMessage", "secondValue");
 		sqsTemplate.send(RESOLVES_POJO_MESSAGE_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_MESSAGE_QUEUE_NAME, messageBody);
-		assertThat(latchContainer.resolvesPojoMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.resolvesPojoMessageLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -120,7 +120,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 		MyPojo payload = new MyPojo("resolvesPojoList", "secondValue");
 		sqsTemplate.send(RESOLVES_POJO_LIST_QUEUE_NAME, payload);
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_LIST_QUEUE_NAME, payload);
-		assertThat(latchContainer.resolvesPojoListLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.resolvesPojoListLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -129,7 +129,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.send(RESOLVES_POJO_MESSAGE_LIST_QUEUE_NAME, messageBody);
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_MESSAGE_LIST_QUEUE_NAME,
 				messageBody);
-		assertThat(latchContainer.resolvesPojoMessageListLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.resolvesPojoMessageListLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -138,7 +138,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.send(RESOLVES_POJO_FROM_HEADER_QUEUE_NAME,
 				MessageBuilder.createMessage(payload, new MessagingMessageHeaders(getHeaderMapping(MyPojo.class))));
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_FROM_HEADER_QUEUE_NAME, payload);
-		assertThat(latchContainer.resolvesPojoFromMappingLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.resolvesPojoFromMappingLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -148,7 +148,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 				new MessagingMessageHeaders(getHeaderMapping(MyOtherPojo.class))));
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_MY_OTHER_POJO_FROM_HEADER_QUEUE_NAME,
 				payload);
-		assertThat(latchContainer.resolvesMyOtherPojoFromMappingLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.resolvesMyOtherPojoFromMappingLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -159,7 +159,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.send(RESOLVES_POJO_FROM_NOTIFICATION_MESSAGE_QUEUE_NAME, payload);
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_FROM_NOTIFICATION_MESSAGE_QUEUE_NAME,
 				payload);
-		assertThat(latchContainer.resolvesPojoNotificationMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.resolvesPojoNotificationMessageLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -172,7 +172,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.sendMany(RESOLVES_POJO_FROM_NOTIFICATION_MESSAGE_LIST_QUEUE_NAME, messages);
 		logger.debug("Sent message to queue {} with messageBody {}",
 				RESOLVES_POJO_FROM_NOTIFICATION_MESSAGE_LIST_QUEUE_NAME, payload);
-		assertThat(latchContainer.resolvesPojoNotificationMessageListLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.resolvesPojoNotificationMessageListLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -183,7 +183,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.send(RESOLVES_SUBJECT_FROM_NOTIFICATION_MESSAGE_QUEUE_NAME, payload);
 		logger.debug("Sent message to queue {} with messageBody {}",
 				RESOLVES_SUBJECT_FROM_NOTIFICATION_MESSAGE_QUEUE_NAME, payload);
-		assertThat(latchContainer.resolvesSubjectNotificationMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.resolvesSubjectNotificationMessageLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	private Map<String, Object> getHeaderMapping(Class<?> clazz) {
@@ -201,7 +201,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.send(to -> to.queue(RESOLVES_POJO_TYPES_QUEUE_NAME).payload(messageBody)
 				.header(MessageHeaders.CONTENT_TYPE, "application/json"));
 		logger.debug("Sent message to queue {} with messageBody {}", RESOLVES_POJO_TYPES_QUEUE_NAME, messageBody);
-		assertThat(latchContainer.resolvesPojoLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.resolvesPojoLatch.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	static class ResolvesPojoListener {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsObservationIntegrationTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsObservationIntegrationTest.java
@@ -119,9 +119,9 @@ class SqsObservationIntegrationTests extends BaseSqsIntegrationTest {
 	@DisplayName("Should correctly instrument and propagate observations across multiple components")
 	void shouldInstrumentObservationsAcrossThreads() throws Exception {
 		sqsTemplate.send(SYNC_CONTEXT_PROPAGATION_QUEUE_NAME, SHOULD_CHANGE_PAYLOAD);
-		assertThat(latchContainer.receivesChangedMessageOnErrorLatch.await(20, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.receivesChangedMessageOnErrorLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(receivesChangedPayloadOnErrorListener.receivedMessages).containsExactly(CHANGED_PAYLOAD);
-		assertThat(latchContainer.receivesChangedMessageLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.receivesChangedMessageLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> TestObservationRegistryAssert.then(observationRegistry)
 				.hasHandledContextsThatSatisfy(contexts -> {
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsObservationIntegrationTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsObservationIntegrationTest.java
@@ -165,7 +165,7 @@ class SqsObservationIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.send(ASYNC_CONTEXT_PROPAGATION_QUEUE_NAME, payload);
 
 		// Then
-		assertThat(latchContainer.asyncContextPropagationLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.asyncContextPropagationLatch.await(60, TimeUnit.SECONDS)).isTrue();
 
 		await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> TestObservationRegistryAssert.then(observationRegistry)
 				.hasHandledContextsThatSatisfy(contexts -> {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsPayloadTypeInferenceIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsPayloadTypeInferenceIntegrationTests.java
@@ -135,11 +135,11 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.send(INFERS_SIMPLE_POJO_QUEUE, event);
 		logger.debug("Sent event to queue {}: {}", INFERS_SIMPLE_POJO_QUEUE, event);
 
-		assertThat(latchContainer.infersSimplePojoLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.infersSimplePojoLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(pojoCollector.receivedSimplePojos).hasSize(1);
 		assertThat(pojoCollector.receivedSimplePojos.get(0)).isEqualTo(event);
 		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_SIMPLE_POJO_QUEUE, event);
-		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_SIMPLE_POJO_QUEUE, event);
 	}
 
@@ -152,11 +152,11 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.send(INFERS_POJO_WITH_MANY_PARAMETERS_QUEUE, event);
 		logger.debug("Sent event to queue {}: {}", INFERS_POJO_WITH_MANY_PARAMETERS_QUEUE, event);
 
-		assertThat(latchContainer.infersPojoWithManyParametersLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.infersPojoWithManyParametersLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(pojoCollector.receivedPojoWithManyParams).hasSize(1);
 		assertThat(pojoCollector.receivedPojoWithManyParams.get(0)).isEqualTo(event);
 		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_POJO_WITH_MANY_PARAMETERS_QUEUE, event);
-		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_POJO_WITH_MANY_PARAMETERS_QUEUE, event);
 	}
 
@@ -172,11 +172,11 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 				events.stream().map(e -> MessageBuilder.withPayload(e).build()).toList());
 		logger.debug("Sent {} events to queue {}", events.size(), INFERS_BATCH_POJO_QUEUE);
 
-		assertThat(latchContainer.infersBatchPojoLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.infersBatchPojoLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(pojoCollector.receivedBatchPojos).containsExactlyInAnyOrderElementsOf(events);
 		// Interceptor runs before the listener, so payloads are already recorded by now
 		interceptorPayloadTypeCollector.assertPayloadsForQueueContainsAll(INFERS_BATCH_POJO_QUEUE, events);
-		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContainsAll(INFERS_BATCH_POJO_QUEUE, events);
 	}
 
@@ -189,11 +189,11 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.send(INFERS_NESTED_GENERIC_POJO_QUEUE, event);
 		logger.debug("Sent nested generic event to queue {}: {}", INFERS_NESTED_GENERIC_POJO_QUEUE, event);
 
-		assertThat(latchContainer.infersNestedGenericLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.infersNestedGenericLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(pojoCollector.receivedNestedGeneric).hasSize(1);
 		assertThat(pojoCollector.receivedNestedGeneric.get(0)).isEqualTo(event);
 		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_NESTED_GENERIC_POJO_QUEUE, event);
-		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(INFERS_NESTED_GENERIC_POJO_QUEUE, event);
 	}
 
@@ -206,11 +206,11 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.send(ASYNC_LISTENER_QUEUE, event);
 		logger.debug("Sent event to async listener queue {}: {}", ASYNC_LISTENER_QUEUE, event);
 
-		assertThat(latchContainer.asyncListenerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.asyncListenerLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(pojoCollector.receivedAsyncPojos).hasSize(1);
 		assertThat(pojoCollector.receivedAsyncPojos.get(0)).isEqualTo(event);
 		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(ASYNC_LISTENER_QUEUE, event);
-		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(ASYNC_LISTENER_QUEUE, event);
 	}
 
@@ -226,11 +226,11 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 				events.stream().map(e -> MessageBuilder.withPayload(e).build()).toList());
 		logger.debug("Sent {} events to queue {}", events.size(), BATCH_MESSAGE_WRAPPER_QUEUE);
 
-		assertThat(latchContainer.batchMessageWrapperLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.batchMessageWrapperLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(pojoCollector.receivedBatchMessageWrapperPojos).containsExactlyInAnyOrderElementsOf(events);
 		// Interceptor runs before the listener, so payloads are already recorded by now
 		interceptorPayloadTypeCollector.assertPayloadsForQueueContainsAll(BATCH_MESSAGE_WRAPPER_QUEUE, events);
-		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContainsAll(BATCH_MESSAGE_WRAPPER_QUEUE, events);
 	}
 
@@ -245,11 +245,11 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 				.header(SqsHeaders.SQS_DEFAULT_TYPE_HEADER, "com.example.NonExistentClass"));
 		logger.debug("Sent event with wrong type header to queue {}: {}", IGNORES_TYPE_HEADER_QUEUE, event);
 
-		assertThat(latchContainer.ignoresTypeHeaderLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.ignoresTypeHeaderLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(pojoCollector.receivedIgnoresTypeHeaderPojos).hasSize(1);
 		assertThat(pojoCollector.receivedIgnoresTypeHeaderPojos.get(0)).isEqualTo(event);
 		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(IGNORES_TYPE_HEADER_QUEUE, event);
-		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(IGNORES_TYPE_HEADER_QUEUE, event);
 	}
 
@@ -263,11 +263,11 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 		logger.debug("Sent event to explicit payload annotation queue {}: {}", EXPLICIT_PAYLOAD_ANNOTATION_QUEUE,
 				event);
 
-		assertThat(latchContainer.explicitPayloadAnnotationLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.explicitPayloadAnnotationLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(pojoCollector.receivedExplicitPayloadPojos).hasSize(1);
 		assertThat(pojoCollector.receivedExplicitPayloadPojos.get(0)).isEqualTo(event);
 		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(EXPLICIT_PAYLOAD_ANNOTATION_QUEUE, event);
-		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(EXPLICIT_PAYLOAD_ANNOTATION_QUEUE, event);
 	}
 
@@ -281,11 +281,11 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.send(to -> to.queue(STRING_PAYLOAD_QUEUE).payload(rawJson));
 		logger.debug("Sent raw JSON string to queue {}: {}", STRING_PAYLOAD_QUEUE, rawJson);
 
-		assertThat(latchContainer.stringPayloadLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.stringPayloadLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(pojoCollector.receivedStringPayloads).hasSize(1);
 		assertThat(pojoCollector.receivedStringPayloads.get(0)).isEqualTo(rawJson);
 		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(STRING_PAYLOAD_QUEUE, rawJson);
-		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(STRING_PAYLOAD_QUEUE, rawJson);
 	}
 
@@ -299,14 +299,14 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 		sqsTemplate.send(to -> to.queue(CUSTOM_CONVERTER_QUEUE).payload(snakeCaseJson));
 		logger.debug("Sent snake_case JSON to custom converter queue {}: {}", CUSTOM_CONVERTER_QUEUE, snakeCaseJson);
 
-		assertThat(latchContainer.customConverterLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.customConverterLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(pojoCollector.receivedCustomConverterPojos).hasSize(1);
 		SnakeCaseEvent received = pojoCollector.receivedCustomConverterPojos.get(0);
 		SnakeCaseEvent expectedEvent = new SnakeCaseEvent("custom-converter-id", "custom-converter-data");
 		assertThat(received.getEventId()).isEqualTo("custom-converter-id");
 		assertThat(received.getEventPayload()).isEqualTo("custom-converter-data");
 		interceptorPayloadTypeCollector.assertPayloadsForQueueContains(CUSTOM_CONVERTER_QUEUE, expectedEvent);
-		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		ackCallbackPayloadTypeCollector.assertPayloadsForQueueContains(CUSTOM_CONVERTER_QUEUE, expectedEvent);
 	}
 
@@ -321,7 +321,7 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 		logger.debug("Sent event to error handler test queue {}: {}", ERROR_HANDLER_TEST_QUEUE, event);
 
 		// Wait for the error handler to process the message
-		assertThat(errorHandlerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(errorHandlerLatch.await(60, TimeUnit.SECONDS)).isTrue();
 
 		// Verify the error handler received the deserialized payload with correct field values
 		errorHandlerPayloadTypeCollector.assertPayloadsForQueueContains(ERROR_HANDLER_TEST_QUEUE, event);

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
@@ -112,7 +112,7 @@ class BatchingAcknowledgementProcessorTests {
 		processor.setId(ID);
 		processor.start();
 		processor.doOnAcknowledge(messages);
-		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		processor.stop();
 
 		then(ackExecutor).should().execute(messages);
@@ -211,7 +211,7 @@ class BatchingAcknowledgementProcessorTests {
 		processor.start();
 
 		processor.doOnAcknowledge(thresholdBatch);
-		assertThat(thresholdFlushLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(thresholdFlushLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		processor.doOnAcknowledge(remainder);
 		processor.stop();
 
@@ -255,7 +255,7 @@ class BatchingAcknowledgementProcessorTests {
 		processor.setMessageGroupingFunction(messageToGroup -> {
 			pollingThreadInsideBufferAdd.countDown();
 			try {
-				releasePollingThread.await(10, TimeUnit.SECONDS);
+				releasePollingThread.await(60, TimeUnit.SECONDS);
 			}
 			catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
@@ -272,7 +272,7 @@ class BatchingAcknowledgementProcessorTests {
 		processor.start();
 
 		processor.doOnAcknowledge(message);
-		assertThat(pollingThreadInsideBufferAdd.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(pollingThreadInsideBufferAdd.await(60, TimeUnit.SECONDS)).isTrue();
 
 		CompletableFuture<Void> stopping = CompletableFuture.runAsync(processor::stop);
 		// Give the shutdown wait loop, which polls every 200ms, several chances to observe the in-flight message
@@ -353,7 +353,7 @@ class BatchingAcknowledgementProcessorTests {
 		processor.setId(ID);
 		processor.start();
 		processor.doOnAcknowledge(messages);
-		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		processor.stop();
 		then(ackExecutor).should().execute(messages.subList(0, 10));
 		then(ackExecutor).should().execute(messages.subList(10, 15));
@@ -385,7 +385,7 @@ class BatchingAcknowledgementProcessorTests {
 
 		processor.start();
 		processor.doOnAcknowledge(messages);
-		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		processor.stop();
 
 		IntStream.range(0, Math.min(messages.size() / maxMessagesPerBatch, 1))
@@ -494,7 +494,7 @@ class BatchingAcknowledgementProcessorTests {
 
 		processor.start();
 		processor.doOnAcknowledge(batches.stream().flatMap(Collection::stream).collect(Collectors.toList()));
-		assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		processor.stop();
 
 		ArgumentCaptor<Collection<Message<String>>> messagesCaptor = ArgumentCaptor.forClass(Collection.class);

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
@@ -450,7 +450,7 @@ class BatchingAcknowledgementProcessorTests {
 		messages.forEach(
 				(group, theMessages) -> CompletableFuture.runAsync(() -> processor.doOnAcknowledge(theMessages)));
 		logger.info("Sent all messages for acknowledgement");
-		assertThat(ackLatch.await(1000, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackLatch.await(30, TimeUnit.SECONDS)).isTrue();
 		processor.stop();
 		messages.forEach((group, messagesFromGroup) -> assertThat(acknowledgedMessages.get(group))
 				.containsExactlyElementsOf(messagesFromGroup.stream().map(Message::getPayload).collect(toList())));

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/ImmediateAcknowledgementProcessorTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/ImmediateAcknowledgementProcessorTests.java
@@ -65,7 +65,7 @@ class ImmediateAcknowledgementProcessorTests {
 				SqsContainerOptions.builder().acknowledgementOrdering(AcknowledgementOrdering.PARALLEL).build());
 		processor.start();
 		processor.doOnAcknowledge(message);
-		assertThat(countDownLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(countDownLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		processor.stop();
 	}
 
@@ -128,7 +128,7 @@ class ImmediateAcknowledgementProcessorTests {
 				SqsContainerOptions.builder().acknowledgementOrdering(AcknowledgementOrdering.PARALLEL).build());
 		processor.start();
 		processor.doOnAcknowledge(message);
-		assertThat(countDownLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(countDownLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		processor.stop();
 	}
 
@@ -158,7 +158,7 @@ class ImmediateAcknowledgementProcessorTests {
 				SqsContainerOptions.builder().acknowledgementOrdering(AcknowledgementOrdering.PARALLEL).build());
 		processor.start();
 		processor.doOnAcknowledge(message);
-		assertThat(countDownLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(countDownLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		processor.stop();
 	}
 
@@ -188,7 +188,7 @@ class ImmediateAcknowledgementProcessorTests {
 				SqsContainerOptions.builder().acknowledgementOrdering(AcknowledgementOrdering.PARALLEL).build());
 		processor.start();
 		CompletableFuture<Void> resultFuture = processor.doOnAcknowledge(message);
-		assertThat(countDownLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(countDownLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		processor.stop();
 		assertThatThrownBy(resultFuture::join).isInstanceOf(CompletionException.class).extracting(Throwable::getCause)
 				.isInstanceOf(AcknowledgementResultCallbackException.class).extracting(Throwable::getCause)

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSourceTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/source/AbstractPollingMessageSourceTests.java
@@ -18,6 +18,7 @@ package io.awspring.cloud.sqs.listener.source;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -30,6 +31,7 @@ import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementCallback;
 import io.awspring.cloud.sqs.listener.acknowledgement.AcknowledgementProcessor;
 import io.awspring.cloud.sqs.listener.backpressure.BackPressureHandler;
 import io.awspring.cloud.sqs.listener.backpressure.BackPressureHandlerFactories;
+import io.awspring.cloud.sqs.listener.backpressure.BatchAwareBackPressureHandler;
 import io.awspring.cloud.sqs.listener.backpressure.CompositeBackPressureHandler;
 import io.awspring.cloud.sqs.listener.backpressure.ConcurrencyLimiterBlockingBackPressureHandler;
 import io.awspring.cloud.sqs.listener.backpressure.ThroughputBackPressureHandler;
@@ -144,13 +146,46 @@ class AbstractPollingMessageSourceTests {
 		SqsContainerOptions options = SqsContainerOptions.builder().maxMessagesPerPoll(10).maxConcurrentMessages(10)
 				.backPressureMode(BackPressureMode.ALWAYS_POLL_MAX_MESSAGES)
 				.maxDelayBetweenPolls(Duration.ofMillis(150)).listenerShutdownTimeout(Duration.ZERO).build();
-		BackPressureHandler backPressureHandler = BackPressureHandlerFactories.adaptiveThroughputBackPressureHandler()
-				.createBackPressureHandler(options);
+		BatchAwareBackPressureHandler delegate = (BatchAwareBackPressureHandler) BackPressureHandlerFactories
+				.adaptiveThroughputBackPressureHandler().createBackPressureHandler(options);
+
+		// The throughput mode is only briefly high: the first poll raises it and the next empty poll lowers it
+		// again. Record it right after each release, on the thread that performed it, rather than sampling for it.
+		Collection<String> modeAfterRelease = new ConcurrentLinkedQueue<>();
+		BatchAwareBackPressureHandler backPressureHandler = new BatchAwareBackPressureHandler() {
+
+			@Override
+			public int request(int amount) throws InterruptedException {
+				return delegate.request(amount);
+			}
+
+			@Override
+			public int requestBatch() throws InterruptedException {
+				return delegate.requestBatch();
+			}
+
+			@Override
+			public int getBatchSize() {
+				return delegate.getBatchSize();
+			}
+
+			@Override
+			public void release(int amount, ReleaseReason reason) {
+				delegate.release(amount, reason);
+				modeAfterRelease.add(reason + ":" + currentThroughputMode(delegate));
+			}
+
+			@Override
+			public boolean drain(Duration timeout) {
+				return delegate.drain(timeout);
+			}
+		};
 
 		ExecutorService threadPool = Executors.newCachedThreadPool();
-		CountDownLatch pollingCounter = new CountDownLatch(3);
 		CountDownLatch processingCounter = new CountDownLatch(1);
+		CountDownLatch emptyPollCounter = new CountDownLatch(2);
 		Collection<Throwable> errors = new ConcurrentLinkedQueue<>();
+		Collection<Integer> requestedAmounts = new ConcurrentLinkedQueue<>();
 
 		AbstractPollingMessageSource<Object, Message> source = new AbstractPollingMessageSource<>() {
 
@@ -160,44 +195,21 @@ class AbstractPollingMessageSourceTests {
 			protected CompletableFuture<Collection<Message>> doPollForMessages(int messagesToRequest) {
 				return CompletableFuture.supplyAsync(() -> {
 					try {
-						int pollAttempt = pollAttemptCounter.incrementAndGet();
-						logger.warn("Poll attempt {}", pollAttempt);
-						if (pollAttempt == 1) {
-							// Initial poll; throughput mode should be low
-							assertThroughputMode(backPressureHandler, "low");
-							// Since no permits were acquired yet, should be 10
-							assertThat(messagesToRequest).isEqualTo(10);
+						requestedAmounts.add(messagesToRequest);
+						// Fewer messages than requested on the first poll, none afterwards
+						if (pollAttemptCounter.incrementAndGet() == 1) {
 							return (Collection<Message>) List.of(
 									Message.builder().messageId(UUID.randomUUID().toString()).body("message").build());
 						}
-						else if (pollAttempt == 2) {
-							// Messages returned in the previous poll; throughput mode should be high
-							assertThroughputMode(backPressureHandler, "high");
-							// Since throughput mode is high, should be 10
-							assertThat(messagesToRequest).isEqualTo(10);
-							return Collections.<Message> emptyList();
-						}
-						else {
-							// No Messages returned in the previous poll; throughput mode should be low
-							assertThroughputMode(backPressureHandler, "low");
-							return Collections.<Message> emptyList();
-						}
+						emptyPollCounter.countDown();
+						return Collections.<Message> emptyList();
 					}
 					catch (Throwable t) {
 						logger.error("Error (not expecting it)", t);
 						errors.add(t);
 						throw new RuntimeException(t);
 					}
-				}, threadPool).whenComplete((v, t) -> {
-					if (t == null) {
-						logger.warn("Polling succeeded", t);
-						pollingCounter.countDown();
-					}
-					else {
-						logger.warn("Polling failed with error", t);
-						errors.add(t);
-					}
-				});
+				}, threadPool);
 			}
 		};
 
@@ -212,15 +224,30 @@ class AbstractPollingMessageSourceTests {
 		source.setTaskExecutor(createTaskExecutor(testName));
 		source.setAcknowledgementProcessor(getNoOpsAcknowledgementProcessor());
 		try {
+			assertThroughputMode(delegate, "low");
 			source.start();
-			assertThat(doAwait(pollingCounter)).isTrue();
+
 			assertThat(doAwait(processingCounter)).isTrue();
+			assertThat(doAwait(emptyPollCounter)).isTrue();
+			await().atMost(Duration.ofSeconds(10))
+					.untilAsserted(() -> assertThat(modeAfterRelease).contains("NONE_FETCHED:low"));
+
+			// A poll returning fewer messages than requested raises the throughput mode, and one returning
+			// none lowers it again
+			assertThat(modeAfterRelease).contains("PARTIAL_FETCH:high", "NONE_FETCHED:low");
+			// Every poll asks for the full batch, in either throughput mode
+			assertThat(requestedAmounts).isNotEmpty().allMatch(amount -> amount == 10);
 			assertThat(errors).isEmpty();
 		}
 		finally {
 			source.stop();
 			threadPool.shutdownNow();
 		}
+	}
+
+	private String currentThroughputMode(BackPressureHandler backPressureHandler) {
+		var bph = extractBackPressureHandler(backPressureHandler, ThroughputBackPressureHandler.class);
+		return getThroughputModeValue(bph, "currentThroughputMode");
 	}
 
 	private static final AtomicInteger testCounter = new AtomicInteger();


### PR DESCRIPTION

The SQS test suite runs its classes and methods concurrently against a single
Localstack container, so on a busy CI runner the work takes longer than it does
on an idle machine. Several tests give that work a fixed budget that only holds
in the fast case, and they may fail while the code under test is correct. This
fixes the ones that were observed failing and the pattern behind them.

- Test code only. No production change, and no test is removed or weakened: every
assertion still checks the same condition.

- Most of the suite waits on a latch with a fixed budget, and a latch returns as
soon as it is counted down, so a green run takes exactly as long whether the
budget is ten seconds or sixty. The budget is only a ceiling on how long we are
willing to wait before calling it a failure, and ten seconds is below what a
loaded runner needs.

- Presence assertions move to sixty seconds. The two assertions that check an
event does *not* occur keep their short timeouts, since those are spent in full
on every green run.

- One latch waited ten minutes and another a thousand seconds. Neither costs time
while the test passes, but on failure they burn the job's budget rather than
reporting it, and the work they wait on completes in seconds. Both are now
thirty seconds.

### Result

Three consecutive runs green across all three JDKs.
