### PR TITLE
Do not put a null message attribute when contentType is unsupported

### DIFF
--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/SnsHeaderConverterUtil.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/SnsHeaderConverterUtil.java
@@ -60,7 +60,13 @@ public class SnsHeaderConverterUtil {
 			}
 
 			if (MessageHeaders.CONTENT_TYPE.equals(messageHeaderName) && messageHeaderValue != null) {
-				messageAttributes.put(messageHeaderName, getContentTypeMessageAttribute(messageHeaderValue));
+				MessageAttributeValue contentType = getContentTypeMessageAttribute(messageHeaderValue);
+				if (contentType != null) {
+					messageAttributes.put(messageHeaderName, contentType);
+				}
+				else {
+					logUnsupportedHeader(messageHeaderName, messageHeaderValue);
+				}
 			}
 			else if (MessageHeaders.ID.equals(messageHeaderName) && messageHeaderValue != null) {
 				messageAttributes.put(messageHeaderName, getStringMessageAttribute(messageHeaderValue.toString()));
@@ -81,14 +87,18 @@ public class SnsHeaderConverterUtil {
 				messageAttributes.put(messageHeaderName, getStringArrayMessageAttribute((List<?>) messageHeaderValue));
 			}
 			else {
-				logger.warn(String.format(
-						"Message header with name '%s' and type '%s' cannot be sent as"
-								+ " message attribute because it is not supported by SNS.",
-						messageHeaderName, messageHeaderValue != null ? messageHeaderValue.getClass().getName() : ""));
+				logUnsupportedHeader(messageHeaderName, messageHeaderValue);
 			}
 		}
 
 		return messageAttributes;
+	}
+
+	private static void logUnsupportedHeader(String messageHeaderName, @Nullable Object messageHeaderValue) {
+		logger.warn(String.format(
+				"Message header with name '%s' and type '%s' cannot be sent as"
+						+ " message attribute because it is not supported by SNS.",
+				messageHeaderName, messageHeaderValue != null ? messageHeaderValue.getClass().getName() : ""));
 	}
 
 	private static boolean isSkipHeader(String headerName) {

--- a/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/core/TopicMessageChannelTest.java
+++ b/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/core/TopicMessageChannelTest.java
@@ -212,6 +212,22 @@ class TopicMessageChannelTest {
 	}
 
 	@Test
+	void sendMessage_withUnsupportedContentTypeHeader_shouldNotSetItAsMessageAttribute() {
+		// Arrange
+		// a contentType that is neither a MimeType nor a String
+		Message<String> message = MessageBuilder.withPayload("Hello")
+				.setHeader(MessageHeaders.CONTENT_TYPE, new Object()).build();
+
+		// Act
+		boolean sent = messageChannel.send(message);
+
+		// Assert
+		assertThat(sent).isTrue();
+		verify(snsClient).publish(requestMatches(
+				it -> assertThat(it.messageAttributes()).doesNotContainKey(MessageHeaders.CONTENT_TYPE)));
+	}
+
+	@Test
 	void sendMessage_withMessageGroupIdHeader_shouldSetMessageGroupIdOnPublishRequestAndNotSetItAsMessageAttribute() {
 		// Arrange
 		Message<String> message = MessageBuilder.withPayload("Hello").setHeader(MESSAGE_GROUP_ID_HEADER, "id-5")


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

`SnsHeaderConverterUtil.getContentTypeMessageAttribute` returns `null` when the `contentType` header is neither a `MimeType` nor a `String`, and the caller put that return value straight into the attribute map:

```java
if (MessageHeaders.CONTENT_TYPE.equals(messageHeaderName) && messageHeaderValue != null) {
    messageAttributes.put(messageHeaderName, getContentTypeMessageAttribute(messageHeaderValue));
}
```

The map then carries `contentType -> null`. `PublishRequest.builder().messageAttributes(map).build()` accepts it, so nothing fails until the request is marshalled:

```
software.amazon.awssdk.core.exception.SdkClientException
Caused by: java.lang.NullPointerException: Cannot invoke
  "software.amazon.awssdk.core.SdkPojo.sdkFields()" because "pojo" is null
```

That happens before the call leaves the client, so the publish fails entirely rather than just dropping the header.

The loop already has a branch for header types SNS cannot carry: it logs a warning and leaves the header out. This change routes the unsupported `contentType` down that same path, and pulls the warning into a small private method so both places use it.

The SQS side handles the same case: `SqsHeaderMapper.getContentTypeMessageAttribute` is not `@Nullable` and falls back to an empty string attribute. I kept SNS consistent with its own loop rather than copying that, since skipping the header matches what this class already does for values it cannot convert. Happy to switch it to the empty-string fallback if you would rather the two modules line up.

This is not a regression. The same code was in `TopicMessageChannel` before it was extracted into `SnsHeaderConverterUtil` in #1574.


## :bulb: Motivation and Context

`toSnsMessageAttributes` is used by the sync (`TopicMessageChannel`), batch (`DefaultSnsMessageConverter`) and async (`DefaultSnsPublishMessageConverter`) publish paths, so any application setting a `contentType` header that is not a `String` or `MimeType` loses the message on all three.


## :green_heart: How did you test it?

Added `sendMessage_withUnsupportedContentTypeHeader_shouldNotSetItAsMessageAttribute` to `TopicMessageChannelTest`, alongside the existing header conversion tests. It fails on current `main` (the attribute map contains the key with a null value) and passes with the change.

I also confirmed the marshalling failure end to end before writing the fix, by sending a request built from the converted attributes through a real `SnsClient` pointed at an unreachable endpoint, which produced the `SdkClientException` above.

`spring-cloud-aws-sns` passes in full (119 tests). I ran the repo-wide unit tests too: the only failure is `S3InboundChannelAdapterTests.s3InboundChannelAdapter`, which fails the same way on an unmodified `main` here.


## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [ ] No breaking changes

Reference docs are unchanged because the documented behaviour is unaffected: supported `contentType` values are converted exactly as before.

On breaking changes: an application that today sends an unsupported `contentType` gets a failed publish, and after this it gets a successful publish with a warning and no `contentType` attribute. Nothing that works today changes.


## :crystal_ball: Next steps

None.
