### PR TITLE
Speed up the Kinesis binder test suite

### DIFF
--- a/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/KinesisBinderFunctionalTests.java
+++ b/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/KinesisBinderFunctionalTests.java
@@ -31,6 +31,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -66,6 +68,7 @@ import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
 		"spring.cloud.stream.kinesis.binder.headers = event.eventType",
 		"spring.cloud.stream.kinesis.binder.autoAddShards = true" })
 @DirtiesContext
+@ResourceLock(value = "kinesis-binder", mode = ResourceAccessMode.READ_WRITE)
 public class KinesisBinderFunctionalTests implements LocalstackContainerTest {
 
 	static final String KINESIS_STREAM = "test_stream";

--- a/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/KinesisBinderTests.java
+++ b/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/KinesisBinderTests.java
@@ -36,6 +36,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.mockito.BDDMockito;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.cloud.stream.binder.Binding;
@@ -83,6 +85,7 @@ import software.amazon.kinesis.metrics.MetricsLevel;
  *
  * @since 4.0
  */
+@ResourceLock(value = "kinesis-binder", mode = ResourceAccessMode.READ)
 public class KinesisBinderTests extends
 		PartitionCapableBinderTests<KinesisTestBinder, ExtendedConsumerProperties<KinesisConsumerProperties>, ExtendedProducerProperties<KinesisProducerProperties>>
 		implements LocalstackContainerTest {

--- a/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/KinesisTestBinder.java
+++ b/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/KinesisTestBinder.java
@@ -20,19 +20,25 @@ import io.awspring.cloud.kinesis.stream.binder.properties.KinesisBinderConfigura
 import io.awspring.cloud.kinesis.stream.binder.properties.KinesisConsumerProperties;
 import io.awspring.cloud.kinesis.stream.binder.properties.KinesisProducerProperties;
 import io.awspring.cloud.kinesis.stream.binder.provisioning.KinesisStreamProvisioner;
+import java.time.Duration;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.cloud.stream.binder.AbstractTestBinder;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.PartitionTestSupport;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
+import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.core.MessageProducer;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
@@ -52,6 +58,8 @@ public class KinesisTestBinder extends
 
 	private final GenericApplicationContext applicationContext;
 
+	private final Set<String> provisionedStreams = ConcurrentHashMap.newKeySet();
+
 	public KinesisTestBinder(KinesisAsyncClient amazonKinesis, DynamoDbAsyncClient dynamoDbClient,
 			CloudWatchAsyncClient cloudWatchClient,
 			KinesisBinderConfigurationProperties kinesisBinderConfigurationProperties) {
@@ -60,8 +68,8 @@ public class KinesisTestBinder extends
 
 		this.amazonKinesis = amazonKinesis;
 
-		KinesisStreamProvisioner provisioningProvider = new KinesisStreamProvisioner(amazonKinesis,
-				kinesisBinderConfigurationProperties);
+		KinesisStreamProvisioner provisioningProvider = new RecordingProvisioner(amazonKinesis,
+				kinesisBinderConfigurationProperties, this.provisionedStreams);
 
 		KinesisMessageChannelBinder binder = new TestKinesisMessageChannelBinder(amazonKinesis, dynamoDbClient,
 				cloudWatchClient, kinesisBinderConfigurationProperties, provisioningProvider);
@@ -77,13 +85,64 @@ public class KinesisTestBinder extends
 
 	@Override
 	public void cleanup() {
-		this.amazonKinesis.listStreams()
-				.thenCompose(reply -> CompletableFuture.allOf(reply.streamNames().stream()
-						.map(streamName -> this.amazonKinesis.deleteStream(request -> request.streamName(streamName))
-								.thenCompose(result -> this.amazonKinesis.waiter()
-										.waitUntilStreamNotExists(request -> request.streamName(streamName))))
-						.toArray(CompletableFuture[]::new)))
-				.join();
+		// Delete only the streams this binder provisioned. Listing the account and deleting everything
+		// removes streams that other test classes are still using, which is invisible while the classes run
+		// one at a time and fails them with ResourceNotFoundException as soon as they do not.
+		CompletableFuture.allOf(this.provisionedStreams.stream().map(streamName -> this.amazonKinesis
+				.deleteStream(request -> request.streamName(streamName))
+				// The SDK default waiter backs off in flat 10-second steps, so every
+				// stream deletion costs at least 10 seconds. Poll once per second.
+				.thenCompose(result -> this.amazonKinesis.waiter().waitUntilStreamNotExists(
+						request -> request.streamName(streamName),
+						waiter -> waiter.maxAttempts(60)
+								.backoffStrategyV2(BackoffStrategy.fixedDelayWithoutJitter(Duration.ofSeconds(1)))))
+				.exceptionally(throwable -> null)).toArray(CompletableFuture[]::new)).join();
+		this.provisionedStreams.clear();
+	}
+
+	private static final class RecordingProvisioner extends KinesisStreamProvisioner {
+
+		/**
+		 * Localstack only creates a few streams at a time, and the provisioner creates one per binding, so concurrent
+		 * classes can exceed that limit. Gate provisioning rather than retry it: CreateStream is not idempotent and
+		 * answers ResourceInUseException once the stream exists.
+		 */
+		private static final Semaphore PROVISIONING = new Semaphore(3);
+
+		private final Set<String> provisionedStreams;
+
+		RecordingProvisioner(KinesisAsyncClient amazonKinesis,
+				KinesisBinderConfigurationProperties configurationProperties, Set<String> provisionedStreams) {
+			super(amazonKinesis, configurationProperties);
+			this.provisionedStreams = provisionedStreams;
+		}
+
+		@Override
+		public ProducerDestination provisionProducerDestination(String name,
+				ExtendedProducerProperties<KinesisProducerProperties> properties) {
+			this.provisionedStreams.add(name);
+			PROVISIONING.acquireUninterruptibly();
+			try {
+				return super.provisionProducerDestination(name, properties);
+			}
+			finally {
+				PROVISIONING.release();
+			}
+		}
+
+		@Override
+		public ConsumerDestination provisionConsumerDestination(String name, String group,
+				ExtendedConsumerProperties<KinesisConsumerProperties> properties) {
+			this.provisionedStreams.add(name);
+			PROVISIONING.acquireUninterruptibly();
+			try {
+				return super.provisionConsumerDestination(name, group, properties);
+			}
+			finally {
+				PROVISIONING.release();
+			}
+		}
+
 	}
 
 	/**

--- a/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/LocalstackContainerTest.java
+++ b/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/LocalstackContainerTest.java
@@ -48,7 +48,9 @@ public interface LocalstackContainerTest {
 
 	@BeforeAll
 	static void startContainer() {
-		LOCAL_STACK_CONTAINER.start();
+		synchronized (LOCAL_STACK_CONTAINER) {
+			LOCAL_STACK_CONTAINER.start();
+		}
 		System.setProperty("spring.cloud.aws.region.static", LOCAL_STACK_CONTAINER.getRegion());
 		System.setProperty("spring.cloud.aws.endpoint", LOCAL_STACK_CONTAINER.getEndpoint().toString());
 		System.setProperty("spring.cloud.aws.credentials.access-key", LOCAL_STACK_CONTAINER.getAccessKey());

--- a/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/dynamodb/DynamoDbStreamsIntegrationTests.java
+++ b/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/dynamodb/DynamoDbStreamsIntegrationTests.java
@@ -29,6 +29,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -60,6 +62,7 @@ import software.amazon.awssdk.services.dynamodb.model.StreamViewType;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = "spring.cloud.stream.kinesis.bindings.dynamoDbConsumer-in-0.consumer.dynamoDbStreams=true")
 @DirtiesContext
+@ResourceLock(value = "kinesis-binder", mode = ResourceAccessMode.READ)
 public class DynamoDbStreamsIntegrationTests implements LocalstackContainerTest {
 
 	static final String TEST_TABLE = "StreamsBinderDemoTable";

--- a/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/observation/KinesisBinderObservationTests.java
+++ b/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/observation/KinesisBinderObservationTests.java
@@ -33,6 +33,8 @@ import java.util.function.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.micrometer.tracing.test.autoconfigure.AutoConfigureTracing;
@@ -70,6 +72,7 @@ import reactor.core.publisher.Flux;
 		"management.tracing.sampling.probability=1.0" })
 @AutoConfigureTracing
 @DirtiesContext
+@ResourceLock(value = "kinesis-binder", mode = ResourceAccessMode.READ)
 public class KinesisBinderObservationTests implements LocalstackContainerTest {
 
 	private static final Log LOGGER = LogFactory.getLog(KinesisBinderObservationTests.class);

--- a/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/provisioning/KinesisStreamProvisionerTests.java
+++ b/spring-cloud-aws-kinesis-stream-binder/src/test/java/io/awspring/cloud/kinesis/stream/binder/provisioning/KinesisStreamProvisionerTests.java
@@ -26,6 +26,8 @@ import java.time.Duration;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.HeaderMode;
@@ -45,6 +47,7 @@ import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
  *
  * @since 4.0
  */
+@ResourceLock(value = "kinesis-binder", mode = ResourceAccessMode.READ)
 class KinesisStreamProvisionerTests implements LocalstackContainerTest {
 
 	private static KinesisAsyncClient AMAZON_KINESIS;

--- a/spring-cloud-aws-kinesis-stream-binder/src/test/resources/junit-platform.properties
+++ b/spring-cloud-aws-kinesis-stream-binder/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.classes.default = concurrent
+junit.jupiter.execution.parallel.mode.default = same_thread
+junit.jupiter.execution.parallel.config.strategy = fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism = 2


### PR DESCRIPTION

## Motivation

Follow-up to #1665, which enabled parallel reactor builds. With modules building concurrently, wall clock is set by the longest dependency chain, and the binder sits at the end of the longest one.

Companion to the change for `spring-cloud-aws-kinesis`. The two are independent and can land in either order.

Test code only. Test counts are unchanged.

## Changes

**Run two classes at a time.** The module had no parallel execution configured, so its five classes ran one after another: 83 seconds of class time in a 90 second module, with the longest class at 42 seconds. Two at a time overlaps them without pushing Localstack past the number of streams it will create at once.

**Delete only the streams the test binder created.** `KinesisTestBinder.cleanup()` listed the account and deleted every stream it found. With two classes running, one class deletes streams the other is still using, and the other then fails on a stream that no longer exists. The provisioner records what it creates, and cleanup deletes only those.

**Gate stream provisioning.** Localstack only creates a few streams at a time and the provisioner creates one per binding, so concurrent classes can exceed that limit. Allow three at once.

**Give the functional test exclusive access.** `KinesisBinderFunctionalTests` reads the binding's lifecycle straight after the context starts, and under a concurrent class the binding is not yet running. A read lock on the other four lets them overlap each other while the functional test holds the write lock alone.

**Stop the cleanup waiting on the default waiter backoff.** `cleanup()` waited on `waitUntilStreamNotExists` with SDK defaults, which back off in flat 10 second steps, so every deletion cost at least 10 seconds across roughly 13 tests. Poll once per second instead, mirroring what `KinesisStreamProvisioner` already does for creation, where `describeStreamBackoff` defaults to 1 second.

## Result

Measured on CI against current main.

| JDK | Before | After |
|---|---|---|
| 17 | 3:40 | 1:27 |
| 21 | 3:26 | 1:14 |
| 24 | 3:20 | 1:11 |

Green on all three JDKs.
