### PR TITLE
Apply Spotless formatting to BatchingAcknowledgementProcessor

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/listener/acknowledgement/BatchingAcknowledgementProcessor.java
@@ -80,9 +80,9 @@ public class BatchingAcknowledgementProcessor<T> extends AbstractOrderingAcknowl
 	private BlockingQueue<Message<T>> acks;
 
 	/**
-	 * Number of messages that have been received for acknowledgement but are not in {@link #acks} nor in the buffer yet.
-	 * Incremented before a message is offered to the queue and decremented after it has been added to the buffer, so a
-	 * message is always accounted for while the polling thread is holding it in between the two.
+	 * Number of messages that have been received for acknowledgement but are not in {@link #acks} nor in the buffer
+	 * yet. Incremented before a message is offered to the queue and decremented after it has been added to the buffer,
+	 * so a message is always accounted for while the polling thread is holding it in between the two.
 	 */
 	private final AtomicInteger unbufferedAcks = new AtomicInteger();
 


### PR DESCRIPTION
Running `spotless:apply` on current main reformats the `unbufferedAcks` Javadoc in `BatchingAcknowledgementProcessor` and nothing else. Contributor branches that run the formatter keep picking up this unrelated hunk in their diffs, most recently in #1640.

This commits the formatter output so `spotless:apply` is a no-op on main again. The `spring-cloud-aws-autoconfigure` module was checked as well and has no drift. No code changes.