### PR TITLE
feat: auto-configure virtual threads for Kinesis listener containers

### DIFF
--- a/spring-cloud-aws-kinesis/src/main/java/io/awspring/cloud/kinesis/integration/KclMessageDrivenChannelAdapter.java
+++ b/spring-cloud-aws-kinesis/src/main/java/io/awspring/cloud/kinesis/integration/KclMessageDrivenChannelAdapter.java
@@ -401,6 +401,13 @@ public class KclMessageDrivenChannelAdapter extends MessageProducerSupport imple
 	@Override
 	protected void onInit() {
 		super.onInit();
+		var applicationContext = getApplicationContext();
+		if (applicationContext != null && applicationContext.getEnvironment()
+				.getProperty("spring.threads.virtual.enabled", Boolean.class, false)) {
+			if (this.executor instanceof SimpleAsyncTaskExecutor sate) {
+				sate.setVirtualThreads(true);
+			}
+		}
 		if (this.listenerMode.equals(ListenerMode.record) && this.emptyRecordList) {
 			this.emptyRecordList = false;
 			logger.warn("The 'emptyRecordList' is processed only in the [ListenerMode.batch].");

--- a/spring-cloud-aws-kinesis/src/main/java/io/awspring/cloud/kinesis/integration/KinesisMessageDrivenChannelAdapter.java
+++ b/spring-cloud-aws-kinesis/src/main/java/io/awspring/cloud/kinesis/integration/KinesisMessageDrivenChannelAdapter.java
@@ -57,6 +57,8 @@ import org.springframework.integration.metadata.SimpleMetadataStore;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.integration.support.ErrorMessageStrategy;
 import org.springframework.integration.support.ErrorMessageUtils;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.support.ExecutorServiceAdapter;
 import org.springframework.integration.support.locks.LockRegistry;
 import org.springframework.integration.support.locks.RenewableLockRegistry;
 import org.springframework.integration.support.management.IntegrationManagedResource;
@@ -361,13 +363,34 @@ public class KinesisMessageDrivenChannelAdapter extends MessageProducerSupport
 		super.onInit();
 
 		final String componentName = getComponentName();
+		boolean virtualThreadsEnabled = false;
+		var applicationContext = getApplicationContext();
+		if (applicationContext != null) {
+			virtualThreadsEnabled = applicationContext.getEnvironment()
+					.getProperty("spring.threads.virtual.enabled", Boolean.class, false);
+		}
+
 		if (this.consumerExecutor == null) {
-			this.consumerExecutor = Executors.newCachedThreadPool(
-					new CustomizableThreadFactory((componentName == null ? "" : componentName) + "-kinesis-consumer-"));
+			if (virtualThreadsEnabled) {
+				SimpleAsyncTaskExecutor sate = new SimpleAsyncTaskExecutor((componentName == null ? "" : componentName) + "-kinesis-consumer-");
+				sate.setVirtualThreads(true);
+				this.consumerExecutor = new ExecutorServiceAdapter(sate);
+			}
+			else {
+				this.consumerExecutor = Executors.newCachedThreadPool(
+						new CustomizableThreadFactory((componentName == null ? "" : componentName) + "-kinesis-consumer-"));
+			}
 		}
 		if (this.dispatcherExecutor == null) {
-			this.dispatcherExecutor = Executors.newCachedThreadPool(new CustomizableThreadFactory(
-					(componentName == null ? "" : componentName) + "-kinesis-dispatcher-"));
+			if (virtualThreadsEnabled) {
+				SimpleAsyncTaskExecutor sate = new SimpleAsyncTaskExecutor((componentName == null ? "" : componentName) + "-kinesis-dispatcher-");
+				sate.setVirtualThreads(true);
+				this.dispatcherExecutor = new ExecutorServiceAdapter(sate);
+			}
+			else {
+				this.dispatcherExecutor = Executors.newCachedThreadPool(new CustomizableThreadFactory(
+						(componentName == null ? "" : componentName) + "-kinesis-dispatcher-"));
+			}
 		}
 
 		if (this.streams == null) {

--- a/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KinesisVirtualThreadsTest.java
+++ b/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KinesisVirtualThreadsTest.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.mock;
 
 import java.util.concurrent.ExecutorService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.integration.test.util.TestUtils;
@@ -30,6 +32,7 @@ import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 class KinesisVirtualThreadsTest {
 
 	@Test
+	@EnabledForJreRange(min = JRE.JAVA_21)
 	void kinesisAdapterVirtualThreadsEnabled() {
 		GenericApplicationContext context = new GenericApplicationContext();
 		MockEnvironment env = new MockEnvironment();
@@ -54,10 +57,10 @@ class KinesisVirtualThreadsTest {
 
 		try {
 			consumer.submit(() -> {
-				assertThat(Thread.currentThread().isVirtual()).isTrue();
+				assertThat(isVirtualThread(Thread.currentThread())).isTrue();
 			}).get();
 			dispatcher.submit(() -> {
-				assertThat(Thread.currentThread().isVirtual()).isTrue();
+				assertThat(isVirtualThread(Thread.currentThread())).isTrue();
 			}).get();
 		}
 		catch (Exception e) {
@@ -90,10 +93,10 @@ class KinesisVirtualThreadsTest {
 
 		try {
 			consumer.submit(() -> {
-				assertThat(Thread.currentThread().isVirtual()).isFalse();
+				assertThat(isVirtualThread(Thread.currentThread())).isFalse();
 			}).get();
 			dispatcher.submit(() -> {
-				assertThat(Thread.currentThread().isVirtual()).isFalse();
+				assertThat(isVirtualThread(Thread.currentThread())).isFalse();
 			}).get();
 		}
 		catch (Exception e) {
@@ -102,6 +105,7 @@ class KinesisVirtualThreadsTest {
 	}
 
 	@Test
+	@EnabledForJreRange(min = JRE.JAVA_21)
 	void kclAdapterVirtualThreadsEnabled() {
 		GenericApplicationContext context = new GenericApplicationContext();
 		MockEnvironment env = new MockEnvironment();
@@ -122,7 +126,7 @@ class KinesisVirtualThreadsTest {
 		SimpleAsyncTaskExecutor sate = (SimpleAsyncTaskExecutor) executor;
 		try {
 			sate.submit(() -> {
-				assertThat(Thread.currentThread().isVirtual()).isTrue();
+				assertThat(isVirtualThread(Thread.currentThread())).isTrue();
 			}).get();
 		}
 		catch (Exception e) {
@@ -151,8 +155,20 @@ class KinesisVirtualThreadsTest {
 		SimpleAsyncTaskExecutor sate = (SimpleAsyncTaskExecutor) executor;
 		try {
 			sate.submit(() -> {
-				assertThat(Thread.currentThread().isVirtual()).isFalse();
+				assertThat(isVirtualThread(Thread.currentThread())).isFalse();
 			}).get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static boolean isVirtualThread(Thread thread) {
+		try {
+			return (boolean) Thread.class.getMethod("isVirtual").invoke(thread);
+		}
+		catch (NoSuchMethodException e) {
+			return false;
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);

--- a/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KinesisVirtualThreadsTest.java
+++ b/spring-cloud-aws-kinesis/src/test/java/io/awspring/cloud/kinesis/integration/KinesisVirtualThreadsTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2013-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.awspring.cloud.kinesis.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.ExecutorService;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.mock.env.MockEnvironment;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
+
+class KinesisVirtualThreadsTest {
+
+	@Test
+	void kinesisAdapterVirtualThreadsEnabled() {
+		GenericApplicationContext context = new GenericApplicationContext();
+		MockEnvironment env = new MockEnvironment();
+		env.setProperty("spring.threads.virtual.enabled", "true");
+		context.setEnvironment(env);
+		context.refresh();
+
+		KinesisAsyncClient client = mock(KinesisAsyncClient.class);
+		KinesisMessageDrivenChannelAdapter adapter = new KinesisMessageDrivenChannelAdapter(client, "stream1");
+		adapter.setApplicationContext(context);
+		adapter.setBeanFactory(context.getBeanFactory());
+		adapter.afterPropertiesSet();
+
+		Object consumerExecutor = TestUtils.getPropertyValue(adapter, "consumerExecutor");
+		Object dispatcherExecutor = TestUtils.getPropertyValue(adapter, "dispatcherExecutor");
+
+		assertThat(consumerExecutor).isNotNull();
+		assertThat(dispatcherExecutor).isNotNull();
+
+		ExecutorService consumer = (ExecutorService) consumerExecutor;
+		ExecutorService dispatcher = (ExecutorService) dispatcherExecutor;
+
+		try {
+			consumer.submit(() -> {
+				assertThat(Thread.currentThread().isVirtual()).isTrue();
+			}).get();
+			dispatcher.submit(() -> {
+				assertThat(Thread.currentThread().isVirtual()).isTrue();
+			}).get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Test
+	void kinesisAdapterVirtualThreadsDisabled() {
+		GenericApplicationContext context = new GenericApplicationContext();
+		MockEnvironment env = new MockEnvironment();
+		env.setProperty("spring.threads.virtual.enabled", "false");
+		context.setEnvironment(env);
+		context.refresh();
+
+		KinesisAsyncClient client = mock(KinesisAsyncClient.class);
+		KinesisMessageDrivenChannelAdapter adapter = new KinesisMessageDrivenChannelAdapter(client, "stream1");
+		adapter.setApplicationContext(context);
+		adapter.setBeanFactory(context.getBeanFactory());
+		adapter.afterPropertiesSet();
+
+		Object consumerExecutor = TestUtils.getPropertyValue(adapter, "consumerExecutor");
+		Object dispatcherExecutor = TestUtils.getPropertyValue(adapter, "dispatcherExecutor");
+
+		assertThat(consumerExecutor).isNotNull();
+		assertThat(dispatcherExecutor).isNotNull();
+
+		ExecutorService consumer = (ExecutorService) consumerExecutor;
+		ExecutorService dispatcher = (ExecutorService) dispatcherExecutor;
+
+		try {
+			consumer.submit(() -> {
+				assertThat(Thread.currentThread().isVirtual()).isFalse();
+			}).get();
+			dispatcher.submit(() -> {
+				assertThat(Thread.currentThread().isVirtual()).isFalse();
+			}).get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Test
+	void kclAdapterVirtualThreadsEnabled() {
+		GenericApplicationContext context = new GenericApplicationContext();
+		MockEnvironment env = new MockEnvironment();
+		env.setProperty("spring.threads.virtual.enabled", "true");
+		context.setEnvironment(env);
+		context.refresh();
+
+		KinesisAsyncClient client = mock(KinesisAsyncClient.class);
+		software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient cloudWatch = mock(software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient.class);
+		software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient dynamoDb = mock(software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient.class);
+		KclMessageDrivenChannelAdapter adapter = new KclMessageDrivenChannelAdapter(client, cloudWatch, dynamoDb, "stream1");
+		adapter.setApplicationContext(context);
+		adapter.setBeanFactory(context.getBeanFactory());
+		adapter.afterPropertiesSet();
+
+		Object executor = TestUtils.getPropertyValue(adapter, "executor");
+		assertThat(executor).isInstanceOf(SimpleAsyncTaskExecutor.class);
+		SimpleAsyncTaskExecutor sate = (SimpleAsyncTaskExecutor) executor;
+		try {
+			sate.submit(() -> {
+				assertThat(Thread.currentThread().isVirtual()).isTrue();
+			}).get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Test
+	void kclAdapterVirtualThreadsDisabled() {
+		GenericApplicationContext context = new GenericApplicationContext();
+		MockEnvironment env = new MockEnvironment();
+		env.setProperty("spring.threads.virtual.enabled", "false");
+		context.setEnvironment(env);
+		context.refresh();
+
+		KinesisAsyncClient client = mock(KinesisAsyncClient.class);
+		software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient cloudWatch = mock(software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient.class);
+		software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient dynamoDb = mock(software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient.class);
+		KclMessageDrivenChannelAdapter adapter = new KclMessageDrivenChannelAdapter(client, cloudWatch, dynamoDb, "stream1");
+		adapter.setApplicationContext(context);
+		adapter.setBeanFactory(context.getBeanFactory());
+		adapter.afterPropertiesSet();
+
+		Object executor = TestUtils.getPropertyValue(adapter, "executor");
+		assertThat(executor).isInstanceOf(SimpleAsyncTaskExecutor.class);
+		SimpleAsyncTaskExecutor sate = (SimpleAsyncTaskExecutor) executor;
+		try {
+			sate.submit(() -> {
+				assertThat(Thread.currentThread().isVirtual()).isFalse();
+			}).get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Enhancement

## :scroll: Description
This pull request adds native support for Java 21+ Virtual Threads to Kinesis and KCL message-driven channel adapters.
* Modifies `KinesisMessageDrivenChannelAdapter` and `KclMessageDrivenChannelAdapter` to hook into the global `spring.threads.virtual.enabled` property.
* If enabled, configures `SimpleAsyncTaskExecutor` with `virtualThreads = true` (wrapped using `ExecutorServiceAdapter` for `KinesisMessageDrivenChannelAdapter` to comply with lifecycle cast/shutdown contracts).

## :bulb: Motivation and Context
Relates to #1693.
Integrates Spring Boot's global standard `spring.threads.virtual.enabled` toggle directly into Spring Cloud AWS Kinesis adapters, allowing users to leverage high-throughput non-blocking concurrency (Project Loom) out-of-the-box on Java 21+ stacks.

## :green_heart: How did you test it?
1. Added new unit tests in `KinesisVirtualThreadsTest` verifying `KinesisMessageDrivenChannelAdapter` and `KclMessageDrivenChannelAdapter` execute processing tasks on virtual threads under active Loom configs.
2. Verified all tests compile and pass successfully.