### PR TITLE
Carry the notification subject on SNS batch entries

### DIFF
--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/batch/converter/DefaultSnsMessageConverter.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/batch/converter/DefaultSnsMessageConverter.java
@@ -18,6 +18,7 @@ package io.awspring.cloud.sns.core.batch.converter;
 import static io.awspring.cloud.sns.core.SnsHeaders.MESSAGE_DEDUPLICATION_ID_HEADER;
 import static io.awspring.cloud.sns.core.SnsHeaders.MESSAGE_GROUP_ID_HEADER;
 import static io.awspring.cloud.sns.core.SnsHeaders.MESSAGE_ID_HEADER;
+import static io.awspring.cloud.sns.core.SnsHeaders.NOTIFICATION_SUBJECT_HEADER;
 
 import io.awspring.cloud.sns.core.SnsHeaderConverterUtil;
 import java.util.ArrayList;
@@ -95,6 +96,9 @@ public class DefaultSnsMessageConverter implements SnsMessageConverter {
 		String id = Optional.ofNullable(message.getHeaders().get(MESSAGE_ID_HEADER, String.class))
 				.filter(StringUtils::hasText).orElseGet(() -> UUID.randomUUID().toString());
 		publishBatchRequestEntry.id(id);
+
+		Optional.ofNullable(message.getHeaders().get(NOTIFICATION_SUBJECT_HEADER, String.class))
+				.ifPresent(publishBatchRequestEntry::subject);
 
 		Optional.ofNullable(message.getHeaders().get(MESSAGE_GROUP_ID_HEADER, String.class))
 				.ifPresent(publishBatchRequestEntry::messageGroupId);

--- a/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/batch/executor/SequentialBatchExecutionStrategy.java
+++ b/spring-cloud-aws-sns/src/main/java/io/awspring/cloud/sns/core/batch/executor/SequentialBatchExecutionStrategy.java
@@ -55,7 +55,7 @@ public class SequentialBatchExecutionStrategy implements BatchExecutionStrategy 
 	@Override
 	public BatchResult send(Arn topicArn, Collection<PublishBatchRequestEntry> entries) {
 		Assert.notNull(topicArn, "topicArn is required");
-		Assert.notNull(topicArn, "entries are required");
+		Assert.notNull(entries, "entries are required");
 
 		List<BatchResult.SnsResult> allResults = new ArrayList<>();
 		List<BatchResult.SnsError> allErrors = new ArrayList<>();

--- a/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/core/batch/converter/DefaultSnsMessageConverterTest.java
+++ b/spring-cloud-aws-sns/src/test/java/io/awspring/cloud/sns/core/batch/converter/DefaultSnsMessageConverterTest.java
@@ -96,11 +96,24 @@ class DefaultSnsMessageConverterTest {
 	}
 
 	@Test
+	void setsNotificationSubject() {
+		Message<String> message = MessageBuilder.withPayload("test")
+				.setHeader(SnsHeaders.NOTIFICATION_SUBJECT_HEADER, "a subject").build();
+
+		PublishBatchRequestEntry entry = converter.convertMessage(message);
+
+		assertThat(entry.subject()).isEqualTo("a subject");
+		// the subject travels on the entry, not as a message attribute
+		assertThat(entry.messageAttributes()).doesNotContainKey(SnsHeaders.NOTIFICATION_SUBJECT_HEADER);
+	}
+
+	@Test
 	void leavesOptionalHeadersNullWhenAbsent() {
 		Message<String> message = MessageBuilder.withPayload("plain").build();
 
 		PublishBatchRequestEntry entry = converter.convertMessage(message);
 
+		assertThat(entry.subject()).isNull();
 		assertThat(entry.messageGroupId()).isNull();
 		assertThat(entry.messageDeduplicationId()).isNull();
 	}


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

`SnsHeaderConverterUtil.isSkipHeader` leaves `NOTIFICATION_SUBJECT_HEADER` out of the message attributes, because the subject belongs on the request rather than in the attribute map:

```java
private static boolean isSkipHeader(String headerName) {
    return NOTIFICATION_SUBJECT_HEADER.equals(headerName) || MESSAGE_GROUP_ID_HEADER.equals(headerName)
            || MESSAGE_DEDUPLICATION_ID_HEADER.equals(headerName);
}
```

Two of the three publish paths then set it:

- `TopicMessageChannel.sendInternal` calls `.subject(findNotificationSubject(message))`
- `DefaultSnsPublishMessageConverter.populateHeaders` sets `publishRequest::subject`

`DefaultSnsMessageConverter` (batch) never mentions the subject. `PublishBatchRequestEntry` has a `subject` field, so nothing fails - the header is excluded from the attributes and never put on the entry, and the subject is silently gone. The FIFO headers next to it are already handled in all three paths, which is what made the gap visible.

So the same message sent through `SnsTemplate` reaches subscribers with a subject, and through `SnsBatchTemplate` without one. Email subscribers get an empty subject line.

The change follows `DefaultSnsPublishMessageConverter`, the closest sibling, and reads the header as a `String` rather than calling `toString()` on it the way `TopicMessageChannel` does.

This PR also carries a one-line fix in the same subpackage: `SequentialBatchExecutionStrategy.send` asserts `topicArn` twice and never checks `entries`.

```java
Assert.notNull(topicArn, "topicArn is required");
Assert.notNull(topicArn, "entries are required");
```

Happy to split that into its own PR if you would rather keep this one to the subject.


## :bulb: Motivation and Context

Both came in with the batch template in #1574 and neither is covered by a test today.


## :green_heart: How did you test it?

Added `setsNotificationSubject` to `DefaultSnsMessageConverterTest`, which checks the subject lands on the entry and does not leak into the message attributes. It fails on current `main` and passes with the change. Extended `leavesOptionalHeadersNullWhenAbsent` to cover the subject alongside the FIFO headers it already asserts.

`spring-cloud-aws-sns` passes in full (119 tests).


## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes

The SNS reference docs describe the payload types the batch template supports and do not enumerate headers, so there is nothing there to correct.


## :crystal_ball: Next steps

While reading this code I noticed `SnsAsyncTopicArnResolver.resolveTopicArn` calls `.join()` when it is given a topic name rather than an ARN, which blocks the caller of `SnsAsyncTemplate`. `TopicArnResolver` is a synchronous interface, so changing that is an API question rather than a fix. I can open an issue if it is worth discussing.
