### PR TITLE
Use floci/floci image in Docker Compose documentation

### DIFF
--- a/docs/src/main/asciidoc/docker-compose.adoc
+++ b/docs/src/main/asciidoc/docker-compose.adoc
@@ -38,7 +38,7 @@ services:
 ----
 services:
   floci:
-    image: hectorvent/floci
+    image: floci/floci
     environment:
       AWS_ACCESS_KEY_ID: noop
       AWS_SECRET_ACCESS_KEY: noop


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
The Floci example in `docs/src/main/asciidoc/docker-compose.adoc` referenced the `hectorvent/floci` image, which is a personal Docker Hub account image. This changes it to the canonical `floci/floci` image.


## :bulb: Motivation and Context
`AwsDockerComposeConnectionDetailsFactory` matches services by image name against a fixed list (`AWS_EMULATOR_CONTAINER_NAMES`): `localstack/localstack`, `localstack/localstack-pro` and `floci/floci`.

Because `hectorvent/floci` is not in that list, a compose file copied from the documentation starts a container that Spring Cloud AWS never detects: no `AwsConnectionDetails` are contributed and the application silently falls back to the default AWS endpoints instead of the local emulator.

The correct image name is already used everywhere else in the project, including the test fixture `docker-compose-floci.yaml` and the Testcontainers tests.


## :green_heart: How did you test it?
Documentation-only change, no production code touched.

- Verified the documented image now matches an entry in `AwsDockerComposeConnectionDetailsFactory#AWS_EMULATOR_CONTAINER_NAMES`, which is the condition the example was failing.
- Cross-checked against the existing fixture `spring-cloud-aws-docker-compose/src/test/resources/docker-compose-floci.yaml`, which already uses `floci/floci` and is exercised by `AwsDockerComposeConnectionDetailsFactoryTest`.
- Ran the `spring-cloud-aws-docker-compose` module tests locally: 10 tests, all passing, including `AwsDockerComposeConnectionDetailsFactoryTest$FlociTests`.


## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes — documentation-only change; `AwsDockerComposeConnectionDetailsFactoryTest$FlociTests` already covers `floci/floci` detection
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
None.
