### PR TITLE
feat: auto-configure virtual threads for SQS listener containers

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -57,6 +57,8 @@ import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.Message;
@@ -186,7 +188,7 @@ public class SqsAutoConfiguration {
 			ObjectProvider<AcknowledgementResultCallback<Object>> acknowledgementResultCallback,
 			ObjectProvider<AsyncAcknowledgementResultCallback<Object>> asyncAcknowledgementResultCallback,
 			ObjectProvider<JacksonMessageConverterMigration> messageConverterFactory,
-			MessagingMessageConverter<?> messagingMessageConverter) {
+			MessagingMessageConverter<?> messagingMessageConverter, Environment environment) {
 
 		SqsMessageListenerContainerFactory<Object> factory = new SqsMessageListenerContainerFactory<>();
 		factory.configure(this::configureProperties);
@@ -203,6 +205,15 @@ public class SqsAutoConfiguration {
 					.ifAvailable(registry -> factory.configure(options -> options.observationRegistry(registry)));
 			observationConventionProvider
 					.ifAvailable(convention -> factory.configure(options -> options.observationConvention(convention)));
+		}
+		if (environment.getProperty("spring.threads.virtual.enabled", Boolean.class, false)) {
+			SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor("sqs-listener-");
+			executor.setVirtualThreads(true);
+			factory.configure(options -> options.componentsTaskExecutor(executor));
+
+			SimpleAsyncTaskExecutor ackExecutor = new SimpleAsyncTaskExecutor("sqs-ack-");
+			ackExecutor.setVirtualThreads(true);
+			factory.configure(options -> options.acknowledgementResultTaskExecutor(ackExecutor));
 		}
 		factory.configure(options -> options.messageConverter(messagingMessageConverter));
 		return factory;

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
@@ -51,6 +51,7 @@ import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.messaging.converter.CompositeMessageConverter;
 import org.springframework.messaging.converter.JacksonJsonMessageConverter;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -445,6 +446,50 @@ class SqsAutoConfigurationTest {
 			};
 		}
 
+	}
+
+	@Test
+	void withVirtualThreadsEnabled() {
+		this.contextRunner.withPropertyValues("spring.threads.virtual.enabled=true").run(context -> {
+			assertThat(context).hasSingleBean(SqsMessageListenerContainerFactory.class);
+			assertThat(context.getBean(SqsMessageListenerContainerFactory.class)).extracting("containerOptionsBuilder")
+					.asInstanceOf(type(ContainerOptionsBuilder.class)).extracting(ContainerOptionsBuilder::build)
+					.satisfies(options -> {
+						assertThat(options).extracting("componentsTaskExecutor").isInstanceOf(SimpleAsyncTaskExecutor.class);
+						SimpleAsyncTaskExecutor executor = (SimpleAsyncTaskExecutor) options.getComponentsTaskExecutor();
+						try {
+							executor.submit(() -> {
+								assertThat(Thread.currentThread().isVirtual()).isTrue();
+							}).get();
+						} catch (Exception e) {
+							throw new RuntimeException(e);
+						}
+
+						assertThat(options).extracting("acknowledgementResultTaskExecutor")
+								.isInstanceOf(SimpleAsyncTaskExecutor.class);
+						SimpleAsyncTaskExecutor ackExecutor = (SimpleAsyncTaskExecutor) options.getAcknowledgementResultTaskExecutor();
+						try {
+							ackExecutor.submit(() -> {
+								assertThat(Thread.currentThread().isVirtual()).isTrue();
+							}).get();
+						} catch (Exception e) {
+							throw new RuntimeException(e);
+						}
+					});
+		});
+	}
+
+	@Test
+	void withVirtualThreadsDisabled() {
+		this.contextRunner.withPropertyValues("spring.threads.virtual.enabled=false").run(context -> {
+			assertThat(context).hasSingleBean(SqsMessageListenerContainerFactory.class);
+			assertThat(context.getBean(SqsMessageListenerContainerFactory.class)).extracting("containerOptionsBuilder")
+					.asInstanceOf(type(ContainerOptionsBuilder.class)).extracting(ContainerOptionsBuilder::build)
+					.satisfies(options -> {
+						assertThat(options).extracting("componentsTaskExecutor").isNull();
+						assertThat(options).extracting("acknowledgementResultTaskExecutor").isNull();
+					});
+		});
 	}
 
 }

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
@@ -45,6 +45,8 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -449,6 +451,7 @@ class SqsAutoConfigurationTest {
 	}
 
 	@Test
+	@EnabledForJreRange(min = JRE.JAVA_21)
 	void withVirtualThreadsEnabled() {
 		this.contextRunner.withPropertyValues("spring.threads.virtual.enabled=true").run(context -> {
 			assertThat(context).hasSingleBean(SqsMessageListenerContainerFactory.class);
@@ -459,7 +462,7 @@ class SqsAutoConfigurationTest {
 						SimpleAsyncTaskExecutor executor = (SimpleAsyncTaskExecutor) options.getComponentsTaskExecutor();
 						try {
 							executor.submit(() -> {
-								assertThat(Thread.currentThread().isVirtual()).isTrue();
+								assertThat(isVirtualThread(Thread.currentThread())).isTrue();
 							}).get();
 						} catch (Exception e) {
 							throw new RuntimeException(e);
@@ -470,13 +473,22 @@ class SqsAutoConfigurationTest {
 						SimpleAsyncTaskExecutor ackExecutor = (SimpleAsyncTaskExecutor) options.getAcknowledgementResultTaskExecutor();
 						try {
 							ackExecutor.submit(() -> {
-								assertThat(Thread.currentThread().isVirtual()).isTrue();
+								assertThat(isVirtualThread(Thread.currentThread())).isTrue();
 							}).get();
 						} catch (Exception e) {
 							throw new RuntimeException(e);
 						}
 					});
 		});
+	}
+
+	private static boolean isVirtualThread(Thread thread) {
+		try {
+			return (boolean) Thread.class.getMethod("isVirtual").invoke(thread);
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Enhancement

## :scroll: Description
This pull request adds native support for Java 21+ Virtual Threads to SQS listener container factories.
* Modifies `SqsAutoConfiguration` to detect the standard Spring Boot property `spring.threads.virtual.enabled`.
* When enabled, configures `SimpleAsyncTaskExecutor` (with `virtualThreads = true`) for both the message processing executor (`componentsTaskExecutor`) and the acknowledgment executor (`acknowledgementResultTaskExecutor`).

## :bulb: Motivation and Context
Closes #1693.
Integrates Spring Boot's global standard `spring.threads.virtual.enabled` toggle directly into Spring Cloud AWS SQS listeners, allowing users to leverage high-throughput non-blocking concurrency (Project Loom) out-of-the-box on Java 21+ stacks.

## :green_heart: How did you test it?
1. Added unit tests in `SqsAutoConfigurationTest` verifying SQS containers operate on virtual threads when enabled and fallback to standard platform thread execution when disabled.
2. Verified all tests compile and pass successfully.