### PR TITLE
Speed up the SQS test suite

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
@@ -80,9 +80,9 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 	private BlockingQueue<Message<T>> acks;
 
 	/**
-	 * Number of messages that have been received for acknowledgement but are not in {@link #acks} nor in the buffer
-	 * yet. Incremented before a message is offered to the queue and decremented after it has been added to the buffer,
-	 * so a message is always accounted for while the polling thread is holding it in between the two.
+	 * Number of messages that have been received for acknowledgement but are not in {@link #acks} nor in the buffer yet.
+	 * Incremented before a message is offered to the queue and decremented after it has been added to the buffer, so a
+	 * message is always accounted for while the polling thread is holding it in between the two.
 	 */
 	private final AtomicInteger unbufferedAcks = new AtomicInteger();
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
@@ -80,9 +80,9 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 	private BlockingQueue<Message<T>> acks;
 
 	/**
-	 * Number of messages that have been received for acknowledgement but are not in {@link #acks} nor in the buffer yet.
-	 * Incremented before a message is offered to the queue and decremented after it has been added to the buffer, so a
-	 * message is always accounted for while the polling thread is holding it in between the two.
+	 * Number of messages that have been received for acknowledgement but are not in {@link #acks} nor in the buffer
+	 * yet. Incremented before a message is offered to the queue and decremented after it has been added to the buffer,
+	 * so a message is always accounted for while the polling thread is holding it in between the two.
 	 */
 	private final AtomicInteger unbufferedAcks = new AtomicInteger();
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/BaseSqsIntegrationTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/BaseSqsIntegrationTest.java
@@ -21,6 +21,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,13 +58,37 @@ abstract class BaseSqsIntegrationTest {
 
 	static StaticCredentialsProvider credentialsProvider;
 
-	@BeforeAll
-	static synchronized void beforeAll() {
-		if (!localstack.isRunning()) {
-			localstack.start();
-			credentialsProvider = StaticCredentialsProvider
-					.create(AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey()));
+	private static final CompletableFuture<Void> STARTED = new CompletableFuture<>();
+
+	private static final AtomicBoolean STARTING = new AtomicBoolean();
+
+	/**
+	 * Starts the container off the JUnit worker threads. The workers block in {@link #beforeAll()} until it is up, and
+	 * a blocking wait does not make the pool compensate with another thread, so starting it from a test would hold as
+	 * many workers as there are integration classes scheduled and leave the rest of the suite idle.
+	 */
+	static void startAsync() {
+		if (!STARTING.compareAndSet(false, true)) {
+			return;
 		}
+		Thread starter = new Thread(() -> {
+			try {
+				localstack.start();
+				credentialsProvider = StaticCredentialsProvider
+						.create(AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey()));
+				STARTED.complete(null);
+			}
+			catch (Throwable t) {
+				STARTED.completeExceptionally(t);
+			}
+		}, "localstack-starter");
+		starter.setDaemon(true);
+		starter.start();
+	}
+
+	@BeforeAll
+	static void beforeAll() {
+		STARTED.join();
 	}
 
 	@DynamicPropertySource
@@ -84,7 +112,30 @@ abstract class BaseSqsIntegrationTest {
 		return createQueue(client, queueName, attributes);
 	}
 
+	// A test class creates its queues in parallel, but only one class does so at a time. Localstack serves
+	// creations from every class at a similar rate, so when all classes create at once each one's last queue lands
+	// near the end of the whole batch and no class can start its tests before then. Giving a class exclusive access
+	// lets it be ready in the time its own queues take, and start running while the next class creates its own.
+	private static final Semaphore CREATION_SLOT = new Semaphore(1);
+
+	private static final Map<Thread, AtomicInteger> PENDING_CREATIONS = new ConcurrentHashMap<>();
+
 	protected static CompletableFuture<?> createQueue(SqsAsyncClient client, String queueName,
+			Map<QueueAttributeName, String> attributes) {
+		Thread owner = Thread.currentThread();
+		AtomicInteger pending = PENDING_CREATIONS.computeIfAbsent(owner, thread -> new AtomicInteger());
+		if (pending.getAndIncrement() == 0) {
+			CREATION_SLOT.acquireUninterruptibly();
+		}
+		return doCreateQueue(client, queueName, attributes).whenComplete((v, t) -> {
+			if (pending.decrementAndGet() == 0) {
+				PENDING_CREATIONS.remove(owner);
+				CREATION_SLOT.release();
+			}
+		});
+	}
+
+	private static CompletableFuture<?> doCreateQueue(SqsAsyncClient client, String queueName,
 			Map<QueueAttributeName, String> attributes) {
 		logger.debug("Creating queue {} with attributes {}", queueName, attributes);
 		return client.createQueue(req -> getCreateQueueRequest(queueName, attributes, req)).handle((v, t) -> {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/LocalStackAwareClassOrderer.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/LocalStackAwareClassOrderer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.integration;
+
+import java.util.Comparator;
+import org.junit.jupiter.api.ClassDescriptor;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.ClassOrdererContext;
+
+/**
+ * Starts Localstack and schedules the classes that do not need it first, so they run while it comes up instead of
+ * queueing behind the classes that wait for it. Ordering runs during discovery, before any test, which is also the
+ * earliest point at which the container can be asked for.
+ */
+public class LocalStackAwareClassOrderer implements ClassOrderer {
+
+	@Override
+	public void orderClasses(ClassOrdererContext context) {
+		if (context.getClassDescriptors().stream().anyMatch(descriptor -> needsContainer(descriptor) == 1)) {
+			BaseSqsIntegrationTest.startAsync();
+		}
+		context.getClassDescriptors().sort(Comparator.comparingInt(LocalStackAwareClassOrderer::needsContainer));
+	}
+
+	private static int needsContainer(ClassDescriptor descriptor) {
+		return BaseSqsIntegrationTest.class.isAssignableFrom(descriptor.getTestClass()) ? 1 : 0;
+	}
+
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SnsNotificationIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SnsNotificationIntegrationTests.java
@@ -327,7 +327,8 @@ class SnsNotificationIntegrationTests extends BaseSqsIntegrationTest {
 			return SqsMessageListenerContainerFactory.builder()
 					.sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
 					.acknowledgementResultCallback(getAcknowledgementResultCallback())
-					.configure(options -> options.maxDelayBetweenPolls(Duration.ofSeconds(5))
+					.configure(options -> options.listenerShutdownTimeout(Duration.ZERO)
+							.acknowledgementShutdownTimeout(Duration.ZERO).maxDelayBetweenPolls(Duration.ofSeconds(5))
 							.queueAttributeNames(Collections.singletonList(QueueAttributeName.QUEUE_ARN))
 							.pollTimeout(Duration.ofSeconds(5)))
 					.build();

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsAnnotationAcknowledgementIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsAnnotationAcknowledgementIntegrationTests.java
@@ -280,7 +280,8 @@ public class SqsAnnotationAcknowledgementIntegrationTests extends BaseSqsIntegra
 			return SqsMessageListenerContainerFactory.builder()
 					.sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
 					.acknowledgementResultCallback(getAcknowledgementResultCallback())
-					.configure(options -> options.maxDelayBetweenPolls(Duration.ofSeconds(5))
+					.configure(options -> options.listenerShutdownTimeout(Duration.ZERO)
+							.acknowledgementShutdownTimeout(Duration.ZERO).maxDelayBetweenPolls(Duration.ofSeconds(5))
 							.queueAttributeNames(Collections.singletonList(QueueAttributeName.QUEUE_ARN))
 							.pollTimeout(Duration.ofSeconds(5)))
 					.build();
@@ -289,8 +290,10 @@ public class SqsAnnotationAcknowledgementIntegrationTests extends BaseSqsIntegra
 		@Bean(name = ACK_AFTER_SECOND_ERROR_FACTORY)
 		public SqsMessageListenerContainerFactory<Object> ackAfterSecondErrorFactory() {
 			return SqsMessageListenerContainerFactory.builder()
-					.configure(options -> options.maxConcurrentMessages(10).pollTimeout(Duration.ofSeconds(10))
-							.maxMessagesPerPoll(10).maxDelayBetweenPolls(Duration.ofSeconds(1)))
+					.configure(options -> options.listenerShutdownTimeout(Duration.ZERO)
+							.acknowledgementShutdownTimeout(Duration.ZERO).maxConcurrentMessages(10)
+							.pollTimeout(Duration.ofSeconds(10)).maxMessagesPerPoll(10)
+							.maxDelayBetweenPolls(Duration.ofSeconds(1)))
 					.containerComponentFactories(getExceptionThrowingAckExecutor())
 					.acknowledgementResultCallback(getAcknowledgementResultCallback()).errorHandler(testErrorHandler())
 					.sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient).build();

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsErrorHandlerIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsErrorHandlerIntegrationTests.java
@@ -595,7 +595,7 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		public SqsMessageListenerContainerFactory<Object> errorHandlerVisibility() {
 			return SqsMessageListenerContainerFactory
 				.builder()
-				.configure(options -> options
+				.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 					.maxConcurrentMessages(10)
 					.pollTimeout(Duration.ofSeconds(10))
 					.maxMessagesPerPoll(10)
@@ -612,7 +612,7 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		public SqsMessageListenerContainerFactory<Object> exponentialBackOffErrorHandler() {
 			return SqsMessageListenerContainerFactory
 				.builder()
-				.configure(options -> options
+				.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 					.maxConcurrentMessages(10)
 					.pollTimeout(Duration.ofSeconds(15))
 					.maxMessagesPerPoll(10)
@@ -632,7 +632,7 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		public SqsMessageListenerContainerFactory<Object> exponentialBackOffFullJitterErrorHandler() {
 			return SqsMessageListenerContainerFactory
 				.builder()
-				.configure(options -> options
+				.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 					.maxConcurrentMessages(10)
 					.pollTimeout(Duration.ofSeconds(15))
 					.maxMessagesPerPoll(10)
@@ -654,7 +654,7 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		public SqsMessageListenerContainerFactory<Object> exponentialBackOffHalfJitterErrorHandler() {
 			return SqsMessageListenerContainerFactory
 				.builder()
-				.configure(options -> options
+				.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 					.maxConcurrentMessages(10)
 					.pollTimeout(Duration.ofSeconds(15))
 					.maxMessagesPerPoll(10)
@@ -676,7 +676,7 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		public SqsMessageListenerContainerFactory<Object> linearBackOffErrorHandler() {
 			return SqsMessageListenerContainerFactory
 				.builder()
-				.configure(options -> options
+				.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 					.maxConcurrentMessages(10)
 					.pollTimeout(Duration.ofSeconds(15))
 					.maxMessagesPerPoll(10)

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsErrorHandlerIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsErrorHandlerIntegrationTests.java
@@ -126,7 +126,7 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		logger.debug("Sent message to queue {} with messageBody {}", SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_QUEUE_NAME,
 				messageBody);
 
-		assertThat(latchContainer.receivesRetryMessageQuicklyLatch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.receivesRetryMessageQuicklyLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -137,7 +137,7 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		logger.debug("Sent message to queue {} with messageBody {}",
 				SUCCESS_VISIBILITY_TIMEOUT_TO_ZERO_BATCH_QUEUE_NAME, messages);
 
-		assertThat(latchContainer.receivesRetryBatchMessageQuicklyLatch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(latchContainer.receivesRetryBatchMessageQuicklyLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -330,7 +330,7 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		@Autowired
 		LatchContainer latchContainer;
 		static Double multiplier = 2.0;
-		static Integer initialValueSeconds = 2;
+		static Integer initialValueSeconds = 1;
 		long firstReceiveTimestamp;
 
 		@SqsListener(queueNames = SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_QUEUE, factory = SUCCESS_EXPONENTIAL_FULL_JITTER_BACKOFF_ERROR_HANDLER_FACTORY, id = "visibilityExponentialFullJitterErrorHandler")
@@ -389,8 +389,8 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 	static class LinearBackOffErrorHandlerListener {
 		@Autowired
 		LatchContainer latchContainer;
-		static int increment = 2;
-		static int initialValueSeconds = 2;
+		static int increment = 1;
+		static int initialValueSeconds = 1;
 		long firstReceiveTimestamp;
 
 		@SqsListener(queueNames = SUCCESS_LINEAR_BACKOFF_ERROR_HANDLER_QUEUE, factory = SUCCESS_LINEAR_BACKOFF_ERROR_HANDLER_FACTORY, id = "visibilityLinearErrorHandler")
@@ -595,7 +595,7 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		public SqsMessageListenerContainerFactory<Object> errorHandlerVisibility() {
 			return SqsMessageListenerContainerFactory
 				.builder()
-				.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
+				.configure(options -> options
 					.maxConcurrentMessages(10)
 					.pollTimeout(Duration.ofSeconds(10))
 					.maxMessagesPerPoll(10)
@@ -612,7 +612,7 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		public SqsMessageListenerContainerFactory<Object> exponentialBackOffErrorHandler() {
 			return SqsMessageListenerContainerFactory
 				.builder()
-				.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
+				.configure(options -> options
 					.maxConcurrentMessages(10)
 					.pollTimeout(Duration.ofSeconds(15))
 					.maxMessagesPerPoll(10)
@@ -632,7 +632,7 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		public SqsMessageListenerContainerFactory<Object> exponentialBackOffFullJitterErrorHandler() {
 			return SqsMessageListenerContainerFactory
 				.builder()
-				.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
+				.configure(options -> options
 					.maxConcurrentMessages(10)
 					.pollTimeout(Duration.ofSeconds(15))
 					.maxMessagesPerPoll(10)
@@ -654,7 +654,7 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		public SqsMessageListenerContainerFactory<Object> exponentialBackOffHalfJitterErrorHandler() {
 			return SqsMessageListenerContainerFactory
 				.builder()
-				.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
+				.configure(options -> options
 					.maxConcurrentMessages(10)
 					.pollTimeout(Duration.ofSeconds(15))
 					.maxMessagesPerPoll(10)
@@ -676,7 +676,7 @@ public class SqsErrorHandlerIntegrationTests extends BaseSqsIntegrationTest {
 		public SqsMessageListenerContainerFactory<Object> linearBackOffErrorHandler() {
 			return SqsMessageListenerContainerFactory
 				.builder()
-				.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
+				.configure(options -> options
 					.maxConcurrentMessages(10)
 					.pollTimeout(Duration.ofSeconds(15))
 					.maxMessagesPerPoll(10)

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsExtendedClientIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsExtendedClientIntegrationTests.java
@@ -133,8 +133,9 @@ class SqsExtendedClientIntegrationTests extends BaseSqsIntegrationTest {
 		@Bean
 		SqsMessageListenerContainerFactory<String> defaultSqsListenerContainerFactory() {
 			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
-			factory.configure(
-					options -> options.maxDelayBetweenPolls(Duration.ofSeconds(1)).pollTimeout(Duration.ofSeconds(3)));
+			factory.configure(options -> options.listenerShutdownTimeout(Duration.ZERO)
+					.acknowledgementShutdownTimeout(Duration.ZERO).maxDelayBetweenPolls(Duration.ofSeconds(1))
+					.pollTimeout(Duration.ofSeconds(3)));
 			factory.setSqsAsyncClientSupplier(SqsExtendedClientIntegrationTests::createExtendedAsyncClient);
 			return factory;
 		}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsFifoIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsFifoIntegrationTests.java
@@ -768,8 +768,9 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 		public SqsMessageListenerContainerFactory<String> observationSqsListenerContainerFactory(
 				ObservationRegistry observationRegistry) {
 			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
-			factory.configure(options -> options.maxConcurrentMessages(10).acknowledgementThreshold(10)
-					.acknowledgementOrdering(AcknowledgementOrdering.ORDERED_BY_GROUP)
+			factory.configure(options -> options.listenerShutdownTimeout(Duration.ZERO)
+					.acknowledgementShutdownTimeout(Duration.ZERO).maxConcurrentMessages(10)
+					.acknowledgementThreshold(10).acknowledgementOrdering(AcknowledgementOrdering.ORDERED_BY_GROUP)
 					.acknowledgementInterval(Duration.ofSeconds(1)).observationRegistry(observationRegistry));
 			factory.setSqsAsyncClientSupplier(BaseSqsIntegrationTest::createHighThroughputAsyncClient);
 			return factory;
@@ -779,7 +780,7 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 		@Bean
 		public SqsMessageListenerContainerFactory<String> defaultSqsListenerContainerFactory() {
 			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
-			factory.configure(options -> options
+			factory.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 				.maxConcurrentMessages(10)
 				.acknowledgementThreshold(10)
 				.acknowledgementOrdering(AcknowledgementOrdering.ORDERED_BY_GROUP)
@@ -813,7 +814,7 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 		@Bean(ERROR_ON_ACK_FACTORY)
 		public SqsMessageListenerContainerFactory<String> errorOnAckSqsListenerContainerFactory() {
 			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
-			factory.configure(options -> options
+			factory.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 				.maxConcurrentMessages(10)
 				.acknowledgementThreshold(10)
 				.acknowledgementInterval(Duration.ofMillis(200))
@@ -872,7 +873,7 @@ class SqsFifoIntegrationTests extends BaseSqsIntegrationTest {
 			}).when(spyAsyncClient).changeMessageVisibilityBatch(any(ChangeMessageVisibilityBatchRequest.class));
 
 			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
-			factory.configure(options -> options
+			factory.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 				.maxConcurrentMessages(10)
 				.acknowledgementThreshold(10)
 				.acknowledgementOrdering(AcknowledgementOrdering.ORDERED_BY_GROUP)

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsIntegrationTests.java
@@ -762,7 +762,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		public SqsMessageListenerContainerFactory<Object> lowResourceFactory() {
 			return SqsMessageListenerContainerFactory
 				.builder()
-				.configure(options -> options
+				.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 					.maxConcurrentMessages(1)
 					.pollTimeout(Duration.ofSeconds(5))
 					.maxMessagesPerPoll(1)
@@ -778,7 +778,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		public SqsMessageListenerContainerFactory<Object> ackAfterSecondErrorFactory() {
 			return SqsMessageListenerContainerFactory
 				.builder()
-				.configure(options -> options
+				.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 					.maxConcurrentMessages(10)
 					.pollTimeout(Duration.ofSeconds(10))
 					.maxMessagesPerPoll(10)
@@ -823,7 +823,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		public SqsMessageListenerContainerFactory<Object> manualAcknowledgementFactory() {
 			return SqsMessageListenerContainerFactory
 				.builder()
-				.configure(options -> options
+				.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 					.acknowledgementMode(AcknowledgementMode.MANUAL)
 					.maxConcurrentMessages(1)
 					.pollTimeout(Duration.ofSeconds(3))
@@ -847,7 +847,7 @@ class SqsIntegrationTests extends BaseSqsIntegrationTest {
 		public SqsMessageListenerContainerFactory<Object> manualAcknowledgementBatchFactory() {
 			return SqsMessageListenerContainerFactory
 				.builder()
-				.configure(options -> options
+				.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 					.acknowledgementMode(AcknowledgementMode.MANUAL)
 					.maxConcurrentMessages(10)
 					.pollTimeout(Duration.ofSeconds(10))

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsInterceptorIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsInterceptorIntegrationTests.java
@@ -258,7 +258,7 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 		@Bean
 		public SqsMessageListenerContainerFactory<String> defaultSqsListenerContainerFactory() {
 			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
-			factory.configure(options -> options
+			factory.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 				.maxDelayBetweenPolls(Duration.ofSeconds(1))
 				.queueAttributeNames(Collections.singletonList(QueueAttributeName.QUEUE_ARN))
 				.acknowledgementMode(AcknowledgementMode.ALWAYS)
@@ -274,7 +274,8 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 		@Bean
 		public SqsMessageListenerContainerFactory<String> interceptorThrowsFactory() {
 			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
-			factory.configure(options -> options.maxDelayBetweenPolls(Duration.ofSeconds(1))
+			factory.configure(options -> options.listenerShutdownTimeout(Duration.ZERO)
+					.acknowledgementShutdownTimeout(Duration.ZERO).maxDelayBetweenPolls(Duration.ofSeconds(1))
 					.acknowledgementMode(AcknowledgementMode.ALWAYS).pollTimeout(Duration.ofSeconds(3)));
 			factory.setSqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient);
 			factory.addMessageInterceptor(new AsyncMessageInterceptor<String>() {
@@ -304,7 +305,8 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 		@Bean
 		public SqsMessageListenerContainerFactory<String> interceptorThrowsBatchFactory() {
 			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
-			factory.configure(options -> options.maxDelayBetweenPolls(Duration.ofSeconds(1))
+			factory.configure(options -> options.listenerShutdownTimeout(Duration.ZERO)
+					.acknowledgementShutdownTimeout(Duration.ZERO).maxDelayBetweenPolls(Duration.ofSeconds(1))
 					.acknowledgementMode(AcknowledgementMode.ALWAYS).pollTimeout(Duration.ofSeconds(3)));
 			factory.setSqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient);
 			factory.addMessageInterceptor(new AsyncMessageInterceptor<String>() {
@@ -334,7 +336,8 @@ class SqsInterceptorIntegrationTests extends BaseSqsIntegrationTest {
 		@Bean
 		public SqsMessageListenerContainerFactory<String> interceptorThrowsRecoversFactory() {
 			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
-			factory.configure(options -> options.maxDelayBetweenPolls(Duration.ofSeconds(1))
+			factory.configure(options -> options.listenerShutdownTimeout(Duration.ZERO)
+					.acknowledgementShutdownTimeout(Duration.ZERO).maxDelayBetweenPolls(Duration.ofSeconds(1))
 					.acknowledgementMode(AcknowledgementMode.ON_SUCCESS).pollTimeout(Duration.ofSeconds(3)));
 			factory.setSqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient);
 			factory.addMessageInterceptor(new AsyncMessageInterceptor<String>() {

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsLoadIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsLoadIntegrationTests.java
@@ -333,7 +333,8 @@ class SqsLoadIntegrationTests extends BaseSqsIntegrationTest {
 					.maxDelayBetweenPolls(Duration.ofSeconds(1))
 					.acknowledgementInterval(Duration.ofMillis(500))
 					.backPressureMode(BackPressureMode.FIXED_HIGH_THROUGHPUT)
-					.listenerShutdownTimeout(Duration.ofSeconds(40)));
+					.listenerShutdownTimeout(Duration.ZERO)
+					.acknowledgementShutdownTimeout(Duration.ZERO));
 			factory.setSqsAsyncClientSupplier(BaseSqsIntegrationTest::createHighThroughputAsyncClient);
 			factory.setContainerComponentFactories(Collections.singletonList(getTestAckHandlerComponentFactory()));
 			return factory;

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsMessageConversionIntegrationTests.java
@@ -340,7 +340,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 		@Bean
 		public SqsMessageListenerContainerFactory<String> defaultSqsListenerContainerFactory() {
 			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
-			factory.configure(options -> options
+			factory.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 				.maxDelayBetweenPolls(Duration.ofSeconds(1))
 				.pollTimeout(Duration.ofSeconds(3)));
 			factory.setSqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient);
@@ -353,7 +353,7 @@ class SqsMessageConversionIntegrationTests extends BaseSqsIntegrationTest {
 			// Configure converter to use header-based type resolution, which takes precedence over type inference
 			SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
 			converter.setPayloadTypeHeader(SqsHeaders.SQS_DEFAULT_TYPE_HEADER);
-			factory.configure(options -> options
+			factory.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 					.messageConverter(converter)
 					.queueAttributeNames(Collections.singletonList(QueueAttributeName.VISIBILITY_TIMEOUT))
 					.maxDelayBetweenPolls(Duration.ofSeconds(1))

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsObservationIntegrationTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsObservationIntegrationTest.java
@@ -359,7 +359,7 @@ class SqsObservationIntegrationTests extends BaseSqsIntegrationTest {
 		@Bean
 		SqsMessageListenerContainerFactory<String> defaultSqsListenerContainerFactory() {
 			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
-			factory.configure(options -> options
+			factory.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 				.maxDelayBetweenPolls(Duration.ofSeconds(1))
 				.queueAttributeNames(Collections.singletonList(QueueAttributeName.QUEUE_ARN))
 				.acknowledgementMode(AcknowledgementMode.ALWAYS)
@@ -379,7 +379,7 @@ class SqsObservationIntegrationTests extends BaseSqsIntegrationTest {
 		@Bean
 		SqsMessageListenerContainerFactory<String> asyncSqsListenerContainerFactory() {
 			SqsMessageListenerContainerFactory<String> factory = new SqsMessageListenerContainerFactory<>();
-			factory.configure(options -> options
+			factory.configure(options -> options.listenerShutdownTimeout(Duration.ZERO).acknowledgementShutdownTimeout(Duration.ZERO)
 				.maxDelayBetweenPolls(Duration.ofSeconds(1))
 				.pollTimeout(Duration.ofSeconds(3)));
 			factory.setSqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient);

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsPayloadTypeInferenceIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/SqsPayloadTypeInferenceIntegrationTests.java
@@ -671,7 +671,8 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 				AckCallbackPayloadTypeCollector ackCallbackPayloadTypeCollector) {
 			return SqsMessageListenerContainerFactory.builder()
 					.sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
-					.configure(options -> options.maxDelayBetweenPolls(Duration.ofSeconds(1))
+					.configure(options -> options.listenerShutdownTimeout(Duration.ZERO)
+							.acknowledgementShutdownTimeout(Duration.ZERO).maxDelayBetweenPolls(Duration.ofSeconds(1))
 							.pollTimeout(Duration.ofSeconds(3)))
 					.messageInterceptor(createPayloadTypeRecordingInterceptor(interceptorPayloadTypeCollector))
 					.errorHandler(createErrorHandler(errorHandlerPayloadTypeCollector))
@@ -685,8 +686,10 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 				AckCallbackPayloadTypeCollector ackCallbackPayloadTypeCollector) {
 			return SqsMessageListenerContainerFactory.builder()
 					.sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
-					.configure(options -> options.acknowledgementMode(AcknowledgementMode.MANUAL)
-							.maxDelayBetweenPolls(Duration.ofSeconds(1)).pollTimeout(Duration.ofSeconds(3))
+					.configure(options -> options.listenerShutdownTimeout(Duration.ZERO)
+							.acknowledgementShutdownTimeout(Duration.ZERO)
+							.acknowledgementMode(AcknowledgementMode.MANUAL).maxDelayBetweenPolls(Duration.ofSeconds(1))
+							.pollTimeout(Duration.ofSeconds(3))
 							.queueAttributeNames(Collections.singletonList(QueueAttributeName.QUEUE_ARN)))
 					.messageInterceptor(createPayloadTypeRecordingInterceptor(interceptorPayloadTypeCollector))
 					.errorHandler(createErrorHandler(errorHandlerPayloadTypeCollector))
@@ -715,7 +718,8 @@ class SqsPayloadTypeInferenceIntegrationTests extends BaseSqsIntegrationTest {
 
 			return SqsMessageListenerContainerFactory.builder()
 					.sqsAsyncClientSupplier(BaseSqsIntegrationTest::createAsyncClient)
-					.configure(options -> options.maxDelayBetweenPolls(Duration.ofSeconds(1))
+					.configure(options -> options.listenerShutdownTimeout(Duration.ZERO)
+							.acknowledgementShutdownTimeout(Duration.ZERO).maxDelayBetweenPolls(Duration.ofSeconds(1))
 							.pollTimeout(Duration.ofSeconds(3)).messageConverter(customConverter))
 					.messageInterceptor(createPayloadTypeRecordingInterceptor(interceptorPayloadTypeCollector))
 					.errorHandler(createErrorHandler(errorHandlerPayloadTypeCollector))

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/CompositeBackPressureHandlerTest.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/CompositeBackPressureHandlerTest.java
@@ -16,6 +16,7 @@
 package io.awspring.cloud.sqs.listener;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.*;
 
 import io.awspring.cloud.sqs.listener.backpressure.BackPressureHandler;
@@ -76,7 +77,7 @@ class CompositeBackPressureHandlerTest {
 	void request_shouldWaitIfNoPermitsAndTimeout() throws InterruptedException {
 		// given
 		CompositeBackPressureHandler compositeHandler = compositeHandlerBuilder()
-				.noPermitsReturnedWaitTimeout(Duration.ofSeconds(5)).backPressureHandlers(List.of(handler1, handler2))
+				.noPermitsReturnedWaitTimeout(Duration.ofSeconds(2)).backPressureHandlers(List.of(handler1, handler2))
 				.build();
 		when(handler1.request(5)).thenReturn(0);
 		when(handler2.request(5)).thenReturn(0);
@@ -148,7 +149,9 @@ class CompositeBackPressureHandlerTest {
 			}
 		});
 		requester.start();
-		Thread.sleep(200); // Ensure requester is waiting
+		// Wait for the requester to actually block rather than guess at how long it takes to get there
+		await().atMost(Duration.ofSeconds(10)).until(() -> requester.getState() == Thread.State.WAITING
+				|| requester.getState() == Thread.State.TIMED_WAITING);
 		assertThat(requester.isAlive()).isTrue();
 		// when
 		compositeHandler.release(5, BackPressureHandler.ReleaseReason.PROCESSED);

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessorTests.java
@@ -458,7 +458,7 @@ class BatchingAcknowledgementProcessorTests {
 
 	private void sleep() {
 		try {
-			Thread.sleep(new Random().nextInt(100));
+			Thread.sleep(new Random().nextInt(10));
 		}
 		catch (InterruptedException e) {
 			Thread.currentThread().interrupt();

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/sink/MessageGroupingSinkTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/listener/sink/MessageGroupingSinkTests.java
@@ -81,7 +81,7 @@ class MessageGroupingSinkTests {
 			public CompletableFuture<Message<Integer>> process(Message<Integer> message,
 					MessageProcessingContext<Integer> context) {
 				try {
-					Thread.sleep(new Random().nextInt(1000));
+					Thread.sleep(new Random().nextInt(50));
 				}
 				catch (InterruptedException e) {
 					throw new RuntimeException(e);

--- a/spring-cloud-aws-sqs/src/test/resources/junit-platform.properties
+++ b/spring-cloud-aws-sqs/src/test/resources/junit-platform.properties
@@ -1,3 +1,4 @@
 junit.jupiter.execution.parallel.enabled = true
 junit.jupiter.execution.parallel.mode.classes.default = concurrent
 junit.jupiter.execution.parallel.mode.default = concurrent
+junit.jupiter.testclass.order.default = io.awspring.cloud.sqs.integration.LocalStackAwareClassOrderer


### PR DESCRIPTION

## Changes

Test code only. No test is removed or weakened.

**Give the factories explicit shutdown timeouts.** Every integration class paid the 20 second listener and 20 second acknowledgement shutdown defaults when its context closed. Set both to zero on the factories the tests already declare. `SqsIntegrationTests` keeps its default factory untouched, so its listeners still exercise the production defaults.

**Start Localstack off the worker threads.** The start ran inside a synchronized `@BeforeAll` and held its worker thread throughout, so the module spent its first twenty seconds with one or two tests in flight. Start it during discovery instead, and order the classes that need no container first to fill that window.

**Shrink the error handler backoff windows.** Linear ran 2+4+6 seconds and the jittered exponential 2+4+8 before the fourth delivery. The listeners compute their expected elapsed time from the same constants and assert with `>=`, so the contract is unchanged. #1675 covers the arithmetic.

**Stop three unit tests waiting on real time.** `CompositeBackPressureHandlerTest` waited five seconds to assert a one second minimum, and slept 200ms for a thread to block. A two second timeout still proves the assertion, and the thread's state is observable directly. `MessageGroupingSinkTests` and `BatchingAcknowledgementProcessorTests` sleep a random interval for ordering variety, so the range is shorter.

## Result

Two runs of each on CI against current main, launched together.

| JDK | Before | After |
|---|---|---|
| 17 | 2:03 / 1:48 | 1:32 / 1:28 |
| 21 | 2:05 / 2:02 | 1:24 / 1:24 |
| 24 | 2:06 / 2:01 | 1:28 / 1:35 |

Green on all six jobs. Test counts are unchanged.
