### PR TITLE
docs(sqs): clarify acknowledgementMode interaction with custom container factory beans

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -855,6 +855,10 @@ public void listen(String message) {
 
 When using a Spring Boot application with auto-configuration, a default factory is provided if there are no other factory beans declared in the context.
 
+NOTE: If a custom `SqsMessageListenerContainerFactory` bean is declared without the `defaultSqsListenerContainerFactory` name, Spring Boot's autoconfiguration backs off and no bean is registered under that name.
+In that case, any `@SqsListener` relying on the default factory - for example to use annotation-level properties such as `acknowledgementMode` - must either set the `factory` property explicitly, or register a `SqsListenerConfigurer` bean calling `setDefaultListenerContainerFactoryBeanName` with the custom bean's name.
+See <<Global configuration for @SqsListeners>> for more information.
+
 
 ===== Other annotation properties
 
@@ -2232,6 +2236,8 @@ The following attributes can be configured in the registrar:
 - `setMessageHandlerMethodFactory` - provide a different factory to be used to create the `invocableHandlerMethod` instances that wrap the listener methods.
 - `setListenerContainerRegistry` - provide a different `MessageListenerContainerRegistry` implementation to be used to register the `MessageListenerContainers`
 - `setMessageListenerContainerRegistryBeanName` - provide a different bean name to be used to retrieve the `MessageListenerContainerRegistry`
+- `setDefaultListenerContainerFactoryBeanName` - change the bean name looked up for the default `MessageListenerContainerFactory` (`defaultSqsListenerContainerFactory` by default).
+This is useful when a custom factory bean is declared under a different name and `@SqsListener` methods should use it without specifying the `factory` property explicitly.
 - `setJacksonMessageConverterMigration` - internal migration wiring for the Jackson 2 to Jackson 3 transition, not intended for application configuration.
 - `setValidator` - set the `Validator` instance that will be used for payload validation in listener methods.
 - `manageMessageConverters` - gives access to the list of message converters that will be used by ArgumentResolvers.


### PR DESCRIPTION
Fixes #971

When a custom `SqsMessageListenerContainerFactory` bean is declared under a name
other than `defaultSqsListenerContainerFactory`, Spring Boot's autoconfiguration
backs off and no bean is registered under the default name. Any `@SqsListener`
relying on the default factory - for example to use `acknowledgementMode` - then
fails at startup with an unhelpful `IllegalArgumentException`.

This documents the two ways to resolve it (explicit `factory` property, or a
`SqsListenerConfigurer` calling `setDefaultListenerContainerFactoryBeanName`),
and adds the missing `setDefaultListenerContainerFactoryBeanName` entry to the
`Global configuration for @SqsListeners` attribute list, which wasn't
documented at all previously.

Builds on the discussion in #979, rewritten in third-person to match the doc's style.

Verified locally: built the `docs` module with the `docs-classic` profile and
confirmed both additions render correctly in `sqs.html`.